### PR TITLE
Card: Add ApplicationContext to ConfirmPaymentSourceRequest

### DIFF
--- a/Demo/Demo/Models/CreateOrderParams.swift
+++ b/Demo/Demo/Models/CreateOrderParams.swift
@@ -2,7 +2,6 @@ struct CreateOrderParams: Codable {
 
     let intent: String
     var purchaseUnits: [PurchaseUnit]?
-    var applicationContext: ApplicationContext?
 }
 
 struct PurchaseUnit: Codable {
@@ -14,10 +13,4 @@ struct Amount: Codable {
 
     let currencyCode: String
     let value: String
-}
-
-struct ApplicationContext: Codable {
-
-    var returnUrl: String?
-    var cancelUrl: String?
 }

--- a/Demo/Demo/ViewModels/BaseViewModel.swift
+++ b/Demo/Demo/ViewModels/BaseViewModel.swift
@@ -57,8 +57,7 @@ class BaseViewModel: ObservableObject, PayPalWebCheckoutDelegate, CardDelegate {
         let amountRequest = Amount(currencyCode: "USD", value: amount)
         let orderRequestParams = CreateOrderParams(
             intent: DemoSettings.intent.rawValue.uppercased(),
-            purchaseUnits: [PurchaseUnit(amount: amountRequest)],
-            applicationContext: ApplicationContext(returnUrl: BaseViewModel.returnUrl, cancelUrl: BaseViewModel.cancelUrl)
+            purchaseUnits: [PurchaseUnit(amount: amountRequest)]
         )
 
         do {

--- a/Sources/Card/ConfirmPaymentSourceRequest.swift
+++ b/Sources/Card/ConfirmPaymentSourceRequest.swift
@@ -5,12 +5,12 @@ import PaymentsCore
 
 /// Describes request to confirm a payment source (approve an order)
 struct ConfirmPaymentSourceRequest: APIRequest {
-
+    
     private let orderID: String
     private let pathFormat: String = "/v2/checkout/orders/%@/confirm-payment-source"
     private let accessToken: String
     private let jsonEncoder = JSONEncoder()
-
+    
     /// Creates a request to attach a payment source to a specific order.
     /// In order to use this initializer, the `paymentSource` parameter has to
     /// contain the entire dictionary as it exists underneath the `payment_source` key.
@@ -18,37 +18,62 @@ struct ConfirmPaymentSourceRequest: APIRequest {
         accessToken: String,
         cardRequest: CardRequest
     ) throws {
+        var confirmPaymentSourceBody = ConfirmPaymentSourceBody()
         var card = cardRequest.card
         if let threeDSecureRequest = cardRequest.threeDSecureRequest {
             let verification = Verification(method: threeDSecureRequest.sca.rawValue)
             card.attributes = Attributes(verification: verification)
+            
+            let applicationContext = ApplicationContext(
+                returnUrl: threeDSecureRequest.returnUrl,
+                cancelUrl: threeDSecureRequest.cancelUrl
+            )
+            confirmPaymentSourceBody.applicationContext = applicationContext
         }
-        let paymentSource = [ "payment_source": [ "card": card ] ]
-
+        
+        confirmPaymentSourceBody.paymentSource = PaymentSource(card: card)
+        
         self.orderID = cardRequest.orderID
         self.accessToken = accessToken
-
+        
         path = String(format: pathFormat, orderID)
-
+        
         jsonEncoder.keyEncodingStrategy = .convertToSnakeCase
-        body = try jsonEncoder.encode(paymentSource)
+        body = try jsonEncoder.encode(confirmPaymentSourceBody)
         
         // TODO - The complexity in this `init` signals to reconsider our use/design of the `APIRequest` protocol.
         // Existing pattern doesn't provide clear, testable interface for encoding JSON POST bodies.
     }
-
+    
     // MARK: - APIRequest
-
+    
     typealias ResponseType = ConfirmPaymentSourceResponse
-
+    
     var path: String
     var method: HTTPMethod = .post
     var body: Data?
-
+    
     var headers: [HTTPHeader: String] {
         [
             .contentType: "application/json", .acceptLanguage: "en_US",
             .authorization: "Bearer \(accessToken)"
         ]
+    }
+    
+    private struct ConfirmPaymentSourceBody: Encodable {
+        
+        var paymentSource: PaymentSource?
+        var applicationContext: ApplicationContext?
+    }
+    
+    private struct ApplicationContext: Encodable {
+        
+        let returnUrl: String
+        let cancelUrl: String
+    }
+    
+    private struct PaymentSource: Encodable {
+        
+        let card: Card
     }
 }

--- a/Sources/Card/ConfirmPaymentSourceRequest.swift
+++ b/Sources/Card/ConfirmPaymentSourceRequest.swift
@@ -18,7 +18,7 @@ struct ConfirmPaymentSourceRequest: APIRequest {
         accessToken: String,
         cardRequest: CardRequest
     ) throws {
-        var confirmPaymentSourceBody = ConfirmPaymentSourceBody()
+        var confirmPaymentSource = ConfirmPaymentSource()
         var card = cardRequest.card
         if let threeDSecureRequest = cardRequest.threeDSecureRequest {
             let verification = Verification(method: threeDSecureRequest.sca.rawValue)
@@ -28,10 +28,10 @@ struct ConfirmPaymentSourceRequest: APIRequest {
                 returnUrl: threeDSecureRequest.returnUrl,
                 cancelUrl: threeDSecureRequest.cancelUrl
             )
-            confirmPaymentSourceBody.applicationContext = applicationContext
+            confirmPaymentSource.applicationContext = applicationContext
         }
         
-        confirmPaymentSourceBody.paymentSource = PaymentSource(card: card)
+        confirmPaymentSource.paymentSource = PaymentSource(card: card)
         
         self.orderID = cardRequest.orderID
         self.accessToken = accessToken
@@ -39,7 +39,7 @@ struct ConfirmPaymentSourceRequest: APIRequest {
         path = String(format: pathFormat, orderID)
         
         jsonEncoder.keyEncodingStrategy = .convertToSnakeCase
-        body = try jsonEncoder.encode(confirmPaymentSourceBody)
+        body = try jsonEncoder.encode(confirmPaymentSource)
         
         // TODO - The complexity in this `init` signals to reconsider our use/design of the `APIRequest` protocol.
         // Existing pattern doesn't provide clear, testable interface for encoding JSON POST bodies.
@@ -60,7 +60,7 @@ struct ConfirmPaymentSourceRequest: APIRequest {
         ]
     }
     
-    private struct ConfirmPaymentSourceBody: Encodable {
+    private struct ConfirmPaymentSource: Encodable {
         
         var paymentSource: PaymentSource?
         var applicationContext: ApplicationContext?

--- a/docs/Card/README.md
+++ b/docs/Card/README.md
@@ -144,8 +144,14 @@ Optionally, a merchant app can request Strong Consumer Authentication (SCA) for 
 To request SCA, add the following to `CardRequest`:
 
 ```swift
-cardRequest.threeDSecureRequest = ThreeDSecureRequest(sca: .always)
+cardRequest.threeDSecureRequest = ThreeDSecureRequest(
+    sca: .always,
+    returnUrl: "\(Bundle.main.bundleIdentifier)://return_url",
+    cancelUrl: "\(Bundle.main.bundleIdentifier)://cancel_url"
+)
 ```
+
+Where `return_url` and `cancel_url` are the urls configured in your [paypal developer dashboard](https://developer.paypal.com/)
 
 ### 6. Approve the order using Payments SDK
 


### PR DESCRIPTION
### Reason for changes

There was a bug in `ordersv2` where we had to add `appliction_context` to the order creation request, in order for 3DS to work. Now, we only have to add it in the `confirm_payment_source` request, removing it from order creation

Jira Ticket: https://engineering.paypalcorp.com/jira/browse/DTNOR-606

### Summary of changes

- Add Application context to ConfirmPaymentSourceRequestFactory

### Checklist

- [ ] Added a changelog entry

### Authors
> List GitHub usernames for everyone who contributed to this pull request.

- @jcnoriega 