### PR TITLE
Adding CoreConfig to Core module

### DIFF
--- a/PayPal.xcodeproj/project.pbxproj
+++ b/PayPal.xcodeproj/project.pbxproj
@@ -7,6 +7,7 @@
 	objects = {
 
 /* Begin PBXBuildFile section */
+		06CE009926F3D1660000CC46 /* CoreConfig.swift in Sources */ = {isa = PBXBuildFile; fileRef = 06CE009826F3D1660000CC46 /* CoreConfig.swift */; };
 		8034A9DE26B8756F0055AF13 /* PaymentsCore.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8034A9DD26B8756F0055AF13 /* PaymentsCore.swift */; };
 		8034A9E626B875C90055AF13 /* PaymentsCore_Tests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8034A9E526B875C90055AF13 /* PaymentsCore_Tests.swift */; };
 		8034A9E726B875C90055AF13 /* PaymentsCore.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 80B9F85126B8750000D67843 /* PaymentsCore.framework */; };
@@ -44,6 +45,7 @@
 /* End PBXContainerItemProxy section */
 
 /* Begin PBXFileReference section */
+		06CE009826F3D1660000CC46 /* CoreConfig.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CoreConfig.swift; sourceTree = "<group>"; };
 		8034A9DD26B8756F0055AF13 /* PaymentsCore.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PaymentsCore.swift; sourceTree = "<group>"; };
 		8034A9E326B875C90055AF13 /* PaymentsCoreTests.xctest */ = {isa = PBXFileReference; explicitFileType = wrapper.cfbundle; includeInIndex = 0; path = PaymentsCoreTests.xctest; sourceTree = BUILT_PRODUCTS_DIR; };
 		8034A9E526B875C90055AF13 /* PaymentsCore_Tests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PaymentsCore_Tests.swift; sourceTree = "<group>"; };
@@ -130,6 +132,7 @@
 			isa = PBXGroup;
 			children = (
 				8034A9DD26B8756F0055AF13 /* PaymentsCore.swift */,
+				06CE009826F3D1660000CC46 /* CoreConfig.swift */,
 			);
 			name = PaymentsCore;
 			path = Sources/PaymentsCore;
@@ -446,6 +449,7 @@
 			isa = PBXSourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				06CE009926F3D1660000CC46 /* CoreConfig.swift in Sources */,
 				8034A9DE26B8756F0055AF13 /* PaymentsCore.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;

--- a/Sources/PaymentsCore/CoreConfig.swift
+++ b/Sources/PaymentsCore/CoreConfig.swift
@@ -1,0 +1,29 @@
+import Foundation
+
+/*
+ The configuration object containing information required by every payment method.
+ It is used to initialize all Client objects.
+ */
+public struct CoreConfig {
+    let clientID: String
+    let environment: Environment
+}
+
+public enum Environment {
+    case sandbox
+    case stage
+    case production
+
+    //swiftlint:disable force_unwrapping
+    var baseURL: URL {
+        switch self {
+        case .sandbox:
+            return URL(string: "https://api.sandbox.paypal.com")!
+        case .stage:
+            return URL(string: "https://api.msmaster.qa.paypal.com")!
+        case .production:
+            return URL(string: "https://api.paypal.com")!
+        }
+    }
+    //swiftlint:enable force_unwrapping
+}


### PR DESCRIPTION
### Reason for changes

Add CoreConfig object to Core module
Note: `enum Environment` was created in `networking-layer` branch, and will be removed from this PR once networking layer PR is merged

### Summary of changes

- Add CoreConfig object to Core module

### Checklist

- [ ] Added a changelog entry

### Authors
> List GitHub usernames for everyone who contributed to this pull request.

- @minhthenguyen 
- @jonathajones 