### PR TITLE
Remove unneeded @available annotations

### DIFF
--- a/Demo/Demo/FeatureViewControllers/PaymentButtonCustomizationViewController.swift
+++ b/Demo/Demo/FeatureViewControllers/PaymentButtonCustomizationViewController.swift
@@ -68,7 +68,6 @@ class PaymentButtonCustomizationViewController: UIViewController {
         configure()
     }
 
-    @available(*, unavailable)
     required init?(coder: NSCoder) {
         fatalError("init(coder:) has not been implemented")
     }

--- a/Demo/Demo/SwiftUIComponents/FeatureBaseViewControllerRepresentable.swift
+++ b/Demo/Demo/SwiftUIComponents/FeatureBaseViewControllerRepresentable.swift
@@ -1,6 +1,5 @@
 import SwiftUI
 
-@available(iOS 13, *)
 struct FeatureBaseViewControllerRepresentable: UIViewControllerRepresentable {
 
     let baseViewModel: BaseViewModel

--- a/Demo/Demo/SwiftUIComponents/SwiftUICardDemo.swift
+++ b/Demo/Demo/SwiftUIComponents/SwiftUICardDemo.swift
@@ -2,7 +2,6 @@ import SwiftUI
 
 /// This view contains the exact same behavior as our `CardDemoViewController` but uses SwiftUI best practices to create the card fields and buttons.
 /// Under the hood they both do the same thing but this represents how a merchant would use the card module with a Swift UI integration.
-@available(iOS 13.0.0, *)
 struct SwiftUICardDemo: View {
 
     // MARK: Variables
@@ -68,7 +67,6 @@ struct SwiftUICardDemo: View {
     }
 }
 
-@available(iOS 13.0.0, *)
 struct ContentView_Previews: PreviewProvider {
 
     static var previews: some View {

--- a/Demo/Demo/SwiftUIComponents/SwiftUINativeCheckoutDemo.swift
+++ b/Demo/Demo/SwiftUIComponents/SwiftUINativeCheckoutDemo.swift
@@ -26,7 +26,6 @@ struct SwiftUINativeCheckoutDemo: View {
     }
 }
 
-@available(iOS 13.0.0, *)
 struct SiftUINativeCheckoutDemo_Preview: PreviewProvider {
 
     static var previews: some View {

--- a/Demo/Demo/SwiftUIComponents/SwiftUIPayPalDemo.swift
+++ b/Demo/Demo/SwiftUIComponents/SwiftUIPayPalDemo.swift
@@ -1,7 +1,6 @@
 import SwiftUI
 import PayPalUI
 
-@available(iOS 13.0.0, *)
 struct SwiftUIPayPalDemo: View {
 
     @StateObject var baseViewModel = BaseViewModel()

--- a/Sources/PaymentsCore/WebAuthenticationSession.swift
+++ b/Sources/PaymentsCore/WebAuthenticationSession.swift
@@ -2,27 +2,21 @@ import Foundation
 import AuthenticationServices
 
 public class WebAuthenticationSession: NSObject {
-
-    public var authenticationSession: ASWebAuthenticationSession?
-    public var presentationContextProvider: ASWebAuthenticationPresentationContextProviding?
-
+    
     public func start(
         url: URL,
         context: ASWebAuthenticationPresentationContextProviding,
         completion: @escaping (URL?, Error?) -> Void
     ) {
-        self.authenticationSession = ASWebAuthenticationSession(
+        let authenticationSession = ASWebAuthenticationSession(
             url: url,
             callbackURLScheme: Bundle.main.bundleIdentifier,
             completionHandler: completion
         )
 
-        authenticationSession?.prefersEphemeralWebBrowserSession = true
-
-        if #available(iOS 13.0, *) {
-            authenticationSession?.presentationContextProvider = context
-        }
-
-        authenticationSession?.start()
+        authenticationSession.prefersEphemeralWebBrowserSession = true
+        authenticationSession.presentationContextProvider = context
+        
+        authenticationSession.start()
     }
 }

--- a/Sources/PaymentsCore/WebAuthenticationSession.swift
+++ b/Sources/PaymentsCore/WebAuthenticationSession.swift
@@ -2,7 +2,7 @@ import Foundation
 import AuthenticationServices
 
 public class WebAuthenticationSession: NSObject {
-    
+
     public func start(
         url: URL,
         context: ASWebAuthenticationPresentationContextProviding,
@@ -16,7 +16,7 @@ public class WebAuthenticationSession: NSObject {
 
         authenticationSession.prefersEphemeralWebBrowserSession = true
         authenticationSession.presentationContextProvider = context
-        
+
         authenticationSession.start()
     }
 }


### PR DESCRIPTION
### Reason for changes
Our SDK supports iOS 13 and up (currently) so we do not need to check if iOS 13 is available.


### Summary of changes

- Remove unneeded `@available(iOS 13, *)` annotations.
- Remove unused `authenticationSession` and `presentationContextProvider` properties in `WebAuthenticationSession`.

### Checklist

- ~Added a changelog entry~

### Authors
@scannillo 