### PR TITLE
Fix Failing Code Cov CI

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -11,7 +11,7 @@ jobs:
       - name: Checkout repository
         uses: actions/checkout@v2
       - name: Use Xcode 13
-        run: sudo xcode-select -switch /Applications/Xcode_13.2.1.app
+        run: sudo xcode-select -switch /Applications/Xcode_14.0.app
       - name: Install Dependencies
         run: bundle install
       - name: Run Unit Tests
@@ -24,7 +24,7 @@ jobs:
       - name: Checkout repository
         uses: actions/checkout@v2
       - name: Use Xcode 13
-        run: sudo xcode-select -switch /Applications/Xcode_13.2.1.app
+        run: sudo xcode-select -switch /Applications/Xcode_14.0.app
       - name: Install Dependencies
         run: bundle install
       - name: Calculate Unit Test Code Coverage

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -11,7 +11,7 @@ jobs:
       - name: Checkout repository
         uses: actions/checkout@v2
       - name: Use Xcode 13
-        run: sudo xcode-select -switch /Applications/Xcode_14.0.app
+        run: sudo xcode-select -switch /Applications/Xcode_14.0.1.app
       - name: Install Dependencies
         run: bundle install
       - name: Run Unit Tests
@@ -24,7 +24,7 @@ jobs:
       - name: Checkout repository
         uses: actions/checkout@v2
       - name: Use Xcode 13
-        run: sudo xcode-select -switch /Applications/Xcode_14.0.app
+        run: sudo xcode-select -switch /Applications/Xcode_14.0.1.app
       - name: Install Dependencies
         run: bundle install
       - name: Calculate Unit Test Code Coverage

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -6,7 +6,7 @@ concurrency:
 jobs:
   unit_test_job:
     name: Unit
-    runs-on: macOS-latest
+    runs-on: macOS-12
     steps:
       - name: Checkout repository
         uses: actions/checkout@v2
@@ -19,7 +19,7 @@ jobs:
 
   code_coverage:
     name: Unit Test Coverage
-    runs-on: macOS-latest
+    runs-on: macOS-12
     steps:
       - name: Checkout repository
         uses: actions/checkout@v2

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -16,16 +16,3 @@ jobs:
         run: bundle install
       - name: Run Unit Tests
         run: bundle exec fastlane unit_tests
-
-  code_coverage:
-    name: Unit Test Coverage
-    runs-on: macOS-12
-    steps:
-      - name: Checkout repository
-        uses: actions/checkout@v2
-      - name: Use Xcode 13
-        run: sudo xcode-select -switch /Applications/Xcode_14.0.1.app
-      - name: Install Dependencies
-        run: bundle install
-      - name: Calculate Unit Test Code Coverage
-        run: bundle exec fastlane coverage

--- a/fastlane/Fastfile
+++ b/fastlane/Fastfile
@@ -27,6 +27,17 @@ platform :ios do
     # Ensure the code coverage directory is empty before creating new coverage
     sh("rm -rf coverage")
 
+    # Fetch NXO dep
+    sh("
+      set -o pipefail && xcodebuild \
+      -resolvePackageDependencies \
+      -workspace ../PayPal.xcworkspace \
+      -configuration 'Debug' \
+      -scheme UnitTests \
+      -destination 'name=iPhone 14,platform=iOS Simulator' \
+      test
+      ")
+
     # Use xcov to get the coverage percentages
     xcov(
       scheme: "Demo",

--- a/fastlane/Fastfile
+++ b/fastlane/Fastfile
@@ -4,8 +4,7 @@ default_platform(:ios)
 
 platform :ios do
 
-  desc "Runs the test target, which executes all the unit tests for each module
-  within the SDK"
+  desc "Runs UnitTests & code coverage check"
   lane :unit_tests do
     sh("
       set -o pipefail && xcodebuild \
@@ -16,13 +15,6 @@ platform :ios do
       -destination 'name=iPhone 14,platform=iOS Simulator' \
       test | xcpretty
       ")
-  end
-
-  desc "Runs the test suite and calculates code coverage percentages for each
-  module within the SDK"
-  lane :coverage do
-    # Run the test lane to get coverage profdata files
-    unit_tests
 
     # Ensure the code coverage directory is empty before creating new coverage
     sh("rm -rf coverage")
@@ -38,7 +30,7 @@ platform :ios do
       test
       ")
 
-    # Use xcov to get the coverage percentages
+    # Fails unit_tests job if coverage below minimum_coverage_percentage
     xcov(
       scheme: "Demo",
       workspace: "PayPal.xcworkspace",
@@ -46,51 +38,6 @@ platform :ios do
       minimum_coverage_percentage: 80.0
     )
   end
-
-  #   # Interpret JSON report and output relevant coverage data
-  #   UI.header "Coverage Data"
-  #   file = File.open "coverage/report.json"
-  #   data = JSON.load file
-
-  #   targets = data["targets"]
-
-  #   # Iterate through all of the targets. If any target is below our minimum
-  #   # coverage percentage, iterate through that target's files and output the
-  #   # coverage data of ones that are poorly tested
-  #   total_coverage_data = data["targets"].map {|target|
-  #     coverage = get_coverage(target, 0)
-
-  #     if coverage < MINIMUM_COVERAGE
-  #       filesForOutput = target["files"].each {|file|
-  #         file_coverage = get_coverage(file, 1)
-
-  #         if file_coverage < MINIMUM_COVERAGE
-  #           file["functions"].each {|function|
-  #             get_coverage(function, 2)
-  #           }
-  #         end
-  #       }
-  #     end
-  #     UI.message ""
-  #     coverage
-  #   }
-
-  #   #If the overall coverage percentage for any module is below our minimum threshhold, fail the test
-  #   if total_coverage_data.any? {|target_percent| target_percent < MINIMUM_COVERAGE }
-  #     UI.user_error!("Failure: All frameworks must have at least #{MINIMUM_COVERAGE}% code coverage")
-  #   end
-  # end
-
-  # desc "Get code coverage data from the input JSON dictionary, output it to the
-  # terminal, and return the coverge percentage"
-  # def get_coverage(hash, indent_count)
-  #   name = hash["name"]
-  #   coverage = hash["coverage"].to_f * 100
-  #   indentation = "\t" * indent_count
-  #   output = indentation + "#{name}: #{coverage}%"
-  #   coverage < MINIMUM_COVERAGE ? UI.error(output) : UI.success(output)
-  #   return coverage
-  # end
 
   desc "Runs SwiftLint and returns any errors if our linter rule aren't met"
   lane :lint do

--- a/fastlane/Fastfile
+++ b/fastlane/Fastfile
@@ -6,6 +6,9 @@ platform :ios do
 
   desc "Runs UnitTests & code coverage check"
   lane :unit_tests do
+    # Fetch NXO dep
+    sh("swift package resolve")
+
     sh("
       set -o pipefail && xcodebuild \
       -workspace '../PayPal.xcworkspace' \
@@ -18,9 +21,6 @@ platform :ios do
 
     # Ensure the code coverage directory is empty before creating new coverage
     sh("rm -rf coverage")
-
-    # Fetch NXO dep
-    sh("swift package resolve")
 
     # Fails unit_tests job if coverage below minimum_coverage_percentage
     xcov(

--- a/fastlane/Fastfile
+++ b/fastlane/Fastfile
@@ -20,15 +20,7 @@ platform :ios do
     sh("rm -rf coverage")
 
     # Fetch NXO dep
-    sh("
-      set -o pipefail && xcodebuild \
-      -resolvePackageDependencies \
-      -workspace ../PayPal.xcworkspace \
-      -configuration 'Debug' \
-      -scheme UnitTests \
-      -destination 'name=iPhone 14,platform=iOS Simulator' \
-      test
-      ")
+    sh("swift package resolve")
 
     # Fails unit_tests job if coverage below minimum_coverage_percentage
     xcov(

--- a/fastlane/Fastfile
+++ b/fastlane/Fastfile
@@ -6,9 +6,6 @@ platform :ios do
 
   desc "Runs UnitTests & code coverage check"
   lane :unit_tests do
-    # Fetch NXO dep
-    sh("swift package resolve")
-
     sh("
       set -o pipefail && xcodebuild \
       -workspace '../PayPal.xcworkspace' \
@@ -21,6 +18,9 @@ platform :ios do
 
     # Ensure the code coverage directory is empty before creating new coverage
     sh("rm -rf coverage")
+
+    # xcov command can't find PayPalCheckout SPM package unless additional resolve is performed
+    sh("swift package resolve")
 
     # Fails unit_tests job if coverage below minimum_coverage_percentage
     xcov(

--- a/fastlane/Fastfile
+++ b/fastlane/Fastfile
@@ -21,8 +21,6 @@ platform :ios do
   desc "Runs the test suite and calculates code coverage percentages for each
   module within the SDK"
   lane :coverage do
-    MINIMUM_COVERAGE = 80.0
-
     # Run the test lane to get coverage profdata files
     unit_tests
 
@@ -34,55 +32,54 @@ platform :ios do
       scheme: "Demo",
       workspace: "PayPal.xcworkspace",
       output_directory: "fastlane/coverage",
-      configuration: "Debug",
-      json_report: true,
-      ignore_file_path: "fastlane/.xcovignore",
+      minimum_coverage_percentage: 80.0
     )
-
-    # Interpret JSON report and output relevant coverage data
-    UI.header "Coverage Data"
-    file = File.open "coverage/report.json"
-    data = JSON.load file
-
-    targets = data["targets"]
-
-    # Iterate through all of the targets. If any target is below our minimum
-    # coverage percentage, iterate through that target's files and output the
-    # coverage data of ones that are poorly tested
-    total_coverage_data = data["targets"].map {|target|
-      coverage = get_coverage(target, 0)
-
-      if coverage < MINIMUM_COVERAGE
-        filesForOutput = target["files"].each {|file|
-          file_coverage = get_coverage(file, 1)
-
-          if file_coverage < MINIMUM_COVERAGE
-            file["functions"].each {|function|
-              get_coverage(function, 2)
-            }
-          end
-        }
-      end
-      UI.message ""
-      coverage
-    }
-
-    #If the overall coverage percentage for any module is below our minimum threshhold, fail the test
-    if total_coverage_data.any? {|target_percent| target_percent < MINIMUM_COVERAGE }
-      UI.user_error!("Failure: All frameworks must have at least #{MINIMUM_COVERAGE}% code coverage")
-    end
   end
 
-  desc "Get code coverage data from the input JSON dictionary, output it to the
-  terminal, and return the coverge percentage"
-  def get_coverage(hash, indent_count)
-    name = hash["name"]
-    coverage = hash["coverage"].to_f * 100
-    indentation = "\t" * indent_count
-    output = indentation + "#{name}: #{coverage}%"
-    coverage < MINIMUM_COVERAGE ? UI.error(output) : UI.success(output)
-    return coverage
-  end
+  #   # Interpret JSON report and output relevant coverage data
+  #   UI.header "Coverage Data"
+  #   file = File.open "coverage/report.json"
+  #   data = JSON.load file
+
+  #   targets = data["targets"]
+
+  #   # Iterate through all of the targets. If any target is below our minimum
+  #   # coverage percentage, iterate through that target's files and output the
+  #   # coverage data of ones that are poorly tested
+  #   total_coverage_data = data["targets"].map {|target|
+  #     coverage = get_coverage(target, 0)
+
+  #     if coverage < MINIMUM_COVERAGE
+  #       filesForOutput = target["files"].each {|file|
+  #         file_coverage = get_coverage(file, 1)
+
+  #         if file_coverage < MINIMUM_COVERAGE
+  #           file["functions"].each {|function|
+  #             get_coverage(function, 2)
+  #           }
+  #         end
+  #       }
+  #     end
+  #     UI.message ""
+  #     coverage
+  #   }
+
+  #   #If the overall coverage percentage for any module is below our minimum threshhold, fail the test
+  #   if total_coverage_data.any? {|target_percent| target_percent < MINIMUM_COVERAGE }
+  #     UI.user_error!("Failure: All frameworks must have at least #{MINIMUM_COVERAGE}% code coverage")
+  #   end
+  # end
+
+  # desc "Get code coverage data from the input JSON dictionary, output it to the
+  # terminal, and return the coverge percentage"
+  # def get_coverage(hash, indent_count)
+  #   name = hash["name"]
+  #   coverage = hash["coverage"].to_f * 100
+  #   indentation = "\t" * indent_count
+  #   output = indentation + "#{name}: #{coverage}%"
+  #   coverage < MINIMUM_COVERAGE ? UI.error(output) : UI.success(output)
+  #   return coverage
+  # end
 
   desc "Runs SwiftLint and returns any errors if our linter rule aren't met"
   lane :lint do

--- a/fastlane/Fastfile
+++ b/fastlane/Fastfile
@@ -13,7 +13,7 @@ platform :ios do
       -sdk 'iphonesimulator' \
       -configuration 'Debug' \
       -scheme 'UnitTests' \
-      -destination 'name=iPhone 12,platform=iOS Simulator' \
+      -destination 'name=iPhone 14,platform=iOS Simulator' \
       test | xcpretty
       ")
   end


### PR DESCRIPTION
### Reason for changes

After we enabled all test targets to run in the `UnitTest` scheme (PR #82), our code cov command was failing when referencing `PayPalCheckout`. See error:

```
❌  /Users/runner/work/iOS-SDK/iOS-SDK/UnitTests/PayPalNativeCheckoutTests/MockNativeCheckoutProvider.swift:4:18: could not build Objective-C module 'PayPalNativeCheckout'

@testable import PayPalNativeCheckout
``` 

### Summary of changes

- Bump Xcode and simulator version for tests.yml
- Add `swift package resolve` step before running codecov command
- Simplify codecov job
    - Remove creation of JSON coverage report. 
        - We were using this to parse coverage percentage _per file_. I don't think we've ever looked at this, and decided to remove it to simplify the fastfile.
    - Replace with using the [`xcov()`](https://docs.fastlane.tools/actions/xcov/) action out of the box from fastlane.
    - Combine `coverage` into `unit_tests` lane. Previously, we were running our unit_tests twice, which significantly slows down the build time.
### Checklist

- ~Added a changelog entry~

### Authors
@scannillo 
@mattwylder 