### PR TITLE
remove return url in docs

### DIFF
--- a/docs/PayPalNativeCheckout/README.md
+++ b/docs/PayPalNativeCheckout/README.md
@@ -182,15 +182,6 @@ curl --location --request POST 'https://api.sandbox.paypal.com/v2/checkout/order
   "plan":
   {
     "type": "MERCHANT_INITIATED_BILLING",
-    "merchant_preferences":
-    {
-      "return_url": "https://example.com/return",
-      "cancel_url": "https://example.com/cancel",
-      "notify_url": "https://example.com/notify",
-      "accepted_pymt_type": "INSTANT",
-      "skip_shipping_address": false,
-      "immutable_shipping_address": true
-    }
   }
 }'
 ```


### PR DESCRIPTION
### Reason for changes

Return url is not needed in order request for creating billing agreement order, removing it from docs

### Summary of changes

- 

### Checklist

- [ ] Added a changelog entry

### Authors
> List GitHub usernames for everyone who contributed to this pull request.

- @kgangineni 