### PR TITLE
Remove unused correlationID from all API requests

### DIFF
--- a/Sources/Card/CardClient.swift
+++ b/Sources/Card/CardClient.swift
@@ -48,7 +48,7 @@ public class CardClient {
         Task {
             do {
                 let confirmPaymentRequest = try ConfirmPaymentSourceRequest(accessToken: config.accessToken, cardRequest: request)
-                let (result, _) = try await apiClient.fetch(endpoint: confirmPaymentRequest)
+                let (result) = try await apiClient.fetch(endpoint: confirmPaymentRequest)
                 if let url: String = result.links?.first(where: { $0.rel == "payer-action" })?.href {
                     delegate?.cardThreeDSecureWillLaunch(self)
                     startThreeDSecureChallenge(url: url, orderId: result.id, context: context, webAuthenticationSession: webAuthenticationSession)
@@ -98,7 +98,7 @@ public class CardClient {
         )
         Task {
             do {
-                let (result, _) = try await apiClient.fetch(endpoint: getOrderInfoRequest)
+                let (result) = try await apiClient.fetch(endpoint: getOrderInfoRequest)
                 let cardResult = CardResult(
                     orderID: result.id,
                     status: result.status,


### PR DESCRIPTION
### Reason for changes

- We are explicitly ignoring the `correlationID` returned on `APIClient.fetch` in every instance it is called. If we don't need it, let's get rid of it.

### Summary of changes

- Remove unused `correlationID`

### Questions

It looks like Android is using `correlationID` more heavily and returning it in merchant-facing errors ([example](https://github.com/paypal/Android-SDK/blob/e8f8aa29e07f1bf5600f8080c7d4046c69b825a0/Core/src/main/java/com/paypal/android/core/APIClientError.kt#L13)). We should align on if this is something we need.

### Checklist

- ~Added a changelog entry~

### Authors
@scannillo 