### PR TITLE
Cleanup swiftlint.yml

### DIFF
--- a/.swiftlint.yml
+++ b/.swiftlint.yml
@@ -9,11 +9,7 @@ included:
   - UnitTests
  
 disabled_rules:
-  - discarded_notification_center_observer
-  - notification_center_detachment
-  - orphaned_doc_comment
   - todo
-  - unused_capture_list
   - type_name # tests will have have the format <SUT>_Tests
   - xctfail_message
 
@@ -108,8 +104,7 @@ private_over_fileprivate:
   validate_extensions: true
 
 trailing_whitespace:
-  ignores_empty_lines: false
-  ignores_comments: true
+  ignores_empty_lines: true
 
 vertical_whitespace:
   max_empty_lines: 2 

--- a/Sources/PaymentsCore/api/EligibilityAPI.swift
+++ b/Sources/PaymentsCore/api/EligibilityAPI.swift
@@ -9,7 +9,7 @@ class EligibilityAPI {
 
     /// Initialize the eligibility API to check for payment methods eligibility
     /// - Parameter coreConfig: configuration object
-    public convenience init(coreConfig: CoreConfig) {
+    convenience init(coreConfig: CoreConfig) {
         self.init(
             coreConfig: coreConfig,
             apiClient: APIClient(coreConfig: coreConfig),
@@ -25,7 +25,7 @@ class EligibilityAPI {
 
     /// Checks merchants eligibility for different payment methods.
     /// - Returns: a result object with either eligibility or an error
-    public func checkEligibility() async throws -> Result<Eligibility, Error> {
+    func checkEligibility() async throws -> Result<Eligibility, Error> {
         let clientID = try await apiClient.getClientID()
         let fundingEligibilityQuery = FundingEligibilityQuery(
             clientID: clientID,

--- a/Sources/PaymentsCore/api/EligibilityAPI.swift
+++ b/Sources/PaymentsCore/api/EligibilityAPI.swift
@@ -9,7 +9,7 @@ class EligibilityAPI {
 
     /// Initialize the eligibility API to check for payment methods eligibility
     /// - Parameter coreConfig: configuration object
-    convenience init(coreConfig: CoreConfig) {
+    public convenience init(coreConfig: CoreConfig) {
         self.init(
             coreConfig: coreConfig,
             apiClient: APIClient(coreConfig: coreConfig),
@@ -25,7 +25,7 @@ class EligibilityAPI {
 
     /// Checks merchants eligibility for different payment methods.
     /// - Returns: a result object with either eligibility or an error
-    func checkEligibility() async throws -> Result<Eligibility, Error> {
+    public func checkEligibility() async throws -> Result<Eligibility, Error> {
         let clientID = try await apiClient.getClientID()
         let fundingEligibilityQuery = FundingEligibilityQuery(
             clientID: clientID,


### PR DESCRIPTION
### Reason for changes
Is it just me, or is it really annoying that the default Xcode setting for auto-formatting (CTRL + i) causes trailing whitespace warnings for newlines with our linter?

We have two options here: set `ignores_empty_lines` to `true` in our swiftlint.yml, which will respect Xcode's default behavior of CTRL + i **OR** we leave the linter settings, and everyone updates their Xcode preferences by ticking the box for "_Include whitespace only lines_".

I would rather avoid manual steps for new devs Xcode setup, and just go with the Xcode default formatting implementation.

### Summary of changes

- Prefer Xcode auto formatting implementation for whitespace on newlines by setting `ignores_empty_lines` to `true`.
- Remove unneeded `disabled_rules`.

### Checklist

- ~Added a changelog entry~
