### PR TITLE
Remove `Bundle.main.bundleIdentifier` inspection for ASWeb flows

### DIFF
--- a/Demo/Demo/ViewModels/BaseViewModel.swift
+++ b/Demo/Demo/ViewModels/BaseViewModel.swift
@@ -10,19 +10,6 @@ import PayPalCheckout
 /// as well as share the logic of `processOrder` across our duplicate (SwiftUI and UIKit) card views.
 class BaseViewModel: ObservableObject, PayPalWebCheckoutDelegate, CardDelegate {
 
-    private static var returnUrl: String {
-        if let identifier = Bundle.main.bundleIdentifier {
-            return "\(identifier)://example.com/returnUrl"
-        }
-        return ""
-    }
-    private static var cancelUrl: String {
-        if let identifier = Bundle.main.bundleIdentifier {
-            return "\(identifier)://example.com/cancelUrl"
-        }
-        return ""
-    }
-
     /// Weak reference to associated view
     weak var view: FeatureBaseViewController?
     var payPalWebCheckoutClient: PayPalWebCheckoutClient?

--- a/PayPal.xcodeproj/project.pbxproj
+++ b/PayPal.xcodeproj/project.pbxproj
@@ -21,7 +21,7 @@
 		537804FD28760BE2006442BD /* EligibilityAPI_Tests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 537804FC28760BE2006442BD /* EligibilityAPI_Tests.swift */; };
 		53A2A4E228A182AC0093441C /* NativeCheckout.swift in Sources */ = {isa = PBXBuildFile; fileRef = 53A2A4E128A182AC0093441C /* NativeCheckout.swift */; };
 		80132D7229008C000088D30D /* TestShared.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 80E743F8270E40CE00BACECA /* TestShared.framework */; };
-		8021B69029144E6D000FBC54 /* PaymentsCoreConstants.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8021B68F29144E6D000FBC54 /* PaymentsCoreConstants.swift */; };
+		8021B69029144E6D000FBC54 /* PayPalCoreConstants.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8021B68F29144E6D000FBC54 /* PayPalCoreConstants.swift */; };
 		8034A9E726B875C90055AF13 /* PaymentsCore.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 80B9F85126B8750000D67843 /* PaymentsCore.framework */; };
 		8036C1E4270F9BE700C0F091 /* APIClient_Tests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8036C1E0270F9BE700C0F091 /* APIClient_Tests.swift */; };
 		8036C1E5270F9BE700C0F091 /* Environment_Tests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8036C1E1270F9BE700C0F091 /* Environment_Tests.swift */; };
@@ -222,7 +222,7 @@
 		5324C2D0283EB45A00DBC34F /* Eligibility.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Eligibility.swift; sourceTree = "<group>"; };
 		537804FC28760BE2006442BD /* EligibilityAPI_Tests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = EligibilityAPI_Tests.swift; sourceTree = "<group>"; };
 		53A2A4E128A182AC0093441C /* NativeCheckout.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NativeCheckout.swift; sourceTree = "<group>"; };
-		8021B68F29144E6D000FBC54 /* PaymentsCoreConstants.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PaymentsCoreConstants.swift; sourceTree = "<group>"; };
+		8021B68F29144E6D000FBC54 /* PayPalCoreConstants.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PayPalCoreConstants.swift; sourceTree = "<group>"; };
 		8034A9E326B875C90055AF13 /* PaymentsCoreTests.xctest */ = {isa = PBXFileReference; explicitFileType = wrapper.cfbundle; includeInIndex = 0; path = PaymentsCoreTests.xctest; sourceTree = BUILT_PRODUCTS_DIR; };
 		8036C1E0270F9BE700C0F091 /* APIClient_Tests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; name = APIClient_Tests.swift; path = UnitTests/PaymentsCoreTests/APIClient_Tests.swift; sourceTree = SOURCE_ROOT; };
 		8036C1E1270F9BE700C0F091 /* Environment_Tests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; name = Environment_Tests.swift; path = UnitTests/PaymentsCoreTests/Environment_Tests.swift; sourceTree = SOURCE_ROOT; };
@@ -563,7 +563,7 @@
 				E65D2D1A2898674700F94DFC /* GetClientIDResponse.swift */,
 				807C5E66291027D400ECECD8 /* AnalyticsEventRequest.swift */,
 				807C5E6829102D9800ECECD8 /* AnalyticsEventData.swift */,
-				8021B68F29144E6D000FBC54 /* PaymentsCoreConstants.swift */,
+				8021B68F29144E6D000FBC54 /* PayPalCoreConstants.swift */,
 			);
 			name = PaymentsCore;
 			path = Sources/PaymentsCore;
@@ -1375,7 +1375,7 @@
 				E6022E822857C6BE008B0E27 /* Error.swift in Sources */,
 				E6022E832857C6BE008B0E27 /* GraphQLQuery.swift in Sources */,
 				E6022E842857C6BE008B0E27 /* GraphQLClient.swift in Sources */,
-				8021B69029144E6D000FBC54 /* PaymentsCoreConstants.swift in Sources */,
+				8021B69029144E6D000FBC54 /* PayPalCoreConstants.swift in Sources */,
 				E65D2D1B2898674700F94DFC /* GetClientIDResponse.swift in Sources */,
 				06CE009926F3D1660000CC46 /* CoreConfig.swift in Sources */,
 				BEA100EC26EFA7790036A6A5 /* HTTPMethod.swift in Sources */,

--- a/Sources/Card/ConfirmPaymentSourceRequest.swift
+++ b/Sources/Card/ConfirmPaymentSourceRequest.swift
@@ -23,11 +23,10 @@ struct ConfirmPaymentSourceRequest: APIRequest {
         let verification = Verification(method: cardRequest.sca.rawValue)
         card.attributes = Attributes(verification: verification)
             
-        let applicationContext = ApplicationContext(
-            returnUrl: cardRequest.returnUrl,
-            cancelUrl: cardRequest.cancelUrl
+        confirmPaymentSource.applicationContext = ApplicationContext(
+            returnUrl: PayPalCoreConstants.callbackURLScheme + "://card/success",
+            cancelUrl: PayPalCoreConstants.callbackURLScheme + "://card/cancel"
         )
-        confirmPaymentSource.applicationContext = applicationContext
         
         confirmPaymentSource.paymentSource = PaymentSource(card: card)
         

--- a/Sources/Card/Models/CardRequest.swift
+++ b/Sources/Card/Models/CardRequest.swift
@@ -11,9 +11,6 @@ public struct CardRequest {
     /// 3DS authentication launch option
     public let sca: SCA
     
-    let returnUrl: String
-    let cancelUrl: String
-    
     /// Creates an instance of a card request
     /// - Parameters:
     ///    - orderID: The order to be approved
@@ -23,10 +20,5 @@ public struct CardRequest {
         self.orderID = orderID
         self.card = card
         self.sca = sca
-        
-        let bundleID = Bundle.main.bundleIdentifier ?? ""
-        
-        self.returnUrl = "\(bundleID)://card/success"
-        self.cancelUrl = "\(bundleID)://card/cancel"
     }
 }

--- a/Sources/PayPalWebCheckout/PayPalWebCheckoutClient.swift
+++ b/Sources/PayPalWebCheckout/PayPalWebCheckoutClient.swift
@@ -71,7 +71,7 @@ public class PayPalWebCheckoutClient {
     }
 
     func payPalCheckoutReturnURL(payPalCheckoutURL: URL) -> URL? {
-        guard let bundleID = Bundle.main.bundleIdentifier else { return nil }
+        let bundleID = PayPalCoreConstants.callbackURLScheme
         let redirectURLString = "\(bundleID)://x-callback-url/paypal-sdk/paypal-checkout"
         let redirectQueryItem = URLQueryItem(name: "redirect_uri", value: redirectURLString)
         let nativeXOQueryItem = URLQueryItem(name: "native_xo", value: "1")

--- a/Sources/PaymentsCore/PayPalCoreConstants.swift
+++ b/Sources/PaymentsCore/PayPalCoreConstants.swift
@@ -1,7 +1,9 @@
 /// :nodoc: This class is exposed for internal PayPal use only. Do not use. It is not covered by Semantic Versioning and may change or be removed at any time.
-enum PayPalCoreConstants {
+public enum PayPalCoreConstants {
     
     // TODO: - Update release script to update this version #
     /// :nodoc: This property is exposed for internal PayPal use only. Do not use. It is not covered by Semantic Versioning and may change or be removed at any time.
     public static let payPalSDKVersion: String = "0.0.3"
+    
+    public static let callbackURLScheme: String = "sdk.ios.paypal"
 }

--- a/Sources/PaymentsCore/WebAuthenticationSession.swift
+++ b/Sources/PaymentsCore/WebAuthenticationSession.swift
@@ -10,7 +10,7 @@ public class WebAuthenticationSession: NSObject {
     ) {
         let authenticationSession = ASWebAuthenticationSession(
             url: url,
-            callbackURLScheme: Bundle.main.bundleIdentifier,
+            callbackURLScheme: PayPalCoreConstants.callbackURLScheme,
             completionHandler: completion
         )
 

--- a/UnitTests/CardTests/ConfirmPaymentSourceRequest_Tests.swift
+++ b/UnitTests/CardTests/ConfirmPaymentSourceRequest_Tests.swift
@@ -13,7 +13,6 @@ class ConfirmPaymentSourceRequest_Tests: XCTestCase {
             expirationYear: "2024",
             securityCode: "222"
         )
-        let bundleID = Bundle.main.bundleIdentifier ?? ""
         let cardRequest = CardRequest(orderID: mockOrderID, card: card)
 
         let confirmPaymentSourceRequest = try XCTUnwrap(
@@ -25,8 +24,8 @@ class ConfirmPaymentSourceRequest_Tests: XCTestCase {
             let expectedPaymentSourceBodyString = """
                 {
                     "application_context": {
-                        "return_url": "\(bundleID):\\/\\/card\\/success",
-                        "cancel_url": "\(bundleID):\\/\\/card\\/cancel"
+                        "return_url": "sdk.ios.paypal:\\/\\/card\\/success",
+                        "cancel_url": "sdk.ios.paypal:\\/\\/card\\/cancel"
                     },
                     "payment_source": {
                         "card": {

--- a/UnitTests/PayPalWebCheckoutTests/PayPalWebCheckoutClient_Tests.swift
+++ b/UnitTests/PayPalWebCheckoutTests/PayPalWebCheckoutClient_Tests.swift
@@ -89,7 +89,7 @@ class PayPalClient_Tests: XCTestCase {
 
         XCTAssertEqual(
             checkoutURL,
-            URL(string: "https://sandbox.paypal.com/checkoutnow?token=1234&redirect_uri=com.apple.dt.xctest.tool://x-callback-url/paypal-sdk/paypal-checkout&native_xo=1")
+            URL(string: "https://sandbox.paypal.com/checkoutnow?token=1234&redirect_uri=sdk.ios.paypal://x-callback-url/paypal-sdk/paypal-checkout&native_xo=1")
         )
     }
 }


### PR DESCRIPTION
### Reason for changes

- We don't need to access the app's Bundle.main.bundleIdentifier for ASWebAuthenticationSession flows 🎉
- See [similar PR ](https://github.com/braintree/braintree_ios/pull/900)on Braintree SEPA

### Summary of changes

- Add an SDK specific URL scheme to the `PayPalCoreConstants` enum
- Renamed `PayPalCoreConstants` file to match its enum name
- Replace `Bundle.main.bundleIdentifier` inspection with custom URL scheme
- Update tests

### Testing
- I manually tested both the Cards 3DS and PayPalWebCheckout flows to work as expected. Feel free to pull this down and check on your machine, as well!

### Checklist

- ~Added a changelog entry~

### Authors
@scannillo