### PR TITLE
Added CHANGELOG entry for exposing PayPalNativeCheckout

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,10 @@
 
 # PayPal iOS SDK Release Notes
 
+## Unreleased
+* PayPalNativeCheckout
+    * Expose PayPalNative checkout through Swift Package Manager
+
 ## 0.0.2 (2022-11-03)
 * PayPalUI
     * Fix fatal crash with iOS 16: `UIViewRepresentables must be value types`. Separate buttons into `UIKit` and `SwiftUI` implementations.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,7 +1,7 @@
 
 # PayPal iOS SDK Release Notes
 
-## Unreleased
+## unreleased
 * PayPalNativeCheckout
     * Expose PayPalNative checkout through Swift Package Manager
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,7 +3,7 @@
 
 ## unreleased
 * PayPalNativeCheckout
-    * Expose PayPalNative checkout through Swift Package Manager
+    * Expose PayPalNativeCheckout through Swift Package Manager
 
 ## 0.0.2 (2022-11-03)
 * PayPalUI


### PR DESCRIPTION
### Reason for changes
PayPalNative Checkout is not visible in 0.0.2 through SPM. Adding ChangeLog Entry to add it in version 0.0.3


### Summary of changes

- Add Changelog entry

### Checklist

- [ ] Added a changelog entry

### Authors
> List GitHub usernames for everyone who contributed to this pull request.

- @jcnoriega 