### PR TITLE
Add PayPalRequest Object

### DIFF
--- a/Demo/Demo/FeatureViewControllers/PayPalDemoViewController.swift
+++ b/Demo/Demo/FeatureViewControllers/PayPalDemoViewController.swift
@@ -77,8 +77,9 @@ class PayPalDemoViewController: FeatureBaseViewController {
     func checkoutWithPayPal(orderID: String) {
         let config = CoreConfig(clientID: DemoSettings.clientID, environment: DemoSettings.environment.paypalSDKEnvironment)
         let payPalClient = PayPalClient(config: config, returnURL: DemoSettings.paypalReturnUrl)
+        let payPalRequest = PayPalRequest(orderID: orderID)
 
-        payPalClient.start(orderID: orderID, presentingViewController: self) { [weak self] state in
+        payPalClient.start(request: payPalRequest, presentingViewController: self) { [weak self] state in
             guard let self = self else { return }
             switch state {
             case .success(let result):

--- a/PayPal.xcodeproj/project.pbxproj
+++ b/PayPal.xcodeproj/project.pbxproj
@@ -42,6 +42,7 @@
 		80E74400270E40F300BACECA /* FakeRequests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 80E743FF270E40F300BACECA /* FakeRequests.swift */; };
 		80E8DAE126B8784600FAFC3F /* Card.swift in Sources */ = {isa = PBXBuildFile; fileRef = 80E8DAE026B8784600FAFC3F /* Card.swift */; };
 		80E8DAEA26B8785D00FAFC3F /* Card.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 80E8DAD926B8783800FAFC3F /* Card.framework */; };
+		9C84ABF92786468800061C77 /* PayPalRequest.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9C84ABF82786468800061C77 /* PayPalRequest.swift */; };
 		BC0A82A5270B9533006E9A21 /* ConfirmPaymentSourceRequest.swift in Sources */ = {isa = PBXBuildFile; fileRef = 06CE009F26F3DF100000CC46 /* ConfirmPaymentSourceRequest.swift */; };
 		BC0A82A6270B9954006E9A21 /* ConfirmPaymentSourceRequest_Tests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 065A4DC226FCE1D20007014A /* ConfirmPaymentSourceRequest_Tests.swift */; };
 		BC7F8123275FC1350011EDC8 /* CardRequest.swift in Sources */ = {isa = PBXBuildFile; fileRef = BC7F8122275FC1350011EDC8 /* CardRequest.swift */; };
@@ -123,6 +124,7 @@
 		80E8DAD926B8783800FAFC3F /* Card.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = Card.framework; sourceTree = BUILT_PRODUCTS_DIR; };
 		80E8DAE026B8784600FAFC3F /* Card.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Card.swift; sourceTree = "<group>"; };
 		80E8DAE626B8785D00FAFC3F /* CardTests.xctest */ = {isa = PBXFileReference; explicitFileType = wrapper.cfbundle; includeInIndex = 0; path = CardTests.xctest; sourceTree = BUILT_PRODUCTS_DIR; };
+		9C84ABF82786468800061C77 /* PayPalRequest.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PayPalRequest.swift; sourceTree = "<group>"; };
 		BC7F8122275FC1350011EDC8 /* CardRequest.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CardRequest.swift; sourceTree = "<group>"; };
 		BE00B79B2742F96200758C63 /* PayPalButton.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PayPalButton.swift; sourceTree = "<group>"; };
 		BE00B79D2742F9F000758C63 /* Assets.xcassets */ = {isa = PBXFileReference; lastKnownFileType = folder.assetcatalog; path = Assets.xcassets; sourceTree = "<group>"; };
@@ -308,11 +310,11 @@
 			isa = PBXGroup;
 			children = (
 				BE00B79A2742F95200758C63 /* Buttons */,
+				0649326E272703A500FA83A6 /* Enums */,
+				BE71161D2723586200165069 /* Extensions */,
+				BE7116112723157900165069 /* Models */,
 				BE7116152723227200165069 /* PayPalClient.swift */,
 				3D25238027344F1E0099E4EB /* PayPalUIInterfaces */,
-				BE71161D2723586200165069 /* Extensions */,
-				0649326E272703A500FA83A6 /* Enums */,
-				BE7116112723157900165069 /* Models */,
 			);
 			name = PayPal;
 			path = Sources/PayPal;
@@ -365,6 +367,7 @@
 		BE7116112723157900165069 /* Models */ = {
 			isa = PBXGroup;
 			children = (
+				9C84ABF82786468800061C77 /* PayPalRequest.swift */,
 				BE7116122723163300165069 /* PayPalResult.swift */,
 			);
 			path = Models;
@@ -792,6 +795,7 @@
 				3D25238627344F330099E4EB /* PayPalApproval.swift in Sources */,
 				BE00B7A92743F6AF00758C63 /* PayPalCreditButton.swift in Sources */,
 				80D0C1382731CC9B00548A3D /* PayPalClient.swift in Sources */,
+				9C84ABF92786468800061C77 /* PayPalRequest.swift in Sources */,
 				BE711621272358E200165069 /* Environment+Extension.swift in Sources */,
 				BE71161C27234B8A00165069 /* PayPalError.swift in Sources */,
 				BE7116142723163B00165069 /* PayPalResult.swift in Sources */,

--- a/Sources/PayPal/Models/PayPalRequest.swift
+++ b/Sources/PayPal/Models/PayPalRequest.swift
@@ -1,0 +1,14 @@
+import Foundation
+
+/// Used to configure options for approving a PayPal order
+public struct PayPalRequest {
+    
+    /// The order ID associated with the request.
+    public let orderID: String
+    
+    /// Creates an instance of a PayPalRequest.
+    /// - Parameter orderID: The ID of the order to be approved.
+    public init(orderID: String) {
+        self.orderID = orderID
+    }
+}

--- a/Sources/PayPal/Models/PayPalRequest.swift
+++ b/Sources/PayPal/Models/PayPalRequest.swift
@@ -2,10 +2,10 @@ import Foundation
 
 /// Used to configure options for approving a PayPal order
 public struct PayPalRequest {
-    
+
     /// The order ID associated with the request.
     public let orderID: String
-    
+
     /// Creates an instance of a PayPalRequest.
     /// - Parameter orderID: The ID of the order to be approved.
     public init(orderID: String) {

--- a/Sources/PayPal/PayPalClient.swift
+++ b/Sources/PayPal/PayPalClient.swift
@@ -34,11 +34,11 @@ public class PayPalClient {
 
     /// Present PayPal Paysheet and start a PayPal transaction
     /// - Parameters:
-    ///   - orderID: the order ID for the transaction
+    ///   - request: the PayPalRequest for the transaction
     ///   - presentingViewController: the ViewController to present PayPalPaysheet on, if not provided, the Paysheet will be presented on your top-most ViewController
     ///   - completion: Completion block to handle buyer's approval, cancellation, and error.
     public func start(
-        orderID: String,
+        request: PayPalRequest,
         presentingViewController: UIViewController? = nil,
         completion: @escaping (PayPalCheckoutResult) -> Void
     ) {
@@ -47,7 +47,7 @@ public class PayPalClient {
         CheckoutFlow.start(
             presentingViewController: presentingViewController,
             createOrder: { order in
-                order.set(orderId: orderID)
+                order.set(orderId: request.orderID)
             },
             onApprove: { approval in
                 let payPalResult = PayPalResult(

--- a/UnitTests/PayPalTests/PayPalClient_Tests.swift
+++ b/UnitTests/PayPalTests/PayPalClient_Tests.swift
@@ -14,10 +14,10 @@ class PayPalClient_Tests: XCTestCase {
     )
 
     func testStart_whenNativeSDKOnApproveCalled_returnsPayPalResult() {
-        let orderID = "1234"
-        let approval = MockApproval(intent: "intent", payerID: "payerID", ecToken: orderID)
+        let request = PayPalRequest(orderID: "1234")
+        let approval = MockApproval(intent: "intent", payerID: "payerID", ecToken: request.orderID)
 
-        paypalClient.start(orderID: orderID, presentingViewController: nil) { result in
+        paypalClient.start(request: request, presentingViewController: nil) { result in
             switch result {
             case .success(let approvalResult):
                 XCTAssertEqual(approvalResult.orderID, approval.ecToken)
@@ -33,7 +33,9 @@ class PayPalClient_Tests: XCTestCase {
     }
 
     func testStart_whenNativeSDKOnCancelCalled_returnsCancellationError() {
-        paypalClient.start(orderID: "1234", presentingViewController: nil) { result in
+        let request = PayPalRequest(orderID: "1234")
+        
+        paypalClient.start(request: request, presentingViewController: nil) { result in
             switch result {
             case .success:
                 XCTFail()
@@ -46,9 +48,10 @@ class PayPalClient_Tests: XCTestCase {
     }
 
     func testStart_whenNativeSDKOnErrorCalled_returnsCheckoutError() {
+        let request = PayPalRequest(orderID: "1234")
         let error = MockPayPalError(reason: "error reason", error: NSError())
 
-        paypalClient.start(orderID: "1234", presentingViewController: nil) { result in
+        paypalClient.start(request: request, presentingViewController: nil) { result in
             switch result {
             case .success:
                 XCTFail()

--- a/UnitTests/PayPalTests/PayPalClient_Tests.swift
+++ b/UnitTests/PayPalTests/PayPalClient_Tests.swift
@@ -34,7 +34,7 @@ class PayPalClient_Tests: XCTestCase {
 
     func testStart_whenNativeSDKOnCancelCalled_returnsCancellationError() {
         let request = PayPalRequest(orderID: "1234")
-        
+
         paypalClient.start(request: request, presentingViewController: nil) { result in
             switch result {
             case .success:


### PR DESCRIPTION
### Reason for changes

We have a `CardRequest` object for configuring parameters for card payments, we should follow this pattern for PayPal and all other features.

### Summary of changes

- Add `PayPalRequest` and update `PayPalClient.start` to accept a `PayPalRequest`

### Checklist

- ~[ ] Added a changelog entry~

### Authors
> List GitHub usernames for everyone who contributed to this pull request.

- @jaxdesmarais 
- @sarahkoop 