### PR TITLE
NXO: Bump version to 0.109.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,10 @@
 
 # PayPal iOS SDK Release Notes
 
+## Unreleased Version
+* PayPalNativeCheckout
+    * Update to version 0.109.0 that fixes shipping callback bug
+
 ## 0.0.1 (2022-07-21)
 
 * Card

--- a/Demo/Demo/ViewModels/PayPalViewModel.swift
+++ b/Demo/Demo/ViewModels/PayPalViewModel.swift
@@ -122,32 +122,25 @@ extension PayPalViewModel: PayPalNativeCheckoutDelegate {
         shippingChange: ShippingChange,
         shippingChangeAction: ShippingChangeAction
     ) {
-        // A bug in NXO calls callback everytime. We have to store shipping preference for cases with no shipping
-        // https://engineering.paypalcorp.com/jira/browse/DTNATIVEXO-1281
-        if shippingPreference == .getFromFile {
-            switch shippingChange.type {
-            case .shippingAddress:
-                // If user selected new address, we generate new shipping methods
-                let availableShippingMethods = OrderRequestHelpers.getShippingMethods(baseValue: Int.random(in: 0..<6))
+        switch shippingChange.type {
+        case .shippingAddress:
+            // If user selected new address, we generate new shipping methods
+            let availableShippingMethods = OrderRequestHelpers.getShippingMethods(baseValue: Int.random(in: 0..<6))
+            // If shipping methods are available, then patch order with the new shipping methods and new amount
+            patchAmountAndShippingOptions(
+                shippingMethods: availableShippingMethods,
+                action: shippingChangeAction
+            )
 
-                // If shipping methods are available, then patch order with the new shipping methods and new amount
-                patchAmountAndShippingOptions(
-                    shippingMethods: availableShippingMethods,
-                    action: shippingChangeAction
-                )
+        case .shippingMethod:
+            // If user selected new method, we patch the selected shipping method + amount
+            patchAmountAndShippingOptions(
+                shippingMethods: shippingChange.shippingMethods,
+                action: shippingChangeAction
+            )
 
-            case .shippingMethod:
-                // If user selected new method, we patch the selected shipping method + amount
-                patchAmountAndShippingOptions(
-                    shippingMethods: shippingChange.shippingMethods,
-                    action: shippingChangeAction
-                )
-
-            @unknown default:
-                break
-            }
-        } else {
-            shippingChangeAction.approve()
+        @unknown default:
+            break
         }
     }
 }

--- a/Package.swift
+++ b/Package.swift
@@ -36,7 +36,7 @@ let package = Package(
     ],
     dependencies: [
         // Dependencies declare other packages that this package depends on.
-        .package(name: "PayPalCheckout", url: "https://github.com/paypal/paypalcheckout-ios", .exact("0.108.0"))
+        .package(name: "PayPalCheckout", url: "https://github.com/paypal/paypalcheckout-ios", .exact("0.109.0"))
     ],
     targets: [
         // Targets are the basic building blocks of a package. A target can define a module or a test suite.

--- a/Package.swift
+++ b/Package.swift
@@ -36,7 +36,7 @@ let package = Package(
     ],
     dependencies: [
         // Dependencies declare other packages that this package depends on.
-        .package(name: "PayPalCheckout", url: "https://github.com/paypal/paypalcheckout-ios", .exact("0.100.0"))
+        .package(name: "PayPalCheckout", url: "https://github.com/paypal/paypalcheckout-ios", .exact("0.108.0"))
     ],
     targets: [
         // Targets are the basic building blocks of a package. A target can define a module or a test suite.

--- a/PayPal.podspec
+++ b/PayPal.podspec
@@ -19,7 +19,7 @@ Pod::Spec.new do |s|
   s.subspec "PayPalNativeCheckout" do |s|
    s.source_files  = "Sources/PayPalNativeCheckout/**/*.swift"
    s.dependency "PayPal/PaymentsCore"
-   s.dependency "PayPalCheckout", "0.108.0"
+   s.dependency "PayPalCheckout", "0.109.0"
   end
 
   s.subspec "PayPalUI" do |s|

--- a/PayPal.podspec
+++ b/PayPal.podspec
@@ -19,7 +19,7 @@ Pod::Spec.new do |s|
   s.subspec "PayPalNativeCheckout" do |s|
    s.source_files  = "Sources/PayPalNativeCheckout/**/*.swift"
    s.dependency "PayPal/PaymentsCore"
-   s.dependency "PayPalCheckout", "0.100.0"
+   s.dependency "PayPalCheckout", "0.108.0"
   end
 
   s.subspec "PayPalUI" do |s|

--- a/PayPal.xcodeproj/project.pbxproj
+++ b/PayPal.xcodeproj/project.pbxproj
@@ -3455,7 +3455,7 @@
 			repositoryURL = "https://github.com/paypal/paypalcheckout-ios";
 			requirement = {
 				kind = exactVersion;
-				version = 0.100.0;
+				version = 0.108.0;
 			};
 		};
 /* End XCRemoteSwiftPackageReference section */

--- a/PayPal.xcodeproj/project.pbxproj
+++ b/PayPal.xcodeproj/project.pbxproj
@@ -3455,7 +3455,7 @@
 			repositoryURL = "https://github.com/paypal/paypalcheckout-ios";
 			requirement = {
 				kind = exactVersion;
-				version = 0.108.0;
+				version = 0.109.0;
 			};
 		};
 /* End XCRemoteSwiftPackageReference section */

--- a/Sources/PayPalNativeCheckout/PayPalNativeCheckoutClient.swift
+++ b/Sources/PayPalNativeCheckout/PayPalNativeCheckoutClient.swift
@@ -44,9 +44,7 @@ public class PayPalNativeCheckoutClient {
                 clientID: clientID,
                 createOrder: nil,
                 onApprove: nil,
-                onShippingChange: { shippingChange, shippingChangeAction in
-                    self.notifyShippingChange(shippingChange: shippingChange, shippingChangeAction: shippingChangeAction)
-                }, // TODO: set on start function, once https://engineering.paypalcorp.com/jira/browse/DTNATIVEXO-1268 is released
+                onShippingChange: nil,
                 onCancel: nil,
                 onError: nil,
                 environment: config.environment.toNativeCheckoutSDKEnvironment()


### PR DESCRIPTION
### Reason for changes
Bump to latest nxo version, where the following bugs were fixed:

Shipping callback ignored if set in `start` function: https://engineering.paypalcorp.com/jira/browse/DTNATIVEXO-1268
Shipping callback called everytime, even when no shipping allowed: https://engineering.paypalcorp.com/jira/browse/DTNATIVEXO-1281

### Summary of changes

- Change NXO version
- Remove setting onShippingCallback on CheckoutConfig
- Remove `.getFromFile` check in shipping callback

### Checklist

- [ ] Added a changelog entry

### Authors
> List GitHub usernames for everyone who contributed to this pull request.

- @jcnoriega 