### PR TITLE
Default analytics metadata strings to "N/A"

### DIFF
--- a/Sources/PaymentsCore/AnalyticsEventData.swift
+++ b/Sources/PaymentsCore/AnalyticsEventData.swift
@@ -29,9 +29,9 @@ struct AnalyticsEventData: Encodable {
         case tenantName = "tenant_name"
     }
     
-    let appID: String = Bundle.main.infoDictionary?[kCFBundleIdentifierKey as String] as? String ?? ""
+    let appID: String = Bundle.main.infoDictionary?[kCFBundleIdentifierKey as String] as? String ?? "N/A"
     
-    let appName: String = Bundle.main.infoDictionary?[kCFBundleNameKey as String] as? String ?? ""
+    let appName: String = Bundle.main.infoDictionary?[kCFBundleNameKey as String] as? String ?? "N/A"
 
     let clientSDKVersion = PayPalCoreConstants.payPalSDKVersion
 
@@ -63,7 +63,7 @@ struct AnalyticsEventData: Encodable {
         #endif
     }()
     
-    let merchantAppVersion: String = Bundle.main.infoDictionary?[kCFBundleVersionKey as String] as? String ?? ""
+    let merchantAppVersion: String = Bundle.main.infoDictionary?[kCFBundleVersionKey as String] as? String ?? "N/A"
 
     let deviceModel: String = {
         var systemInfo = utsname()


### PR DESCRIPTION
### Reason for changes

- Analytics metadata behavior should align as much as possible with Android

### Summary of changes

- Set default value for missing metadata strings to `"N/A"` instead of `""` empty string
- Matches implementation in PR https://github.com/paypal/Android-SDK/pull/104

### Checklist

- ~Added a changelog entry~

### Authors
@scannillo 