### PR TITLE
Access Token Docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,7 +37,7 @@ The PayPal SDK uses access tokens for authentication.
 
 To create an access token:
 
-1. Follw the steps in [Get Started](https://developer.paypal.com/api/rest/#link-getstarted) to obtain a client ID and secret from the PayPal Developer site.
+1. Follow the steps in [Get Started](https://developer.paypal.com/api/rest/#link-getstarted) to obtain a client ID and secret from the PayPal Developer site.
 1. Make an HTTP request with Basic Authentication using client ID and secret to fetch an access token:
 
 **Request**

--- a/README.md
+++ b/README.md
@@ -33,7 +33,7 @@ This SDK supports:
 
 The PayPal SDK uses access tokens for authentication.
 
-> The follwing example can be adapted to any server-side language/framework of your choice. We use command-line curl to demonstrate the overall composition of the Access Token HTTP request.
+> The following example can be adapted to any server-side language/framework of your choice. We use command-line curl requests to demonstrate the overall composition of the Access Token HTTP request.
 
 To create an access token:
 

--- a/README.md
+++ b/README.md
@@ -29,12 +29,56 @@ This SDK supports:
 * UIKit
 * SwiftUI
 
-## Modularity
+## Access Token
 
-The PayPal iOS SDK is comprised of various submodules.
-* `Card`
-* `PayPal`
-* ...
+The PayPal SDK uses access tokens for authentication.
+
+> The follwing example can be adapted to any server-side language/framework of your choice. We use command-line curl to demonstrate the overall composition of the Access Token HTTP request.
+
+To create an access token:
+
+1. Follw the steps in [Get Started](https://developer.paypal.com/api/rest/#link-getstarted) to obtain a client ID and secret from the PayPal Developer site.
+1. Make an HTTP request with Basic Authentication using client ID and secret to fetch an access token:
+
+**Request**
+```bash
+# for LIVE environment
+curl -X POST https://api.paypal.com/v1/oauth2/token \
+-u $CLIENT_ID:$CLIENT_SECRET \
+-H 'Content-Type: application/x-www-form-urlencoded' \
+-d 'grant_type=client_credentials&response_type=token&return_authn_schemes=true'
+
+# for SANDBOX environment
+curl -X POST https://api.sandbox.paypal.com/v1/oauth2/token \
+-u $CLIENT_ID:$CLIENT_SECRET \
+-H 'Content-Type: application/x-www-form-urlencoded' \
+-d 'grant_type=client_credentials&response_type=token&return_authn_schemes=true'
+```
+
+:warning:&nbsp;Make sure the environment variables for `CLIENT_ID` and `CLIENT_SECRET` are set.
+
+**Response**
+
+```json
+{
+  "scope": "...",
+  "access_token": "<ACCESS_TOKEN>",
+  "token_type": "Bearer",
+  "app_id": "...",
+  "expires_in": 32400,
+  "nonce": "..."
+}
+```
+
+Use the value for `access_token` in the response to create an instance of `CoreConfig` to use with any of the SDK's feature clients.
+
+## Modules
+
+Each feature module has its own onboarding guide:
+
+- [Card](docs/Card)
+- [PayPalUI](docs/PayPalUI)
+- [PayPal Web Checkout](docs/PayPalWebCheckout)
 
 To accept a certain payment method in your app, you only need to include that payment-specific submodule.
 

--- a/docs/Card/README.md
+++ b/docs/Card/README.md
@@ -67,10 +67,10 @@ extension MyViewController: ASWebAuthenticationPresentationContextProviding {
 
 ### 3. Initiate the Payments SDK
 
-Create a `CoreConfig` using your client ID from the PayPal Developer Portal:
+Create a `CoreConfig` using an [access token](../../README.md#access-token):
 
 ```swift
-let config = CoreConfig(clientID: "<CLIENT_ID>", environment: .sandbox)
+let config = CoreConfig(accessToken: "<ACCESS_TOKEN>", environment: .sandbox)
 ```
 
 Create a `CardClient` to approve an order with a Card payment method:

--- a/docs/PayPalWebCheckout/README.md
+++ b/docs/PayPalWebCheckout/README.md
@@ -67,10 +67,10 @@ extension MyViewController: ASWebAuthenticationPresentationContextProviding {
 
 ### 3. Initiate the Payments SDK
 
-Create a `CoreConfig` using your Client ID from the PayPal Developer Portal:
+Create a `CoreConfig` using an [access token](../../README.md#access-token):
 
 ```swift
-let config = CoreConfig(clientID: "<CLIENT_ID>", environment: .sandbox)
+let config = CoreConfig(accessToken: "<ACCESS_TOKEN>", environment: .sandbox)
 ```
 
 Create a `PayPalWebCheckoutClient` to approve an order with a PayPal payment method:


### PR DESCRIPTION
### Summary of changes

 - This PR updates documentation Access Token request onboarding and make sure `CoreConfig` examples use access tokens instead of client ids.

 ### Checklist

 ~- [ ] Added a changelog entry~

### Authors
> List GitHub usernames for everyone who contributed to this pull request.

- @sshropshire 