### PR TITLE
Remove merchant `ASWebAuthenticationPresentationContextProviding` step

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,9 +2,12 @@
 # PayPal iOS SDK Release Notes
 
 ## unreleased
-* `Card`:
+* Card:
   * Remove `ThreeDSecureRequest` from `CardRequest` and create URLs internally 
   * Update `CardRequest` to optionally pass `sca`
+  * Remove step requiring `ASWebAuthenticationPresentationContextProviding` conformance
+* PayPalWebCheckout
+  * Remove step requiring `ASWebAuthenticationPresentationContextProviding` conformance
 
 ## 0.0.3 (2022-11-03)
 * PayPalNativeCheckout

--- a/Demo/Demo/ViewModels/BaseViewModel.swift
+++ b/Demo/Demo/ViewModels/BaseViewModel.swift
@@ -111,7 +111,7 @@ class BaseViewModel: ObservableObject, PayPalWebCheckoutDelegate, CardDelegate {
         let cardClient = CardClient(config: config)
         cardClient.delegate = self
         let cardRequest = CardRequest(orderID: orderID, card: card, sca: .scaAlways)
-        cardClient.approveOrder(request: cardRequest, context: context)
+        cardClient.approveOrder(request: cardRequest)
     }
 
     func isCardFormValid(cardNumber: String, expirationDate: String, cvv: String) -> Bool {

--- a/Demo/Demo/ViewModels/BaseViewModel.swift
+++ b/Demo/Demo/ViewModels/BaseViewModel.swift
@@ -162,7 +162,7 @@ class BaseViewModel: ObservableObject, PayPalWebCheckoutDelegate, CardDelegate {
                     return
                 }
                 let payPalRequest = PayPalWebCheckoutRequest(orderID: orderID, fundingSource: funding)
-                client.start(request: payPalRequest, context: context)
+                client.start(request: payPalRequest)
             } catch {
                 print("Error in starting paypal webcheckout client")
             }

--- a/Sources/Card/CardClient.swift
+++ b/Sources/Card/CardClient.swift
@@ -35,13 +35,6 @@ public class CardClient: NSObject {
     /// - Returns: Card result
     /// - Throws: PayPalSDK error if approve order could not complete successfully
     public func approveOrder(request: CardRequest) {
-        start(request: request)
-    }
-
-    /// Internal function for testing
-    func start(
-        request: CardRequest
-    ) {
         Task {
             do {
                 let confirmPaymentRequest = try ConfirmPaymentSourceRequest(accessToken: config.accessToken, cardRequest: request)

--- a/Sources/Card/CardClient.swift
+++ b/Sources/Card/CardClient.swift
@@ -4,20 +4,7 @@ import AuthenticationServices
 import PaymentsCore
 #endif
 
-public class CardClient: NSObject, ASWebAuthenticationPresentationContextProviding {
-    
-    // MARK: - ASWebAuthenticationPresentationContextProviding conformance
-
-    public func presentationAnchor(for session: ASWebAuthenticationSession) -> ASPresentationAnchor {
-        if #available(iOS 15, *) {
-            let firstScene = UIApplication.shared.connectedScenes.first as? UIWindowScene
-            let window = firstScene?.windows.first { $0.isKeyWindow }
-            return window ?? ASPresentationAnchor()
-        } else {
-            let window = UIApplication.shared.windows.first { $0.isKeyWindow }
-            return window ?? ASPresentationAnchor()
-        }
-    }
+public class CardClient: NSObject {
 
     public weak var delegate: CardDelegate?
 
@@ -129,5 +116,21 @@ public class CardClient: NSObject, ASWebAuthenticationPresentationContextProvidi
 
     private func notifyCancellation() {
         delegate?.cardDidCancel(self)
+    }
+}
+
+// MARK: - ASWebAuthenticationPresentationContextProviding conformance
+
+extension CardClient: ASWebAuthenticationPresentationContextProviding {
+
+    public func presentationAnchor(for session: ASWebAuthenticationSession) -> ASPresentationAnchor {
+        if #available(iOS 15, *) {
+            let firstScene = UIApplication.shared.connectedScenes.first as? UIWindowScene
+            let window = firstScene?.windows.first { $0.isKeyWindow }
+            return window ?? ASPresentationAnchor()
+        } else {
+            let window = UIApplication.shared.windows.first { $0.isKeyWindow }
+            return window ?? ASPresentationAnchor()
+        }
     }
 }

--- a/Sources/Card/CardClient.swift
+++ b/Sources/Card/CardClient.swift
@@ -4,24 +4,40 @@ import AuthenticationServices
 import PaymentsCore
 #endif
 
-public class CardClient {
+public class CardClient: NSObject, ASWebAuthenticationPresentationContextProviding {
+    
+    // MARK: - ASWebAuthenticationPresentationContextProviding conformance
+
+    public func presentationAnchor(for session: ASWebAuthenticationSession) -> ASPresentationAnchor {
+        if #available(iOS 15, *) {
+            let firstScene = UIApplication.shared.connectedScenes.first as? UIWindowScene
+            let window = firstScene?.windows.first { $0.isKeyWindow }
+            return window ?? ASPresentationAnchor()
+        } else {
+            let window = UIApplication.shared.windows.first { $0.isKeyWindow }
+            return window ?? ASPresentationAnchor()
+        }
+    }
 
     public weak var delegate: CardDelegate?
 
     private let apiClient: APIClient
     private let config: CoreConfig
+    private let webAuthenticationSession: WebAuthenticationSession
 
     /// Initialize a CardClient to process card payment
     /// - Parameter config: The CoreConfig object
     public init(config: CoreConfig) {
         self.config = config
         self.apiClient = APIClient(coreConfig: config)
+        self.webAuthenticationSession = WebAuthenticationSession()
     }
 
     /// For internal use for testing/mocking purpose
-    init(config: CoreConfig, apiClient: APIClient) {
+    init(config: CoreConfig, apiClient: APIClient, webAuthenticationSession: WebAuthenticationSession) {
         self.config = config
         self.apiClient = apiClient
+        self.webAuthenticationSession = webAuthenticationSession
     }
 
     /// Approve an order with a card, which validates buyer's card, and if valid, attaches the card as the payment source to the order.
@@ -29,21 +45,15 @@ public class CardClient {
     /// - Parameters:
     ///   - orderId: Order id for approval
     ///   - request: The request containing the card
-    ///   - context: The ASWebAuthenticationPresentationContextProviding protocol conforming ViewController
     /// - Returns: Card result
     /// - Throws: PayPalSDK error if approve order could not complete successfully
-    public func approveOrder(
-        request: CardRequest,
-        context: ASWebAuthenticationPresentationContextProviding
-    ) {
-        start(request: request, context: context, webAuthenticationSession: WebAuthenticationSession())
+    public func approveOrder(request: CardRequest) {
+        start(request: request)
     }
 
     /// Internal function for testing
     func start(
-        request: CardRequest,
-        context: ASWebAuthenticationPresentationContextProviding,
-        webAuthenticationSession: WebAuthenticationSession
+        request: CardRequest
     ) {
         Task {
             do {
@@ -51,7 +61,7 @@ public class CardClient {
                 let (result) = try await apiClient.fetch(request: confirmPaymentRequest)
                 if let url: String = result.links?.first(where: { $0.rel == "payer-action" })?.href {
                     delegate?.cardThreeDSecureWillLaunch(self)
-                    startThreeDSecureChallenge(url: url, orderId: result.id, context: context, webAuthenticationSession: webAuthenticationSession)
+                    startThreeDSecureChallenge(url: url, orderId: result.id)
                 } else {
                     let cardResult = CardResult(
                         orderID: result.id,
@@ -69,12 +79,10 @@ public class CardClient {
 
     private func startThreeDSecureChallenge(
         url: String,
-        orderId: String,
-        context: ASWebAuthenticationPresentationContextProviding,
-        webAuthenticationSession: WebAuthenticationSession
+        orderId: String
     ) {
         if let threeDSUrl = URL(string: url) {
-            webAuthenticationSession.start(url: threeDSUrl, context: context) { _, error in
+            webAuthenticationSession.start(url: threeDSUrl, context: self) { _, error in
                 self.delegate?.cardThreeDSecureDidFinish(self)
                 if let error = error {
                     switch error {

--- a/Sources/Card/CardClient.swift
+++ b/Sources/Card/CardClient.swift
@@ -116,6 +116,8 @@ public class CardClient: NSObject {
 
 extension CardClient: ASWebAuthenticationPresentationContextProviding {
 
+    // TODO: - Allow merchant to optionally set active UIWindow for multi-tasking.
+    // DTNOR-749
     public func presentationAnchor(for session: ASWebAuthenticationSession) -> ASPresentationAnchor {
         if #available(iOS 15, *) {
             let firstScene = UIApplication.shared.connectedScenes.first as? UIWindowScene

--- a/Sources/Card/CardClient.swift
+++ b/Sources/Card/CardClient.swift
@@ -116,8 +116,6 @@ public class CardClient: NSObject {
 
 extension CardClient: ASWebAuthenticationPresentationContextProviding {
 
-    // TODO: - Allow merchant to optionally set active UIWindow for multi-tasking.
-    // DTNOR-749
     public func presentationAnchor(for session: ASWebAuthenticationSession) -> ASPresentationAnchor {
         if #available(iOS 15, *) {
             let firstScene = UIApplication.shared.connectedScenes.first as? UIWindowScene

--- a/Sources/PayPalWebCheckout/PayPalWebCheckoutClient.swift
+++ b/Sources/PayPalWebCheckout/PayPalWebCheckoutClient.swift
@@ -27,7 +27,6 @@ public class PayPalWebCheckoutClient: NSObject {
     /// Launch the PayPal web flow
     /// - Parameters:
     ///   - request: the PayPalRequest for the transaction
-    ///   - context: the ASWebAuthenticationPresentationContextProviding protocol conforming ViewController
     public func start(request: PayPalWebCheckoutRequest) {
         let baseURLString = config.environment.payPalBaseURL.absoluteString
         let payPalCheckoutURLString =
@@ -102,6 +101,8 @@ public class PayPalWebCheckoutClient: NSObject {
 
 extension PayPalWebCheckoutClient: ASWebAuthenticationPresentationContextProviding {
     
+    // TODO: - Allow merchant to optionally set active UIWindow for multi-tasking.
+    // DTNOR-749
     public func presentationAnchor(for session: ASWebAuthenticationSession) -> ASPresentationAnchor {
         if #available(iOS 15, *) {
             let firstScene = UIApplication.shared.connectedScenes.first as? UIWindowScene

--- a/Sources/PayPalWebCheckout/PayPalWebCheckoutClient.swift
+++ b/Sources/PayPalWebCheckout/PayPalWebCheckoutClient.swift
@@ -4,7 +4,20 @@ import AuthenticationServices
 import PaymentsCore
 #endif
 
-public class PayPalWebCheckoutClient {
+public class PayPalWebCheckoutClient: NSObject, ASWebAuthenticationPresentationContextProviding {
+    
+    // MARK: - ASWebAuthenticationPresentationContextProviding conformance
+
+    public func presentationAnchor(for session: ASWebAuthenticationSession) -> ASPresentationAnchor {
+        if #available(iOS 15, *) {
+            let firstScene = UIApplication.shared.connectedScenes.first as? UIWindowScene
+            let window = firstScene?.windows.first { $0.isKeyWindow }
+            return window ?? ASPresentationAnchor()
+        } else {
+            let window = UIApplication.shared.windows.first { $0.isKeyWindow }
+            return window ?? ASPresentationAnchor()
+        }
+    }
 
     public weak var delegate: PayPalWebCheckoutDelegate?
     let config: CoreConfig
@@ -24,7 +37,7 @@ public class PayPalWebCheckoutClient {
         request: PayPalWebCheckoutRequest,
         context: ASWebAuthenticationPresentationContextProviding
     ) {
-        start(request: request, context: context, webAuthenticationSession: WebAuthenticationSession())
+        start(request: request, context: self, webAuthenticationSession: WebAuthenticationSession())
     }
 
     /// Internal function for testing the start function

--- a/Sources/PayPalWebCheckout/PayPalWebCheckoutClient.swift
+++ b/Sources/PayPalWebCheckout/PayPalWebCheckoutClient.swift
@@ -101,8 +101,6 @@ public class PayPalWebCheckoutClient: NSObject {
 
 extension PayPalWebCheckoutClient: ASWebAuthenticationPresentationContextProviding {
     
-    // TODO: - Allow merchant to optionally set active UIWindow for multi-tasking.
-    // DTNOR-749
     public func presentationAnchor(for session: ASWebAuthenticationSession) -> ASPresentationAnchor {
         if #available(iOS 15, *) {
             let firstScene = UIApplication.shared.connectedScenes.first as? UIWindowScene

--- a/Sources/PayPalWebCheckout/PayPalWebCheckoutClient.swift
+++ b/Sources/PayPalWebCheckout/PayPalWebCheckoutClient.swift
@@ -8,31 +8,27 @@ public class PayPalWebCheckoutClient: NSObject {
 
     public weak var delegate: PayPalWebCheckoutDelegate?
     let config: CoreConfig
+    private let webAuthenticationSession: WebAuthenticationSession
 
     /// Initialize a PayPalNativeCheckoutClient to process PayPal transaction
     /// - Parameters:
     ///   - config: The CoreConfig object
     public init(config: CoreConfig) {
         self.config = config
+        self.webAuthenticationSession = WebAuthenticationSession()
+    }
+    
+    /// For internal use for testing/mocking purpose
+    init(config: CoreConfig, webAuthenticationSession: WebAuthenticationSession) {
+        self.config = config
+        self.webAuthenticationSession = webAuthenticationSession
     }
 
     /// Launch the PayPal web flow
     /// - Parameters:
     ///   - request: the PayPalRequest for the transaction
     ///   - context: the ASWebAuthenticationPresentationContextProviding protocol conforming ViewController
-    public func start(
-        request: PayPalWebCheckoutRequest,
-        context: ASWebAuthenticationPresentationContextProviding
-    ) {
-        start(request: request, context: self, webAuthenticationSession: WebAuthenticationSession())
-    }
-
-    /// Internal function for testing the start function
-    func start(
-        request: PayPalWebCheckoutRequest,
-        context: ASWebAuthenticationPresentationContextProviding,
-        webAuthenticationSession: WebAuthenticationSession
-    ) {
+    public func start(request: PayPalWebCheckoutRequest) {
         let baseURLString = config.environment.payPalBaseURL.absoluteString
         let payPalCheckoutURLString =
             "\(baseURLString)/checkoutnow?token=\(request.orderID)" +
@@ -45,7 +41,7 @@ public class PayPalWebCheckoutClient: NSObject {
             return
         }
 
-        webAuthenticationSession.start(url: payPalCheckoutURLComponents, context: context) { url, error in
+        webAuthenticationSession.start(url: payPalCheckoutURLComponents, context: self) { url, error in
             if let error = error {
                 switch error {
                 case ASWebAuthenticationSessionError.canceledLogin:

--- a/Sources/PayPalWebCheckout/PayPalWebCheckoutClient.swift
+++ b/Sources/PayPalWebCheckout/PayPalWebCheckoutClient.swift
@@ -4,20 +4,7 @@ import AuthenticationServices
 import PaymentsCore
 #endif
 
-public class PayPalWebCheckoutClient: NSObject, ASWebAuthenticationPresentationContextProviding {
-    
-    // MARK: - ASWebAuthenticationPresentationContextProviding conformance
-
-    public func presentationAnchor(for session: ASWebAuthenticationSession) -> ASPresentationAnchor {
-        if #available(iOS 15, *) {
-            let firstScene = UIApplication.shared.connectedScenes.first as? UIWindowScene
-            let window = firstScene?.windows.first { $0.isKeyWindow }
-            return window ?? ASPresentationAnchor()
-        } else {
-            let window = UIApplication.shared.windows.first { $0.isKeyWindow }
-            return window ?? ASPresentationAnchor()
-        }
-    }
+public class PayPalWebCheckoutClient: NSObject {
 
     public weak var delegate: PayPalWebCheckoutDelegate?
     let config: CoreConfig
@@ -112,5 +99,21 @@ public class PayPalWebCheckoutClient: NSObject, ASWebAuthenticationPresentationC
 
     private func notifyCancellation() {
         delegate?.payPalDidCancel(self)
+    }
+}
+
+// MARK: - ASWebAuthenticationPresentationContextProviding conformance
+
+extension PayPalWebCheckoutClient: ASWebAuthenticationPresentationContextProviding {
+    
+    public func presentationAnchor(for session: ASWebAuthenticationSession) -> ASPresentationAnchor {
+        if #available(iOS 15, *) {
+            let firstScene = UIApplication.shared.connectedScenes.first as? UIWindowScene
+            let window = firstScene?.windows.first { $0.isKeyWindow }
+            return window ?? ASPresentationAnchor()
+        } else {
+            let window = UIApplication.shared.windows.first { $0.isKeyWindow }
+            return window ?? ASPresentationAnchor()
+        }
     }
 }

--- a/Sources/PaymentsCore/WebAuthenticationSession.swift
+++ b/Sources/PaymentsCore/WebAuthenticationSession.swift
@@ -17,6 +17,8 @@ public class WebAuthenticationSession: NSObject {
         authenticationSession.prefersEphemeralWebBrowserSession = true
         authenticationSession.presentationContextProvider = context
 
-        authenticationSession.start()
+        DispatchQueue.main.async {
+            authenticationSession.start()
+        }
     }
 }

--- a/UnitTests/CardTests/CardClient_Tests.swift
+++ b/UnitTests/CardTests/CardClient_Tests.swift
@@ -76,7 +76,7 @@ class CardClient_Tests: XCTestCase {
 
             cardClient.delegate = mockCardDelegate
 
-            cardClient.start(request: cardRequest)
+            cardClient.approveOrder(request: cardRequest)
 
             waitForExpectations(timeout: 10)
         } else {
@@ -111,7 +111,7 @@ class CardClient_Tests: XCTestCase {
 
             cardClient.delegate = mockCardDelegate
 
-            cardClient.start(request: cardRequest)
+            cardClient.approveOrder(request: cardRequest)
             
             waitForExpectations(timeout: 10)
         } else {
@@ -158,7 +158,7 @@ class CardClient_Tests: XCTestCase {
 
             cardClient.delegate = mockCardDelegate
 
-            cardClient.start(request: cardRequest)
+            cardClient.approveOrder(request: cardRequest)
 
             waitForExpectations(timeout: 10)
         } else {
@@ -204,7 +204,7 @@ class CardClient_Tests: XCTestCase {
 
             cardClient.delegate = mockCardDelegate
 
-            cardClient.start(request: cardRequest)
+            cardClient.approveOrder(request: cardRequest)
 
             waitForExpectations(timeout: 10)
         } else {
@@ -250,7 +250,7 @@ class CardClient_Tests: XCTestCase {
 
             cardClient.delegate = mockCardDelegate
 
-            cardClient.start(request: cardRequest)
+            cardClient.approveOrder(request: cardRequest)
 
             waitForExpectations(timeout: 10)
         } else {

--- a/UnitTests/CardTests/CardClient_Tests.swift
+++ b/UnitTests/CardTests/CardClient_Tests.swift
@@ -24,6 +24,7 @@ class CardClient_Tests: XCTestCase {
     // swiftlint:disable implicitly_unwrapped_optional
     var config: CoreConfig!
     var mockURLSession: MockQuededURLSession!
+    var mockWebAuthSession: MockWebAuthenticationSession!
     var apiClient: APIClient!
     var cardClient: CardClient!
     // swiftlint:enable implicitly_unwrapped_optional
@@ -34,9 +35,14 @@ class CardClient_Tests: XCTestCase {
         super.setUp()
         config = CoreConfig(accessToken: mockAccessToken, environment: .sandbox)
         mockURLSession = MockQuededURLSession()
+        mockWebAuthSession = MockWebAuthenticationSession()
 
         apiClient = APIClient(urlSession: mockURLSession, coreConfig: config)
-        cardClient = CardClient(config: config, apiClient: apiClient)
+        cardClient = CardClient(
+            config: config,
+            apiClient: apiClient,
+            webAuthenticationSession: mockWebAuthSession
+        )
     }
 
     override func tearDown() {
@@ -70,11 +76,7 @@ class CardClient_Tests: XCTestCase {
 
             cardClient.delegate = mockCardDelegate
 
-            cardClient.start(
-                request: cardRequest,
-                context: MockViewController(),
-                webAuthenticationSession: MockWebAuthenticationSession()
-            )
+            cardClient.start(request: cardRequest)
 
             waitForExpectations(timeout: 10)
         } else {
@@ -109,11 +111,8 @@ class CardClient_Tests: XCTestCase {
 
             cardClient.delegate = mockCardDelegate
 
-            cardClient.start(
-                request: cardRequest,
-                context: MockViewController(),
-                webAuthenticationSession: MockWebAuthenticationSession()
-            )
+            cardClient.start(request: cardRequest)
+            
             waitForExpectations(timeout: 10)
         } else {
             XCTFail("Data json cannot be null")
@@ -159,11 +158,7 @@ class CardClient_Tests: XCTestCase {
 
             cardClient.delegate = mockCardDelegate
 
-            cardClient.start(
-                request: cardRequest,
-                context: MockViewController(),
-                webAuthenticationSession: MockWebAuthenticationSession()
-            )
+            cardClient.start(request: cardRequest)
 
             waitForExpectations(timeout: 10)
         } else {
@@ -179,7 +174,6 @@ class CardClient_Tests: XCTestCase {
 
             mockURLSession.addResponse(mockConfirmResponse)
 
-            let mockWebAuthSession = MockWebAuthenticationSession()
             mockWebAuthSession.cannedErrorResponse = ASWebAuthenticationSessionError(
                 _bridgedNSError: NSError(
                     domain: ASWebAuthenticationSessionError.errorDomain,
@@ -210,11 +204,7 @@ class CardClient_Tests: XCTestCase {
 
             cardClient.delegate = mockCardDelegate
 
-            cardClient.start(
-                request: cardRequest,
-                context: MockViewController(),
-                webAuthenticationSession: mockWebAuthSession
-            )
+            cardClient.start(request: cardRequest)
 
             waitForExpectations(timeout: 10)
         } else {
@@ -230,7 +220,6 @@ class CardClient_Tests: XCTestCase {
 
             mockURLSession.addResponse(mockConfirmResponse)
 
-            let mockWebAuthSession = MockWebAuthenticationSession()
             mockWebAuthSession.cannedErrorResponse = CoreSDKError(
                 code: CardClientError.Code.threeDSecureError.rawValue,
                 domain: CardClientError.domain,
@@ -261,11 +250,7 @@ class CardClient_Tests: XCTestCase {
 
             cardClient.delegate = mockCardDelegate
 
-            cardClient.start(
-                request: cardRequest,
-                context: MockViewController(),
-                webAuthenticationSession: mockWebAuthSession
-            )
+            cardClient.start(request: cardRequest)
 
             waitForExpectations(timeout: 10)
         } else {

--- a/docs/Card/README.md
+++ b/docs/Card/README.md
@@ -44,28 +44,7 @@ In your app's source files, use the following import syntax to include PayPal's 
 import Card
 ```
 
-### 2. Configure your application to present an authentication session
-
-The Card module uses an [ASWebAuthenticationSession](https://developer.apple.com/documentation/authenticationservices/aswebauthenticationsession) to complete 3D Secure authentication when necessary.
-
-Make sure your `ViewController` conforms to the `ASWebAuthenticationPresentationContextProviding` protocol:
-
-```swift
-extension MyViewController: ASWebAuthenticationPresentationContextProviding {
-
-    // MARK: - ASWebAuthenticationPresentationContextProviding
-    func presentationAnchor(for session: ASWebAuthenticationSession) -> ASPresentationAnchor {
-        UIApplication
-            .shared
-            .connectedScenes
-            .flatMap { ($0 as? UIWindowScene)?.windows ?? [] }
-            .first { $0.isKeyWindow }
-        ?? ASPresentationAnchor()
-    }
-}
-```
-
-### 3. Initiate the Payments SDK
+### 2. Initiate the Payments SDK
 
 Create a `CoreConfig` using an [access token](../../README.md#access-token):
 
@@ -79,7 +58,7 @@ Create a `CardClient` to approve an order with a Card payment method:
 let cardClient = CardClient(config: config)
 ```
 
-### 4. Create an order
+### 3. Create an order
 
 When a user initiates a payment flow, call `v2/checkout/orders` to create an order and obtain an order ID:
 
@@ -111,7 +90,7 @@ curl --location --request POST 'https://api.sandbox.paypal.com/v2/checkout/order
 
 The `id` field of the response contains the order ID to pass to your client.
 
-### 5. Create a request containing the card payment details
+### 4. Create a request containing the card payment details
 
 Create a `Card` object containing the user's card details.
 
@@ -143,7 +122,7 @@ let cardRequest = CardRequest(
 )
 ```
 
-### 6. Approve the order using Payments SDK
+### 5. Approve the order using Payments SDK
 
 Call `cardClient.approveOrder()` to approve the order.
 
@@ -154,7 +133,7 @@ extension MyViewController: CardDelegate {
 
     func approveOrder(cardRequest: CardRequest) {
         cardClient.delegate = self
-        cardClient.approveOrder(request: cardRequest, context: self)
+        cardClient.approveOrder(request: cardRequest)
     }
 
     func card(_ cardClient: CardClient, didFinishWithResult result: CardResult) {
@@ -179,7 +158,7 @@ extension MyViewController: CardDelegate {
 }
 ```
 
-### 7. Capture/Authorize the order
+### 6. Capture/Authorize the order
 
 If you receive a successful result in the client-side flow, you can then capture or authorize the order. 
 

--- a/docs/PayPalWebCheckout/README.md
+++ b/docs/PayPalWebCheckout/README.md
@@ -44,28 +44,7 @@ In your app's source files, use the following import syntax to include PayPal's 
 import PayPalWebCheckout
 ```
 
-### 2. Configure your application to present an authentication session
-
-The PayPal Web Checkout module uses an [ASWebAuthenticationSession](https://developer.apple.com/documentation/authenticationservices/aswebauthenticationsession) to complete the payment flow.
-
-Make sure your `ViewController` conforms to the `ASWebAuthenticationPresentationContextProviding` protocol:
-
-```swift
-extension MyViewController: ASWebAuthenticationPresentationContextProviding {
-
-    // MARK: - ASWebAuthenticationPresentationContextProviding
-    func presentationAnchor(for session: ASWebAuthenticationSession) -> ASPresentationAnchor {
-        UIApplication
-            .shared
-            .connectedScenes
-            .flatMap { ($0 as? UIWindowScene)?.windows ?? [] }
-            .first { $0.isKeyWindow }
-        ?? ASPresentationAnchor()
-    }
-}
-```
-
-### 3. Initiate the Payments SDK
+### 2. Initiate the Payments SDK
 
 Create a `CoreConfig` using an [access token](../../README.md#access-token):
 
@@ -79,7 +58,7 @@ Create a `PayPalWebCheckoutClient` to approve an order with a PayPal payment met
 let payPalClient = PayPalWebCheckoutClient(config: config)
 ```
 
-### 4. Create an order
+### 3. Create an order
 
 
 When a user initiates a payment flow, call `v2/checkout/orders` to create an order and obtain an order ID:
@@ -112,7 +91,7 @@ curl --location --request POST 'https://api.sandbox.paypal.com/v2/checkout/order
 
 The `id` field of the response contains the order ID to pass to your client.
 
-### 5. Create a request object for launching the PayPal flow
+### 4. Create a request object for launching the PayPal flow
 
 Configure your `PayPalWebCheckoutRequest` and include the order ID generated in [step 4](#4-create-an-order):
 
@@ -123,7 +102,7 @@ let payPalRequest = PayPalWebCheckoutRequest(orderID: "<ORDER_ID>")
 You can also specify one of the following funding sources for your order: `PayPal` (default), `PayLater` or `PayPalCredit`.
 > Click [here](https://developer.paypal.com/docs/checkout/pay-later/us/) for more information on PayPal Pay Later
 
-### 6. Approve the order using the Payments SDK
+### 5. Approve the order using the Payments SDK
 
 To start the PayPal Web Checkout flow, call `payPalWebCheckoutClient.start(payPalWebCheckoutRequest)`.
 
@@ -134,7 +113,7 @@ extension MyViewController: PayPalWebCheckoutDelegate {
 
     func checkoutWithPayPal() {
         payPalClient.delegate = self
-        payPalClient.start(request: payPalRequest, context: self)
+        payPalClient.start(request: payPalRequest)
     }
 
     // MARK: - PayPalWebCheckoutDelegate
@@ -152,7 +131,7 @@ extension MyViewController: PayPalWebCheckoutDelegate {
 }
 ```
 
-### 7. Capture/Authorize the order
+### 6. Capture/Authorize the order
 
 If you receive a successful result in the client-side flow, you can then capture or authorize the order. 
 


### PR DESCRIPTION
### Reason for changes

We can clean-up our docs story by removing the need for merchants to conform to `ASWebAuthenticationPresentationContextProviding`, and instead place this burden on the PayPal SDK.

### Summary of changes

- Remove `ASWebAuthenticationPresentationContextProviding` merchant step from Card & PayPal web docs
- Refactor internal use of `WebAuthenticationSession` in `CardClient` and `PayPalWebCheckoutClient`
   - Make our testing/mocking strategy more in-line with the rest of the iOS SDK by injecting via internal initializer
   - Existing pattern is more in-line with Android testing setup
- Conform `CardClient` and `PayPalWebCheckoutClient` to `ASWebAuthenticationPresentationContextProviding`

### Checklist

- [X] Added a changelog entry
- [X] [Follow-up PR ](https://github.com/paypal/iOS-SDK/pull/105)to cleanup Demo

### Authors
@scannillo