### PR TITLE
Fixup - Remove public from Eligibility API methods

### DIFF
--- a/Sources/PaymentsCore/api/EligibilityAPI.swift
+++ b/Sources/PaymentsCore/api/EligibilityAPI.swift
@@ -9,7 +9,7 @@ class EligibilityAPI {
 
     /// Initialize the eligibility API to check for payment methods eligibility
     /// - Parameter coreConfig: configuration object
-    public convenience init(coreConfig: CoreConfig) {
+    convenience init(coreConfig: CoreConfig) {
         self.init(
             coreConfig: coreConfig,
             apiClient: APIClient(coreConfig: coreConfig),
@@ -25,7 +25,7 @@ class EligibilityAPI {
 
     /// Checks merchants eligibility for different payment methods.
     /// - Returns: a result object with either eligibility or an error
-    public func checkEligibility() async throws -> Result<Eligibility, Error> {
+    func checkEligibility() async throws -> Result<Eligibility, Error> {
         let clientID = try await apiClient.getClientID()
         let fundingEligibilityQuery = FundingEligibilityQuery(
             clientID: clientID,


### PR DESCRIPTION
### Reason for changes
- Looks like we missed a few `public` annotations in[ this PR ](https://github.com/paypal/iOS-SDK/pull/75)


### Summary of changes

- Remove `public` annotations for internal `EligibilityAPI` class

### Checklist

- ~Added a changelog entry~

### Authors
@scannillo