### PR TITLE
Update Buttons to UIKit + PayPal Buttons

### DIFF
--- a/Demo/Demo.xcodeproj/project.pbxproj
+++ b/Demo/Demo.xcodeproj/project.pbxproj
@@ -33,6 +33,8 @@
 		BE1766D926FA7BC8007EF438 /* Settings.bundle in Resources */ = {isa = PBXBuildFile; fileRef = BE1766D826FA7BC8007EF438 /* Settings.bundle */; };
 		BE31187C273F00B60021C5A2 /* DemoUIFramework.swift in Sources */ = {isa = PBXBuildFile; fileRef = BE31187B273F00B60021C5A2 /* DemoUIFramework.swift */; };
 		BE31187E273F02A80021C5A2 /* SwiftUICardDemo.swift in Sources */ = {isa = PBXBuildFile; fileRef = BE31187D273F02A80021C5A2 /* SwiftUICardDemo.swift */; };
+		BE420F3728189A7A00D8D66A /* PayPalUI.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = BE420F3628189A7A00D8D66A /* PayPalUI.framework */; };
+		BE420F3828189A7A00D8D66A /* PayPalUI.framework in Embed Frameworks */ = {isa = PBXBuildFile; fileRef = BE420F3628189A7A00D8D66A /* PayPalUI.framework */; settings = {ATTRIBUTES = (CodeSignOnCopy, RemoveHeadersOnCopy, ); }; };
 		BE9F36D82745490400AFC7DA /* FloatingLabelTextField.swift in Sources */ = {isa = PBXBuildFile; fileRef = BE9F36D72745490400AFC7DA /* FloatingLabelTextField.swift */; };
 		BE9F36DC274578D100AFC7DA /* FeatureBaseViewControllerRepresentable.swift in Sources */ = {isa = PBXBuildFile; fileRef = BE9F36DB274578D100AFC7DA /* FeatureBaseViewControllerRepresentable.swift */; };
 		BE9F36E7275548A600AFC7DA /* BaseViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = BE9F36E6275548A600AFC7DA /* BaseViewModel.swift */; };
@@ -65,6 +67,7 @@
 			dstSubfolderSpec = 10;
 			files = (
 				BCE8A7EF27EA2B1E00AC301B /* PayPalWebCheckout.framework in Embed Frameworks */,
+				BE420F3828189A7A00D8D66A /* PayPalUI.framework in Embed Frameworks */,
 				805AB85126B87A87003BEE0D /* Card.framework in Embed Frameworks */,
 			);
 			name = "Embed Frameworks";
@@ -102,6 +105,7 @@
 		BE1766D826FA7BC8007EF438 /* Settings.bundle */ = {isa = PBXFileReference; lastKnownFileType = "wrapper.plug-in"; path = Settings.bundle; sourceTree = "<group>"; };
 		BE31187B273F00B60021C5A2 /* DemoUIFramework.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DemoUIFramework.swift; sourceTree = "<group>"; };
 		BE31187D273F02A80021C5A2 /* SwiftUICardDemo.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SwiftUICardDemo.swift; sourceTree = "<group>"; };
+		BE420F3628189A7A00D8D66A /* PayPalUI.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; path = PayPalUI.framework; sourceTree = BUILT_PRODUCTS_DIR; };
 		BE9F36D72745490400AFC7DA /* FloatingLabelTextField.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FloatingLabelTextField.swift; sourceTree = "<group>"; };
 		BE9F36DB274578D100AFC7DA /* FeatureBaseViewControllerRepresentable.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FeatureBaseViewControllerRepresentable.swift; sourceTree = "<group>"; };
 		BE9F36E6275548A600AFC7DA /* BaseViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BaseViewModel.swift; sourceTree = "<group>"; };
@@ -124,6 +128,7 @@
 				805AB85026B87A87003BEE0D /* Card.framework in Frameworks */,
 				BE1766D726FA7AC3007EF438 /* InAppSettingsKit in Frameworks */,
 				BCE8A7EE27EA2B1E00AC301B /* PayPalWebCheckout.framework in Frameworks */,
+				BE420F3728189A7A00D8D66A /* PayPalUI.framework in Frameworks */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -150,6 +155,7 @@
 		805AB84C26B87A87003BEE0D /* Frameworks */ = {
 			isa = PBXGroup;
 			children = (
+				BE420F3628189A7A00D8D66A /* PayPalUI.framework */,
 				BCE8A7ED27EA2B1E00AC301B /* PayPalWebCheckout.framework */,
 				80DB6F1C26B89DDA00277E54 /* PayPal.framework */,
 				805AB84D26B87A87003BEE0D /* Card.framework */,

--- a/Demo/Demo/FeatureViewControllers/PayPalWebCheckoutViewController.swift
+++ b/Demo/Demo/FeatureViewControllers/PayPalWebCheckoutViewController.swift
@@ -20,7 +20,7 @@ class PayPalWebCheckoutViewController: FeatureBaseViewController {
 
     lazy var payPalCreditButton: PayPalCreditButton = {
         let payPalCreditButton = PayPalCreditButton()
-        payPalCreditButton.addTarget(self, action: #selector(paymentButtonTapped), for: .touchUpInside)
+        payPalCreditButton.addTarget(self, action: #selector(paymentCreditButtonTapped), for: .touchUpInside)
         payPalCreditButton.layer.cornerRadius = 4.0
         return payPalCreditButton
     }()

--- a/Demo/Demo/FeatureViewControllers/PayPalWebCheckoutViewController.swift
+++ b/Demo/Demo/FeatureViewControllers/PayPalWebCheckoutViewController.swift
@@ -1,6 +1,7 @@
 import UIKit
 import PayPalWebCheckout
 import PaymentsCore
+import PayPalUI
 
 class PayPalWebCheckoutViewController: FeatureBaseViewController {
 
@@ -10,20 +11,16 @@ class PayPalWebCheckoutViewController: FeatureBaseViewController {
 
     // MARK: - UI Components
 
-    lazy var payPalButton: UIButton = {
-        let payPalButton = UIButton(type: .system)
-        payPalButton.translatesAutoresizingMaskIntoConstraints = false
-        payPalButton.setTitle("Pay with PayPal", for: .normal)
+    lazy var payPalButton: PayPalButton = {
+        let payPalButton = PayPalButton()
         payPalButton.addTarget(self, action: #selector(paymentButtonTapped), for: .touchUpInside)
         payPalButton.layer.cornerRadius = 4.0
         return payPalButton
     }()
 
-    lazy var payPalCreditButton: UIButton = {
-        let payPalCreditButton = UIButton(type: .system)
-        payPalCreditButton.translatesAutoresizingMaskIntoConstraints = false
-        payPalCreditButton.setTitle("Pay with PayPal Credit", for: .normal)
-        payPalCreditButton.addTarget(self, action: #selector(paymentCreditButtonTapped), for: .touchUpInside)
+    lazy var payPalCreditButton: PayPalCreditButton = {
+        let payPalCreditButton = PayPalCreditButton()
+        payPalCreditButton.addTarget(self, action: #selector(paymentButtonTapped), for: .touchUpInside)
         payPalCreditButton.layer.cornerRadius = 4.0
         return payPalCreditButton
     }()

--- a/Demo/Demo/SwiftUIComponents/SwiftUIPayPalDemo.swift
+++ b/Demo/Demo/SwiftUIComponents/SwiftUIPayPalDemo.swift
@@ -16,7 +16,7 @@ struct SwiftUIPayPalDemo: View {
                 .cornerRadius(4)
                 .frame(maxWidth: .infinity, maxHeight: 40)
                 PayPalCreditButton {
-                    baseViewModel.payPalButtonTapped(context: FeatureBaseViewController(baseViewModel: BaseViewModel()))
+                    baseViewModel.payPalCreditButtonTapped(context: FeatureBaseViewController(baseViewModel: BaseViewModel()))
                 }
                 .cornerRadius(4)
                 .frame(maxWidth: .infinity, maxHeight: 40)

--- a/Demo/Demo/SwiftUIComponents/SwiftUIPayPalDemo.swift
+++ b/Demo/Demo/SwiftUIComponents/SwiftUIPayPalDemo.swift
@@ -1,4 +1,5 @@
 import SwiftUI
+import PayPalUI
 
 @available(iOS 13.0.0, *)
 struct SwiftUIPayPalDemo: View {
@@ -9,12 +10,12 @@ struct SwiftUIPayPalDemo: View {
         ZStack {
             FeatureBaseViewControllerRepresentable(baseViewModel: baseViewModel)
             VStack(spacing: 50) {
-                Button("Pay with PayPal") {
+                PayPalButton {
                     baseViewModel.payPalButtonTapped(context: FeatureBaseViewController(baseViewModel: BaseViewModel()))
                 }
                 .cornerRadius(4)
                 .frame(maxWidth: .infinity, maxHeight: 40)
-                Button("Pay with PayPal Credit") {
+                PayPalCreditButton {
                     baseViewModel.payPalButtonTapped(context: FeatureBaseViewController(baseViewModel: BaseViewModel()))
                 }
                 .cornerRadius(4)

--- a/Sources/PayPalUI/PayPalCreditButton.swift
+++ b/Sources/PayPalUI/PayPalCreditButton.swift
@@ -15,7 +15,7 @@ public final class PayPalCreditButton: PaymentButton, UIViewRepresentable {
     /// - Parameter action: action of the button on click
     public init(_ action: @escaping () -> Void) {
         self.action = action
-        super.init(color: .gold, image: .payPal)
+        super.init(color: .darkBlue, image: .payPalCredit)
     }
 
     required init?(coder: NSCoder) {

--- a/Sources/PayPalUI/PaymentButton.swift
+++ b/Sources/PayPalUI/PaymentButton.swift
@@ -3,8 +3,8 @@ import UIKit
 /// Handles functionality shared across payment buttons
 public class PaymentButton: UIButton {
 
-    // asset identfier path for image and color button assets
-    static var bundle = Bundle(identifier: "com.paypal.ios-sdk.PayPal")
+    // asset identifier path for image and color button assets
+    static var bundle = Bundle(identifier: "com.paypal.ios-sdk.PayPalUI")
 
     // MARK: - Init
 


### PR DESCRIPTION
### Reason for changes

When we moved UI to a new module, we also need to update the bundle ID to pull in the assets correctly. 

### Summary of changes

- Update bundle ID
- Add back in buttons to use UIKit + SwiftUI PayPal/PayPalCredit buttons

### Checklist

- ~[ ] Added a changelog entry~

### Authors
> List GitHub usernames for everyone who contributed to this pull request.

- @jaxdesmarais 