### PR TITLE
Add concurrency to Github Actions

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,5 +1,8 @@
 name: Build
 on: [pull_request, workflow_dispatch]
+concurrency:
+  group: build-${{ github.event.number }}
+  cancel-in-progress: true
 jobs:
   cocoapods:
     name: CocoaPods

--- a/.github/workflows/swiftlint.yml
+++ b/.github/workflows/swiftlint.yml
@@ -1,5 +1,8 @@
 name: Lint
 on: [pull_request, workflow_dispatch]
+concurrency:
+  group: lint-${{ github.event.number }}
+  cancel-in-progress: true
 jobs:
   swiftlint:
     name: SwiftLint

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -1,5 +1,8 @@
 name: Tests
 on: [pull_request, workflow_dispatch]
+concurrency:
+  group: tests-${{ github.event.number }}
+  cancel-in-progress: true
 jobs:
   unit_test_job:
     name: Unit


### PR DESCRIPTION
### Reason for changes



### Summary of changes

- This changes will cancel any github action workflow launched on a PR when a new commit happens. Right now, if you commit before GA finishes, it will launch all the workflows but not cancel the old ones. This should improve our CI speed

### Checklist

- [ ] Added a changelog entry

### Authors
> List GitHub usernames for everyone who contributed to this pull request.

- @jcnoriega 