### PR TITLE
Card Client Confirm Payment Source

### DIFF
--- a/Demo/Demo/ViewModels/BaseViewModel.swift
+++ b/Demo/Demo/ViewModels/BaseViewModel.swift
@@ -101,7 +101,7 @@ class BaseViewModel: ObservableObject, PayPalDelegate {
 
         do {
             _ = try await cardClient.confirmPaymentSource(request: cardRequest)
-            updateTitle("\(DemoSettings.intent.rawValue.capitalized) status: APPROVED")
+            updateTitle("\(DemoSettings.intent.rawValue.capitalized) status: CONFIRMED")
         } catch {
             updateTitle("\(DemoSettings.intent) failed: \(error.localizedDescription)")
         }

--- a/Demo/Demo/ViewModels/BaseViewModel.swift
+++ b/Demo/Demo/ViewModels/BaseViewModel.swift
@@ -100,7 +100,7 @@ class BaseViewModel: ObservableObject, PayPalDelegate {
         let cardRequest = CardRequest(orderID: orderID, card: card)
 
         do {
-            _ = try await cardClient.approveOrder(request: cardRequest)
+            _ = try await cardClient.confirmPaymentSource(request: cardRequest)
             updateTitle("\(DemoSettings.intent.rawValue.capitalized) status: APPROVED")
         } catch {
             updateTitle("\(DemoSettings.intent) failed: \(error.localizedDescription)")

--- a/Demo/DemoUITests/CardUITests.swift
+++ b/Demo/DemoUITests/CardUITests.swift
@@ -25,7 +25,7 @@ class CardUITests: XCTestCase {
 
         app.button(named: "Capture Order").tap()
 
-        let elementExists = app.staticText(containing: "status: APPROVED").waitForExistence()
+        let elementExists = app.staticText(containing: "status: CONFIRMED").waitForExistence()
         XCTAssertTrue(elementExists)
     }
 }

--- a/Sources/Card/CardClient.swift
+++ b/Sources/Card/CardClient.swift
@@ -21,12 +21,12 @@ public class CardClient {
         self.apiClient = apiClient
     }
 
-    /// Approve an order with a card, which validates buyer's card, and if valid, attaches the card as the payment source to the order.
-    /// After the order has been successfully approved, you will need to handle capturing/authorizing the order in your server.
-    /// - Parameter request: The request containing the card and order id for approval
+    /// Confirm a payment source with a card, which validates buyer's card, and if valid, attaches the card as the payment source to the order.
+    /// After the order has been successfully confirmed, you will need to handle capturing/authorizing the order on your server.
+    /// - Parameter request: The request containing the card and order id for confirmation
     /// - Returns: Card result
-    /// - Throws: PayPalSDK error if approve order could not complete successfully
-    public func approveOrder(request: CardRequest) async throws -> CardResult {
+    /// - Throws: PayPalSDK error if confirm payment source could not complete successfully
+    public func confirmPaymentSource(request: CardRequest) async throws -> CardResult {
         let confirmPaymentRequest = try ConfirmPaymentSourceRequest(
             card: request.card,
             orderID: request.orderID,

--- a/UnitTests/CardTests/CardClient_Tests.swift
+++ b/UnitTests/CardTests/CardClient_Tests.swift
@@ -37,9 +37,9 @@ class CardClient_Tests: XCTestCase {
         cardClient = CardClient(config: config, apiClient: apiClient)
     }
 
-    // MARK: - approveOrder() tests
+    // MARK: - confirmPaymentSource() tests
 
-    func testApproveOrder_withValidJSONRequest_returnsOrderData() async {
+    func testConfirmPaymentSource_withValidJSONRequest_returnsOrderData() async {
         let jsonResponse = """
         {
             "id": "testOrderID",
@@ -60,7 +60,7 @@ class CardClient_Tests: XCTestCase {
         let cardRequest = CardRequest(orderID: "", card: card)
 
         do {
-            let cardResult = try await cardClient.approveOrder(request: cardRequest)
+            let cardResult = try await cardClient.confirmPaymentSource(request: cardRequest)
             XCTAssertEqual(cardResult.orderID, "testOrderID")
             XCTAssertEqual(cardResult.brand, "VISA")
             XCTAssertEqual(cardResult.lastFourDigits, "7321")
@@ -70,7 +70,7 @@ class CardClient_Tests: XCTestCase {
         }
     }
 
-    func testApproveOrder_withInvalidJSONResponse_returnsParseError() async {
+    func testConfirmPaymentSource_withInvalidJSONResponse_returnsParseError() async {
         let jsonResponse = """
         {
             "some_unexpected_response": "something"
@@ -82,7 +82,7 @@ class CardClient_Tests: XCTestCase {
 
         let cardRequest = CardRequest(orderID: "", card: card)
         do {
-            _ = try await cardClient.approveOrder(request: cardRequest)
+            _ = try await cardClient.confirmPaymentSource(request: cardRequest)
             XCTFail("This should fail.")
         } catch let error as PayPalSDKError {
             XCTAssertEqual(error.domain, APIClientError.domain)

--- a/docs/Card/integration.md
+++ b/docs/Card/integration.md
@@ -61,7 +61,7 @@ Create a `CoreConfig` using your client ID from the PayPal Developer Portal:
 let config = CoreConfig(clientID: "<CLIENT_ID>", environment: .sandbox)
 ```
 
-Create a `CardClient` to approve an order with a Card payment method:
+Create a `CardClient` to confirm a payment source with a Card:
 
 ```swift
 let cardClient = CardClient(config: config)
@@ -122,13 +122,13 @@ let cardRequest = CardRequest(orderID: "<ORDER_ID>", card: card)
 
 Approve the order using your `CardClient`.
 
-Call `CardClient#approveOrder` to approve the order, and then handle results:
+Call `CardClient#confirmPaymentSource` to confirm a payment source for the order, and then handle results:
 
 ```swift
-cardClient.approveOrder(request: cardRequest) { result in
+cardClient.confirmPaymentSource(request: cardRequest) { result in
     switch result {
         case .success(let result):
-            // order was successfully approved and is ready to be captured/authorized (see step 6)
+            // payment method was successfully confirmed and the order is ready to be captured/authorized (see step 6)
         case .failure(let error):
             // handle the error by accessing `result.localizedDescription`
     }


### PR DESCRIPTION
### Reason for changes

This PR updates the CardClient API to better align with the Orders v2 API. In the future, we may revisit API naming to improve the developer experience.

### Summary of changes

- Rename CardClient `approveOrder` method to `confirmPaymentSource`

### Checklist

~- [ ] Added a changelog entry~