### PR TITLE
Add PayLater and Credit funding source

### DIFF
--- a/Demo/Demo/FeatureViewControllers/PayPalWebCheckoutViewController.swift
+++ b/Demo/Demo/FeatureViewControllers/PayPalWebCheckoutViewController.swift
@@ -23,7 +23,7 @@ class PayPalWebCheckoutViewController: FeatureBaseViewController {
         let payPalCreditButton = UIButton(type: .system)
         payPalCreditButton.translatesAutoresizingMaskIntoConstraints = false
         payPalCreditButton.setTitle("Pay with PayPal Credit", for: .normal)
-        payPalCreditButton.addTarget(self, action: #selector(paymentButtonTapped), for: .touchUpInside)
+        payPalCreditButton.addTarget(self, action: #selector(paymentCreditButtonTapped), for: .touchUpInside)
         payPalCreditButton.layer.cornerRadius = 4.0
         return payPalCreditButton
     }()
@@ -70,5 +70,9 @@ class PayPalWebCheckoutViewController: FeatureBaseViewController {
 
     @objc func paymentButtonTapped() {
         baseViewModel.payPalButtonTapped(context: self)
+    }
+
+    @objc func paymentCreditButtonTapped() {
+        baseViewModel.payPalCreditButtonTapped(context: self)
     }
 }

--- a/Demo/Demo/ViewModels/BaseViewModel.swift
+++ b/Demo/Demo/ViewModels/BaseViewModel.swift
@@ -143,7 +143,7 @@ class BaseViewModel: ObservableObject, PayPalWebCheckoutDelegate {
         paymentButtonTapped(context: context, funding: .unspecified)
     }
     
-    private func paymentButtonTapped(context: ASWebAuthenticationPresentationContextProviding, funding: PayPalWebCheckoutFunding) {
+    private func paymentButtonTapped(context: ASWebAuthenticationPresentationContextProviding, funding: PayPalWebCheckoutFundingSource) {
         guard let orderID = orderID else {
             self.updateTitle("Failed: missing orderID.")
             return
@@ -152,7 +152,7 @@ class BaseViewModel: ObservableObject, PayPalWebCheckoutDelegate {
         checkoutWithPayPal(orderID: orderID, context: context, funding: funding)
     }
 
-    func checkoutWithPayPal(orderID: String, context: ASWebAuthenticationPresentationContextProviding, funding: PayPalWebCheckoutFunding) {
+    func checkoutWithPayPal(orderID: String, context: ASWebAuthenticationPresentationContextProviding, funding: PayPalWebCheckoutFundingSource) {
         let payPalRequest = PayPalWebCheckoutRequest(orderID: orderID, funding: funding)
         payPalClient.start(request: payPalRequest, context: context)
     }

--- a/Demo/Demo/ViewModels/BaseViewModel.swift
+++ b/Demo/Demo/ViewModels/BaseViewModel.swift
@@ -138,9 +138,9 @@ class BaseViewModel: ObservableObject, PayPalWebCheckoutDelegate {
     func payPalCreditButtonTapped(context: ASWebAuthenticationPresentationContextProviding) {
         paymentButtonTapped(context: context, funding: .credit)
     }
-    
+
     func payPalButtonTapped(context: ASWebAuthenticationPresentationContextProviding) {
-        paymentButtonTapped(context: context, funding: .unspecified)
+        paymentButtonTapped(context: context, funding: .paypal)
     }
     
     private func paymentButtonTapped(context: ASWebAuthenticationPresentationContextProviding, funding: PayPalWebCheckoutFundingSource) {
@@ -151,7 +151,7 @@ class BaseViewModel: ObservableObject, PayPalWebCheckoutDelegate {
 
         checkoutWithPayPal(orderID: orderID, context: context, funding: funding)
     }
-
+    
     func checkoutWithPayPal(orderID: String, context: ASWebAuthenticationPresentationContextProviding, funding: PayPalWebCheckoutFundingSource) {
         let payPalRequest = PayPalWebCheckoutRequest(orderID: orderID, funding: funding)
         payPalClient.start(request: payPalRequest, context: context)

--- a/Demo/Demo/ViewModels/BaseViewModel.swift
+++ b/Demo/Demo/ViewModels/BaseViewModel.swift
@@ -135,17 +135,25 @@ class BaseViewModel: ObservableObject, PayPalWebCheckoutDelegate {
 
     // MARK: - PayPal Module Integration
 
+    func payPalCreditButtonTapped(context: ASWebAuthenticationPresentationContextProviding) {
+        paymentButtonTapped(context: context, funding: .credit)
+    }
+    
     func payPalButtonTapped(context: ASWebAuthenticationPresentationContextProviding) {
+        paymentButtonTapped(context: context, funding: .unspecified)
+    }
+    
+    private func paymentButtonTapped(context: ASWebAuthenticationPresentationContextProviding, funding: PayPalWebCheckoutFunding) {
         guard let orderID = orderID else {
             self.updateTitle("Failed: missing orderID.")
             return
         }
 
-        checkoutWithPayPal(orderID: orderID, context: context)
+        checkoutWithPayPal(orderID: orderID, context: context, funding: funding)
     }
 
-    func checkoutWithPayPal(orderID: String, context: ASWebAuthenticationPresentationContextProviding) {
-        let payPalRequest = PayPalWebCheckoutRequest(orderID: orderID)
+    func checkoutWithPayPal(orderID: String, context: ASWebAuthenticationPresentationContextProviding, funding: PayPalWebCheckoutFunding) {
+        let payPalRequest = PayPalWebCheckoutRequest(orderID: orderID, funding: funding)
         payPalClient.start(request: payPalRequest, context: context)
     }
 

--- a/Demo/Demo/ViewModels/BaseViewModel.swift
+++ b/Demo/Demo/ViewModels/BaseViewModel.swift
@@ -142,7 +142,7 @@ class BaseViewModel: ObservableObject, PayPalWebCheckoutDelegate {
     func payPalButtonTapped(context: ASWebAuthenticationPresentationContextProviding) {
         paymentButtonTapped(context: context, funding: .paypal)
     }
-    
+
     private func paymentButtonTapped(context: ASWebAuthenticationPresentationContextProviding, funding: PayPalWebCheckoutFundingSource) {
         guard let orderID = orderID else {
             self.updateTitle("Failed: missing orderID.")
@@ -151,9 +151,13 @@ class BaseViewModel: ObservableObject, PayPalWebCheckoutDelegate {
 
         checkoutWithPayPal(orderID: orderID, context: context, funding: funding)
     }
-    
-    func checkoutWithPayPal(orderID: String, context: ASWebAuthenticationPresentationContextProviding, funding: PayPalWebCheckoutFundingSource) {
-        let payPalRequest = PayPalWebCheckoutRequest(orderID: orderID, funding: funding)
+
+    func checkoutWithPayPal(
+        orderID: String,
+        context: ASWebAuthenticationPresentationContextProviding,
+        funding: PayPalWebCheckoutFundingSource
+    ) {
+        let payPalRequest = PayPalWebCheckoutRequest(orderID: orderID, fundingSource: funding)
         payPalClient.start(request: payPalRequest, context: context)
     }
 

--- a/Demo/Demo/ViewModels/BaseViewModel.swift
+++ b/Demo/Demo/ViewModels/BaseViewModel.swift
@@ -136,7 +136,7 @@ class BaseViewModel: ObservableObject, PayPalWebCheckoutDelegate {
     // MARK: - PayPal Module Integration
 
     func payPalCreditButtonTapped(context: ASWebAuthenticationPresentationContextProviding) {
-        paymentButtonTapped(context: context, funding: .credit)
+        paymentButtonTapped(context: context, funding: .paypalCredit)
     }
 
     func payPalButtonTapped(context: ASWebAuthenticationPresentationContextProviding) {

--- a/PayPal.xcodeproj/project.pbxproj
+++ b/PayPal.xcodeproj/project.pbxproj
@@ -101,7 +101,7 @@
 		BEA100F026EFA7C20036A6A5 /* APIClientError.swift in Sources */ = {isa = PBXBuildFile; fileRef = BEA100EF26EFA7C20036A6A5 /* APIClientError.swift */; };
 		BEA100F226EFA7DE0036A6A5 /* Environment.swift in Sources */ = {isa = PBXBuildFile; fileRef = BEA100F126EFA7DE0036A6A5 /* Environment.swift */; };
 		CB38546327F4B616003CE179 /* PayPalDataCollectorEnvironment.swift in Sources */ = {isa = PBXBuildFile; fileRef = CB38546227F4B616003CE179 /* PayPalDataCollectorEnvironment.swift */; };
-		CB51FF7227FCB947001A97F5 /* PayPalWebCheckoutFunding.swift in Sources */ = {isa = PBXBuildFile; fileRef = CB51FF7127FCB947001A97F5 /* PayPalWebCheckoutFunding.swift */; };
+		CB51FF7227FCB947001A97F5 /* PayPalWebCheckoutFundingSource.swift in Sources */ = {isa = PBXBuildFile; fileRef = CB51FF7127FCB947001A97F5 /* PayPalWebCheckoutFundingSource.swift */; };
 		CBA92A4327B304140077FF14 /* APIClientDecoder.swift in Sources */ = {isa = PBXBuildFile; fileRef = CBA92A4227B304140077FF14 /* APIClientDecoder.swift */; };
 /* End PBXBuildFile section */
 
@@ -241,7 +241,7 @@
 		BEDB7FE32788AB8E00CEA554 /* Coordinator.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Coordinator.swift; sourceTree = "<group>"; };
 		BEF3FF1627AC5DF3006B4B69 /* Coordinator_Tests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Coordinator_Tests.swift; sourceTree = "<group>"; };
 		CB38546227F4B616003CE179 /* PayPalDataCollectorEnvironment.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PayPalDataCollectorEnvironment.swift; sourceTree = "<group>"; };
-		CB51FF7127FCB947001A97F5 /* PayPalWebCheckoutFunding.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PayPalWebCheckoutFunding.swift; sourceTree = "<group>"; };
+		CB51FF7127FCB947001A97F5 /* PayPalWebCheckoutFundingSource.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PayPalWebCheckoutFundingSource.swift; sourceTree = "<group>"; };
 		CBA92A4227B304140077FF14 /* APIClientDecoder.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = APIClientDecoder.swift; sourceTree = "<group>"; };
 		OBJ_16 /* README.md */ = {isa = PBXFileReference; lastKnownFileType = net.daringfireball.markdown; path = README.md; sourceTree = "<group>"; };
 		OBJ_6 /* Package.swift */ = {isa = PBXFileReference; explicitFileType = sourcecode.swift; path = Package.swift; sourceTree = "<group>"; };
@@ -585,7 +585,7 @@
 				BE4F784527EB629100FF4C0E /* PayPalWebCheckoutRequest.swift */,
 				BE4F784727EB629100FF4C0E /* PayPalWebCheckoutResult.swift */,
 				BE4F784827EB629100FF4C0E /* WebAuthenticationSession.swift */,
-				CB51FF7127FCB947001A97F5 /* PayPalWebCheckoutFunding.swift */,
+				CB51FF7127FCB947001A97F5 /* PayPalWebCheckoutFundingSource.swift */,
 			);
 			name = PayPalWebCheckout;
 			path = Sources/PayPalWebCheckout;
@@ -1241,7 +1241,7 @@
 				BE4F785727EB656400FF4C0E /* PayPalWebCheckoutRequest.swift in Sources */,
 				BE4F785827EB656400FF4C0E /* PayPalWebCheckoutResult.swift in Sources */,
 				BE4F785927EB656400FF4C0E /* WebAuthenticationSession.swift in Sources */,
-				CB51FF7227FCB947001A97F5 /* PayPalWebCheckoutFunding.swift in Sources */,
+				CB51FF7227FCB947001A97F5 /* PayPalWebCheckoutFundingSource.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};

--- a/PayPal.xcodeproj/project.pbxproj
+++ b/PayPal.xcodeproj/project.pbxproj
@@ -101,6 +101,7 @@
 		BEA100F026EFA7C20036A6A5 /* APIClientError.swift in Sources */ = {isa = PBXBuildFile; fileRef = BEA100EF26EFA7C20036A6A5 /* APIClientError.swift */; };
 		BEA100F226EFA7DE0036A6A5 /* Environment.swift in Sources */ = {isa = PBXBuildFile; fileRef = BEA100F126EFA7DE0036A6A5 /* Environment.swift */; };
 		CB38546327F4B616003CE179 /* PayPalDataCollectorEnvironment.swift in Sources */ = {isa = PBXBuildFile; fileRef = CB38546227F4B616003CE179 /* PayPalDataCollectorEnvironment.swift */; };
+		CB51FF7227FCB947001A97F5 /* PayPalWebCheckoutFunding.swift in Sources */ = {isa = PBXBuildFile; fileRef = CB51FF7127FCB947001A97F5 /* PayPalWebCheckoutFunding.swift */; };
 		CBA92A4327B304140077FF14 /* APIClientDecoder.swift in Sources */ = {isa = PBXBuildFile; fileRef = CBA92A4227B304140077FF14 /* APIClientDecoder.swift */; };
 /* End PBXBuildFile section */
 
@@ -240,6 +241,7 @@
 		BEDB7FE32788AB8E00CEA554 /* Coordinator.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Coordinator.swift; sourceTree = "<group>"; };
 		BEF3FF1627AC5DF3006B4B69 /* Coordinator_Tests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Coordinator_Tests.swift; sourceTree = "<group>"; };
 		CB38546227F4B616003CE179 /* PayPalDataCollectorEnvironment.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PayPalDataCollectorEnvironment.swift; sourceTree = "<group>"; };
+		CB51FF7127FCB947001A97F5 /* PayPalWebCheckoutFunding.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PayPalWebCheckoutFunding.swift; sourceTree = "<group>"; };
 		CBA92A4227B304140077FF14 /* APIClientDecoder.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = APIClientDecoder.swift; sourceTree = "<group>"; };
 		OBJ_16 /* README.md */ = {isa = PBXFileReference; lastKnownFileType = net.daringfireball.markdown; path = README.md; sourceTree = "<group>"; };
 		OBJ_6 /* Package.swift */ = {isa = PBXFileReference; explicitFileType = sourcecode.swift; path = Package.swift; sourceTree = "<group>"; };
@@ -583,6 +585,7 @@
 				BE4F784527EB629100FF4C0E /* PayPalWebCheckoutRequest.swift */,
 				BE4F784727EB629100FF4C0E /* PayPalWebCheckoutResult.swift */,
 				BE4F784827EB629100FF4C0E /* WebAuthenticationSession.swift */,
+				CB51FF7127FCB947001A97F5 /* PayPalWebCheckoutFunding.swift */,
 			);
 			name = PayPalWebCheckout;
 			path = Sources/PayPalWebCheckout;
@@ -1238,6 +1241,7 @@
 				BE4F785727EB656400FF4C0E /* PayPalWebCheckoutRequest.swift in Sources */,
 				BE4F785827EB656400FF4C0E /* PayPalWebCheckoutResult.swift in Sources */,
 				BE4F785927EB656400FF4C0E /* WebAuthenticationSession.swift in Sources */,
+				CB51FF7227FCB947001A97F5 /* PayPalWebCheckoutFunding.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};

--- a/Sources/PayPalWebCheckout/PayPalWebCheckoutClient.swift
+++ b/Sources/PayPalWebCheckout/PayPalWebCheckoutClient.swift
@@ -35,7 +35,7 @@ public class PayPalWebCheckoutClient {
         webAuthenticationSession: WebAuthenticationSession
     ) {
         let baseURLString = config.environment.payPalBaseURL.absoluteString
-        let payPalCheckoutURLString = "\(baseURLString)/checkoutnow?token=\(request.orderID)"
+        let payPalCheckoutURLString = "\(baseURLString)/checkoutnow?token=\(request.orderID)&fundingSource=\(request.funding.rawValue)"
 
         guard let payPalCheckoutURL = URL(string: payPalCheckoutURLString),
         let payPalCheckoutURLComponents = payPalCheckoutReturnURL(payPalCheckoutURL: payPalCheckoutURL)

--- a/Sources/PayPalWebCheckout/PayPalWebCheckoutClient.swift
+++ b/Sources/PayPalWebCheckout/PayPalWebCheckoutClient.swift
@@ -35,7 +35,9 @@ public class PayPalWebCheckoutClient {
         webAuthenticationSession: WebAuthenticationSession
     ) {
         let baseURLString = config.environment.payPalBaseURL.absoluteString
-        let payPalCheckoutURLString = "\(baseURLString)/checkoutnow?token=\(request.orderID)&fundingSource=\(request.funding.rawValue)"
+        let payPalCheckoutURLString =
+            "\(baseURLString)/checkoutnow?token=\(request.orderID)" +
+            "&fundingSource=\(request.fundingSource.rawValue)"
 
         guard let payPalCheckoutURL = URL(string: payPalCheckoutURLString),
         let payPalCheckoutURLComponents = payPalCheckoutReturnURL(payPalCheckoutURL: payPalCheckoutURL)

--- a/Sources/PayPalWebCheckout/PayPalWebCheckoutFunding.swift
+++ b/Sources/PayPalWebCheckout/PayPalWebCheckoutFunding.swift
@@ -1,0 +1,6 @@
+/// Enum class to specify the type of funding for an order
+public enum PayPalWebCheckoutFunding: String {
+    case credit = "credit"
+    case paylater = "paylater"
+    case unspecified = ""
+}

--- a/Sources/PayPalWebCheckout/PayPalWebCheckoutFundingSource.swift
+++ b/Sources/PayPalWebCheckout/PayPalWebCheckoutFundingSource.swift
@@ -1,7 +1,7 @@
 /// Enum class to specify the type of funding for an order.
 /// For more information go to: https://developer.paypal.com/docs/checkout/pay-later/us/
 public enum PayPalWebCheckoutFundingSource: String {
-    
+
     /// PayPal Credit will launch the web checkout flow and display PayPal Credit funding to eligible customers
     /// Eligible costumers receive a revolving line of credit that they can use to pay over time.
     case paypalCredit = "credit"

--- a/Sources/PayPalWebCheckout/PayPalWebCheckoutFundingSource.swift
+++ b/Sources/PayPalWebCheckout/PayPalWebCheckoutFundingSource.swift
@@ -1,9 +1,12 @@
-/// Enum class to specify the type of funding for an order
+/// Enum class to specify the type of funding for an order.
+/// For more information go to: https://developer.paypal.com/docs/checkout/pay-later/us/
 public enum PayPalWebCheckoutFundingSource: String {
-    /// credit will launch the web checkout flow with credit funding selected
-    case credit
-    /// paylater will launch the web checkout flow with pay later selected
-    case paylater
-    /// paypal will launch the web checkout default flow
-    case paypal
+    /// PayPal Credit will launch the web checkout flow and display PayPal Credit funding to eligible customers
+    /// Eligible costumers receive a revolving line of credit that they can use to pay over time.
+    case paypalCredit = "credit"
+    /// PayLater will launch the web checkout flow and display Pay Later offers to eligible customers,
+    /// which include short-term, interest-free payments and other special financing options
+    case paylater = "paylater"
+    /// PayPal will launch the web checkout for a one-time PayPal Checkout flow
+    case paypal = "paypal"
 }

--- a/Sources/PayPalWebCheckout/PayPalWebCheckoutFundingSource.swift
+++ b/Sources/PayPalWebCheckout/PayPalWebCheckoutFundingSource.swift
@@ -1,5 +1,5 @@
 /// Enum class to specify the type of funding for an order
-public enum PayPalWebCheckoutFunding: String {
+public enum PayPalWebCheckoutFundingSource: String {
     case credit = "credit"
     case paylater = "paylater"
     case unspecified = ""

--- a/Sources/PayPalWebCheckout/PayPalWebCheckoutFundingSource.swift
+++ b/Sources/PayPalWebCheckout/PayPalWebCheckoutFundingSource.swift
@@ -5,6 +5,7 @@ public enum PayPalWebCheckoutFundingSource: String {
     /// PayPal Credit will launch the web checkout flow and display PayPal Credit funding to eligible customers
     /// Eligible costumers receive a revolving line of credit that they can use to pay over time.
     case paypalCredit = "credit"
+
     /// PayLater will launch the web checkout flow and display Pay Later offers to eligible customers,
     /// which include short-term, interest-free payments and other special financing options
     case paylater = "paylater"

--- a/Sources/PayPalWebCheckout/PayPalWebCheckoutFundingSource.swift
+++ b/Sources/PayPalWebCheckout/PayPalWebCheckoutFundingSource.swift
@@ -7,6 +7,7 @@ public enum PayPalWebCheckoutFundingSource: String {
     /// PayLater will launch the web checkout flow and display Pay Later offers to eligible customers,
     /// which include short-term, interest-free payments and other special financing options
     case paylater = "paylater"
+
     /// PayPal will launch the web checkout for a one-time PayPal Checkout flow
     case paypal = "paypal"
 }

--- a/Sources/PayPalWebCheckout/PayPalWebCheckoutFundingSource.swift
+++ b/Sources/PayPalWebCheckout/PayPalWebCheckoutFundingSource.swift
@@ -1,6 +1,9 @@
 /// Enum class to specify the type of funding for an order
 public enum PayPalWebCheckoutFundingSource: String {
+    /// credit will launch the web checkout flow with credit funding selected
     case credit
+    /// paylater will launch the web checkout flow with pay later selected
     case paylater
+    /// paypal will launch the web checkout default flow
     case paypal
 }

--- a/Sources/PayPalWebCheckout/PayPalWebCheckoutFundingSource.swift
+++ b/Sources/PayPalWebCheckout/PayPalWebCheckoutFundingSource.swift
@@ -1,6 +1,7 @@
 /// Enum class to specify the type of funding for an order.
 /// For more information go to: https://developer.paypal.com/docs/checkout/pay-later/us/
 public enum PayPalWebCheckoutFundingSource: String {
+    
     /// PayPal Credit will launch the web checkout flow and display PayPal Credit funding to eligible customers
     /// Eligible costumers receive a revolving line of credit that they can use to pay over time.
     case paypalCredit = "credit"

--- a/Sources/PayPalWebCheckout/PayPalWebCheckoutFundingSource.swift
+++ b/Sources/PayPalWebCheckout/PayPalWebCheckoutFundingSource.swift
@@ -1,6 +1,6 @@
 /// Enum class to specify the type of funding for an order
 public enum PayPalWebCheckoutFundingSource: String {
-    case credit = "credit"
-    case paylater = "paylater"
-    case unspecified = ""
+    case credit
+    case paylater
+    case paypal
 }

--- a/Sources/PayPalWebCheckout/PayPalWebCheckoutRequest.swift
+++ b/Sources/PayPalWebCheckout/PayPalWebCheckoutRequest.swift
@@ -6,11 +6,11 @@ public struct PayPalWebCheckoutRequest {
     /// The order ID associated with the request.
     public let orderID: String
     /// The funding for the order: credit, paylater or default
-    public let funding: PayPalWebCheckoutFunding
+    public let funding: PayPalWebCheckoutFundingSource
 
     /// Creates an instance of a PayPalRequest.
     /// - Parameter orderID: The ID of the order to be approved.
-    public init(orderID: String, funding: PayPalWebCheckoutFunding = .unspecified) {
+    public init(orderID: String, funding: PayPalWebCheckoutFundingSource = .unspecified) {
         self.orderID = orderID
         self.funding = funding
     }

--- a/Sources/PayPalWebCheckout/PayPalWebCheckoutRequest.swift
+++ b/Sources/PayPalWebCheckout/PayPalWebCheckoutRequest.swift
@@ -10,7 +10,7 @@ public struct PayPalWebCheckoutRequest {
 
     /// Creates an instance of a PayPalRequest.
     /// - Parameter orderID: The ID of the order to be approved.
-    public init(orderID: String, funding: PayPalWebCheckoutFundingSource = .unspecified) {
+    public init(orderID: String, funding: PayPalWebCheckoutFundingSource = .paypal) {
         self.orderID = orderID
         self.funding = funding
     }

--- a/Sources/PayPalWebCheckout/PayPalWebCheckoutRequest.swift
+++ b/Sources/PayPalWebCheckout/PayPalWebCheckoutRequest.swift
@@ -5,10 +5,13 @@ public struct PayPalWebCheckoutRequest {
 
     /// The order ID associated with the request.
     public let orderID: String
+    /// The funding for the order: credit, paylater or default
+    public let funding: PayPalWebCheckoutFunding
 
     /// Creates an instance of a PayPalRequest.
     /// - Parameter orderID: The ID of the order to be approved.
-    public init(orderID: String) {
+    public init(orderID: String, funding: PayPalWebCheckoutFunding = .unspecified) {
         self.orderID = orderID
+        self.funding = funding
     }
 }

--- a/Sources/PayPalWebCheckout/PayPalWebCheckoutRequest.swift
+++ b/Sources/PayPalWebCheckout/PayPalWebCheckoutRequest.swift
@@ -6,12 +6,13 @@ public struct PayPalWebCheckoutRequest {
     /// The order ID associated with the request.
     public let orderID: String
     /// The funding for the order: credit, paylater or default
-    public let funding: PayPalWebCheckoutFundingSource
+    public let fundingSource: PayPalWebCheckoutFundingSource
 
     /// Creates an instance of a PayPalRequest.
     /// - Parameter orderID: The ID of the order to be approved.
-    public init(orderID: String, funding: PayPalWebCheckoutFundingSource = .paypal) {
+    /// - Parameter fundingSource: The funding source for and order. Default value is .paypal
+    public init(orderID: String, fundingSource: PayPalWebCheckoutFundingSource = .paypal) {
         self.orderID = orderID
-        self.funding = funding
+        self.fundingSource = fundingSource
     }
 }

--- a/docs/PayPal/integration.md
+++ b/docs/PayPal/integration.md
@@ -115,6 +115,9 @@ Configure your `PayPalWebCheckoutRequest` and include the order ID generated in 
 let payPalRequest = PayPalWebCheckoutRequest(orderID: "<ORDER_ID>")
 ```
 
+You can also specify the funding source for your order which are `PayPal` (default), `PayLater` and `PayPalCredit`.
+For more information go to: https://developer.paypal.com/docs/checkout/pay-later/us/
+
 ### 6. Approve the order through the Payments SDK
 
 When a user initiates the PayPal payment flow through your UI, approve the order using your `PayPalWebCheckoutClient`.


### PR DESCRIPTION
### Reason for changes
PayLayer and Credit funding source are added as funding sources for an order passed to the web checkout flow


### Summary of changes

- Adds `PayPalCheckoutWebFundingSource`
- Adds `fundingSource` param to `payPalWebCheckoutClient.start()` func and then is added as query param

### Checklist

- [ ] Added a changelog entry

### Authors
> List GitHub usernames for everyone who contributed to this pull request.

- @jcnoriega 