### PR TITLE
Remove exit survey for Native Checkout

### DIFF
--- a/Sources/PayPalNativeCheckout/PayPalUIInterfaces/NativeCheckout.swift
+++ b/Sources/PayPalNativeCheckout/PayPalUIInterfaces/NativeCheckout.swift
@@ -17,6 +17,7 @@ class NativeCheckoutProvider: NativeCheckoutStartable {
         onError: CheckoutConfig.ErrorCallback?,
         nxoConfig: CheckoutConfig
     ) {
+        Checkout.showsExitAlert = false
         Checkout.set(config: nxoConfig)
         DispatchQueue.main.async {
             Checkout.start(


### PR DESCRIPTION
Signed-off-by: Steven Shropshire <steven.shropshire@getbraintree.com>

### Reason for changes

On iOS & Android, we want a customer to be able to cancel out of the PayPal flow without needing to complete an exit survey. This occurs by default in the NXO SDK.
Currently, when they try to exit the Native PayPal flow - they are required to complete an "exit survey", increasing friction for them to change to a different payment method.

### Summary of changes

- Disable the exit survey before Native Checkout starts.

### Checklist

~- [ ] Added a changelog entry~

### Authors
> List GitHub usernames for everyone who contributed to this pull request.

- @sshropshire @mattwylder @jcnoriega 