### PR TITLE
Remove PaymentsCore dependency on PayPalDataCollector

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -64,7 +64,7 @@ let package = Package(
         ),
         .target(
             name: "PayPalDataCollector",
-            dependencies: ["PaymentsCore", "PPRiskMagnes"]
+            dependencies: ["PPRiskMagnes"]
         ),
         .binaryTarget(
             name: "PPRiskMagnes",

--- a/PayPal.podspec
+++ b/PayPal.podspec
@@ -36,7 +36,6 @@ Pod::Spec.new do |s|
   s.subspec "PayPalDataCollector" do |s|
     s.source_files = "Sources/PayPalDataCollector/*.swift"
     s.vendored_frameworks = "Frameworks/XCFrameworks/PPRiskMagnes.xcframework"
-    s.dependency "PayPal/PaymentsCore"
   end
 
   s.subspec "PaymentsCore" do |s|

--- a/PayPal.xcodeproj/project.pbxproj
+++ b/PayPal.xcodeproj/project.pbxproj
@@ -59,7 +59,6 @@
 		BCF59E5D27E91ECC00CDFD47 /* PayPalApproval.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3D25238327344F330099E4EB /* PayPalApproval.swift */; };
 		BCF59E5E27E91ECC00CDFD47 /* PayPalErrorType.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3D25238227344F330099E4EB /* PayPalErrorType.swift */; };
 		BCF59E5F27E91ECC00CDFD47 /* CheckoutProtocol.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3D25238127344F330099E4EB /* CheckoutProtocol.swift */; };
-		BCF735CD27D1583200A52E03 /* PaymentsCore.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 80B9F85126B8750000D67843 /* PaymentsCore.framework */; platformFilter = ios; };
 		BCF735DB27D1583400A52E03 /* TestShared.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 80E743F8270E40CE00BACECA /* TestShared.framework */; platformFilter = ios; };
 		BCF735E327D158B400A52E03 /* PPRiskMagnes.xcframework in Frameworks */ = {isa = PBXBuildFile; fileRef = BCF735E227D158B400A52E03 /* PPRiskMagnes.xcframework */; platformFilter = ios; };
 		BCF735E427D158E900A52E03 /* PPRiskMagnes.xcframework in Frameworks */ = {isa = PBXBuildFile; fileRef = BCF735E227D158B400A52E03 /* PPRiskMagnes.xcframework */; platformFilter = ios; };
@@ -101,6 +100,7 @@
 		BEA100EE26EFA7990036A6A5 /* HTTPHeader.swift in Sources */ = {isa = PBXBuildFile; fileRef = BEA100ED26EFA7990036A6A5 /* HTTPHeader.swift */; };
 		BEA100F026EFA7C20036A6A5 /* APIClientError.swift in Sources */ = {isa = PBXBuildFile; fileRef = BEA100EF26EFA7C20036A6A5 /* APIClientError.swift */; };
 		BEA100F226EFA7DE0036A6A5 /* Environment.swift in Sources */ = {isa = PBXBuildFile; fileRef = BEA100F126EFA7DE0036A6A5 /* Environment.swift */; };
+		CB38546327F4B616003CE179 /* PayPalDataCollectorEnvironment.swift in Sources */ = {isa = PBXBuildFile; fileRef = CB38546227F4B616003CE179 /* PayPalDataCollectorEnvironment.swift */; };
 		CBA92A4327B304140077FF14 /* APIClientDecoder.swift in Sources */ = {isa = PBXBuildFile; fileRef = CBA92A4227B304140077FF14 /* APIClientDecoder.swift */; };
 /* End PBXBuildFile section */
 
@@ -239,6 +239,7 @@
 		BEA100F126EFA7DE0036A6A5 /* Environment.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Environment.swift; sourceTree = "<group>"; };
 		BEDB7FE32788AB8E00CEA554 /* Coordinator.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Coordinator.swift; sourceTree = "<group>"; };
 		BEF3FF1627AC5DF3006B4B69 /* Coordinator_Tests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Coordinator_Tests.swift; sourceTree = "<group>"; };
+		CB38546227F4B616003CE179 /* PayPalDataCollectorEnvironment.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PayPalDataCollectorEnvironment.swift; sourceTree = "<group>"; };
 		CBA92A4227B304140077FF14 /* APIClientDecoder.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = APIClientDecoder.swift; sourceTree = "<group>"; };
 		OBJ_16 /* README.md */ = {isa = PBXFileReference; lastKnownFileType = net.daringfireball.markdown; path = README.md; sourceTree = "<group>"; };
 		OBJ_6 /* Package.swift */ = {isa = PBXFileReference; explicitFileType = sourcecode.swift; path = Package.swift; sourceTree = "<group>"; };
@@ -316,7 +317,6 @@
 			isa = PBXFrameworksBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
-				BCF735CD27D1583200A52E03 /* PaymentsCore.framework in Frameworks */,
 				BCF735E327D158B400A52E03 /* PPRiskMagnes.xcframework in Frameworks */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
@@ -530,6 +530,7 @@
 				BC9C18D727D279C70019B541 /* MagnesSDKResult.swift */,
 				BCF735EA27D160E800A52E03 /* MagnesSetupParams.swift */,
 				BCF735E627D15AB800A52E03 /* PayPalDataCollector.swift */,
+				CB38546227F4B616003CE179 /* PayPalDataCollectorEnvironment.swift */,
 			);
 			name = PayPalDataCollector;
 			path = Sources/PayPalDataCollector;
@@ -1257,6 +1258,7 @@
 			buildActionMask = 2147483647;
 			files = (
 				BCF735EF27D1652100A52E03 /* DeviceInspectorProtocol.swift in Sources */,
+				CB38546327F4B616003CE179 /* PayPalDataCollectorEnvironment.swift in Sources */,
 				BCF735E727D15AB800A52E03 /* PayPalDataCollector.swift in Sources */,
 				BCF735EB27D160E800A52E03 /* MagnesSetupParams.swift in Sources */,
 				BCF735E927D15D2600A52E03 /* MagnesSDKProtocol.swift in Sources */,

--- a/Sources/PayPalDataCollector/PayPalDataCollector.swift
+++ b/Sources/PayPalDataCollector/PayPalDataCollector.swift
@@ -1,42 +1,35 @@
 import Foundation
 import PPRiskMagnes
-#if canImport(PaymentsCore)
-import PaymentsCore
-#endif
 
 /// Enables you to collect data about a customer's device and correlate it with a session identifier on your server.
 public class PayPalDataCollector {
 
     // MARK: - Properties
 
-    private let config: CoreConfig
     private let magnesSDK: MagnesSDKProtocol
     private let deviceInspector: DeviceInspectorProtocol
+    private let magnesEnvironment: MagnesSDK.Environment
 
     // MARK: - Initializers
 
     /// Construct an instance to collect device data to send to your server.
     /// - Parameter config: configuration to use when collecting device data
-    public convenience init(config: CoreConfig) {
-        self.init(config: config, magnesSDK: MagnesSDK.shared(), deviceInspector: DeviceInspector())
+    public convenience init(environment: PayPalDataCollectorEnvironment) {
+        self.init(environment: environment, magnesSDK: MagnesSDK.shared(), deviceInspector: DeviceInspector())
     }
 
     /// internal constructor for testing
-    init(config: CoreConfig, magnesSDK: MagnesSDKProtocol, deviceInspector: DeviceInspectorProtocol) {
-        self.config = config
+    init(environment: PayPalDataCollectorEnvironment, magnesSDK: MagnesSDKProtocol, deviceInspector: DeviceInspectorProtocol) {
+        magnesEnvironment = {
+            switch environment {
+            case .sandbox:
+                return .SANDBOX
+            case .production:
+                return .LIVE
+            }
+        }()
         self.magnesSDK = magnesSDK
         self.deviceInspector = deviceInspector
-    }
-
-    // MARK: - Computed Properties
-
-    private var magnesEnvironment: MagnesSDK.Environment {
-        switch config.environment {
-        case .sandbox:
-            return .SANDBOX
-        case .production:
-            return .LIVE
-        }
     }
 
     // MARK: - PayPalDataCollector

--- a/Sources/PayPalDataCollector/PayPalDataCollector.swift
+++ b/Sources/PayPalDataCollector/PayPalDataCollector.swift
@@ -20,14 +20,7 @@ public class PayPalDataCollector {
 
     /// internal constructor for testing
     init(environment: PayPalDataCollectorEnvironment, magnesSDK: MagnesSDKProtocol, deviceInspector: DeviceInspectorProtocol) {
-        magnesEnvironment = {
-            switch environment {
-            case .sandbox:
-                return .SANDBOX
-            case .production:
-                return .LIVE
-            }
-        }()
+        self.magnesEnvironment = environment.magnesEnvironment
         self.magnesSDK = magnesSDK
         self.deviceInspector = deviceInspector
     }

--- a/Sources/PayPalDataCollector/PayPalDataCollector.swift
+++ b/Sources/PayPalDataCollector/PayPalDataCollector.swift
@@ -13,7 +13,7 @@ public class PayPalDataCollector {
     // MARK: - Initializers
 
     /// Construct an instance to collect device data to send to your server.
-    /// - Parameter config: configuration to use when collecting device data
+    /// - Parameter environment: enviroment for the data collector
     public convenience init(environment: PayPalDataCollectorEnvironment) {
         self.init(environment: environment, magnesSDK: MagnesSDK.shared(), deviceInspector: DeviceInspector())
     }

--- a/Sources/PayPalDataCollector/PayPalDataCollectorEnvironment.swift
+++ b/Sources/PayPalDataCollector/PayPalDataCollectorEnvironment.swift
@@ -1,0 +1,6 @@
+import Foundation
+
+public enum PayPalDataCollectorEnvironment {
+    case sandbox
+    case production
+}

--- a/Sources/PayPalDataCollector/PayPalDataCollectorEnvironment.swift
+++ b/Sources/PayPalDataCollector/PayPalDataCollectorEnvironment.swift
@@ -1,6 +1,16 @@
-import Foundation
+import PPRiskMagnes
 
+/// Enum of environments to use with PayPalDataCollector
 public enum PayPalDataCollectorEnvironment {
     case sandbox
     case production
+    
+    internal var magnesEnvironment: MagnesSDK.Environment {
+        switch self {
+        case .sandbox:
+            return .SANDBOX
+        case .production:
+            return .LIVE
+        }
+    }
 }

--- a/Sources/PayPalDataCollector/PayPalDataCollectorEnvironment.swift
+++ b/Sources/PayPalDataCollector/PayPalDataCollectorEnvironment.swift
@@ -4,7 +4,7 @@ import PPRiskMagnes
 public enum PayPalDataCollectorEnvironment {
     case sandbox
     case production
-    
+
     internal var magnesEnvironment: MagnesSDK.Environment {
         switch self {
         case .sandbox:

--- a/Sources/PayPalDataCollector/PayPalDataCollectorEnvironment.swift
+++ b/Sources/PayPalDataCollector/PayPalDataCollectorEnvironment.swift
@@ -5,7 +5,7 @@ public enum PayPalDataCollectorEnvironment {
     case sandbox
     case production
 
-    internal var magnesEnvironment: MagnesSDK.Environment {
+    var magnesEnvironment: MagnesSDK.Environment {
         switch self {
         case .sandbox:
             return .SANDBOX

--- a/UnitTests/PayPalDataCollector/PayPalDataCollector_Tests.swift
+++ b/UnitTests/PayPalDataCollector/PayPalDataCollector_Tests.swift
@@ -1,24 +1,20 @@
 import XCTest
-import PaymentsCore
 @testable import PayPalDataCollector
 
 class PayPalDataCollector_Tests: XCTestCase {
-
-    private let sandboxConfig = CoreConfig(clientID: "", environment: .sandbox)
-    private let productionConfig = CoreConfig(clientID: "", environment: .production)
 
     private var deviceInspector = MockDeviceInspector()
     private var magnesSDK = MockMagnesSDK()
 
     func testCollectDeviceData_setsMagnesEnvironmentToSANDBOX() {
-        let sut = PayPalDataCollector(config: sandboxConfig, magnesSDK: magnesSDK, deviceInspector: deviceInspector)
+        let sut = PayPalDataCollector(environment: .sandbox, magnesSDK: magnesSDK, deviceInspector: deviceInspector)
         _ = sut.collectDeviceData()
 
         XCTAssertEqual(.SANDBOX, magnesSDK.capturedSetupParams?.env)
     }
 
     func testCollectDeviceData_setsMagnesEnvironmentToLIVE() {
-        let sut = PayPalDataCollector(config: productionConfig, magnesSDK: magnesSDK, deviceInspector: deviceInspector)
+        let sut = PayPalDataCollector(environment: .production, magnesSDK: magnesSDK, deviceInspector: deviceInspector)
         _ = sut.collectDeviceData()
 
         XCTAssertEqual(.LIVE, magnesSDK.capturedSetupParams?.env)
@@ -27,28 +23,28 @@ class PayPalDataCollector_Tests: XCTestCase {
     func testCollectDeviceData_setsMagnesAppGUIDToTheCurrentDeviceID() {
         deviceInspector.stubPayPalDeviceIdentifierWithValue("sample_device_identifier")
 
-        let sut = PayPalDataCollector(config: sandboxConfig, magnesSDK: magnesSDK, deviceInspector: deviceInspector)
+        let sut = PayPalDataCollector(environment: .sandbox, magnesSDK: magnesSDK, deviceInspector: deviceInspector)
         _ = sut.collectDeviceData()
 
         XCTAssertEqual("sample_device_identifier", magnesSDK.capturedSetupParams?.appGuid)
     }
 
     func testCollectDeviceData_disablesMagnesRemoteConfiguration() {
-        let sut = PayPalDataCollector(config: sandboxConfig, magnesSDK: magnesSDK, deviceInspector: deviceInspector)
+        let sut = PayPalDataCollector(environment: .sandbox, magnesSDK: magnesSDK, deviceInspector: deviceInspector)
         _ = sut.collectDeviceData()
 
         XCTAssertEqual(false, magnesSDK.capturedSetupParams?.isRemoteConfigDisabled)
     }
 
     func testCollectDeviceData_disablesMagnesBeacon() {
-        let sut = PayPalDataCollector(config: sandboxConfig, magnesSDK: magnesSDK, deviceInspector: deviceInspector)
+        let sut = PayPalDataCollector(environment: .sandbox, magnesSDK: magnesSDK, deviceInspector: deviceInspector)
         _ = sut.collectDeviceData()
 
         XCTAssertEqual(false, magnesSDK.capturedSetupParams?.isBeaconDisabled)
     }
 
     func testCollectDeviceData_setsMagnesSourceToPAYPAL() {
-        let sut = PayPalDataCollector(config: sandboxConfig, magnesSDK: magnesSDK, deviceInspector: deviceInspector)
+        let sut = PayPalDataCollector(environment: .sandbox, magnesSDK: magnesSDK, deviceInspector: deviceInspector)
         _ = sut.collectDeviceData()
 
         XCTAssertEqual(.PAYPAL, magnesSDK.capturedSetupParams?.source)
@@ -59,7 +55,7 @@ class PayPalDataCollector_Tests: XCTestCase {
         let magnesResult = MockMagnesSDKResult(payPalClientMetaDataId: "new_client_metadata_id")
         magnesSDK.stubCollectDeviceData(forArgs: args, withValue: magnesResult)
 
-        let sut = PayPalDataCollector(config: sandboxConfig, magnesSDK: magnesSDK, deviceInspector: deviceInspector)
+        let sut = PayPalDataCollector(environment: .sandbox, magnesSDK: magnesSDK, deviceInspector: deviceInspector)
         let result = sut.collectDeviceData(additionalData: ["sample": "data"])
 
         let expected = """


### PR DESCRIPTION
### Reason for changes
This PR removes the PaymentsCore dependency on PayPalDataCollector

### Summary of changes

- We expose PayPalDataCollector environment to the merchant, which it transforms to Magnes environment, so that we can not depend on PaymentsCore environment

### Checklist

- [ ] Added a changelog entry

### Authors
> List GitHub usernames for everyone who contributed to this pull request.

- @jcnoriega