### PR TITLE
Fix assets not rendering when importing with Cocoapods

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,7 +9,7 @@
 * PayPalWebCheckout
   * Remove step requiring `ASWebAuthenticationPresentationContextProviding` conformance
 * PayPalUI
-  * Fix assets not rendering when importing with Swift Package Manager
+  * Fix assets not rendering when importing with Swift Package Manager and Cocoapods
 
 ## 0.0.3 (2022-11-03)
 * PayPalNativeCheckout

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,7 +9,7 @@
 * PayPalWebCheckout
   * Remove step requiring `ASWebAuthenticationPresentationContextProviding` conformance
 * PayPalUI
-  * Fix assets not rendering when importing with Swift Package Manager and Cocoapods
+  * Fix assets not rendering when importing with Swift Package Manager and CocoaPods
 
 ## 0.0.3 (2022-11-03)
 * PayPalNativeCheckout

--- a/PayPal.podspec
+++ b/PayPal.podspec
@@ -25,7 +25,9 @@ Pod::Spec.new do |s|
   s.subspec "PayPalUI" do |s|
     s.source_files  = "Sources/PayPalUI/*.swift"
     s.dependency "PayPal/PaymentsCore"
-    s.resources = "Sources/PayPalUI/*.xcassets"
+    s.resource_bundle = {
+    	'PayPalSDK' => ['Sources/PayPalUI/*.xcassets']
+    }
   end
 
   s.subspec "PayPalWebCheckout" do |s|

--- a/PayPal.podspec
+++ b/PayPal.podspec
@@ -25,6 +25,7 @@ Pod::Spec.new do |s|
   s.subspec "PayPalUI" do |s|
     s.source_files  = "Sources/PayPalUI/*.swift"
     s.dependency "PayPal/PaymentsCore"
+    s.resources = "Sources/PayPalUI/*.xcassets"
   end
 
   s.subspec "PayPalWebCheckout" do |s|

--- a/Sources/PayPalUI/PaymentButton.swift
+++ b/Sources/PayPalUI/PaymentButton.swift
@@ -6,6 +6,8 @@ public class PaymentButton: UIButton {
     // asset identifier path for image and color button assets
     #if SWIFT_PACKAGE
     static var bundle = Bundle.module
+    #elseif COCOAPODS
+    static var bundle = Bundle(identifier: "PayPalSDK")
     #else
     static var bundle = Bundle(identifier: "com.paypal.ios-sdk.PayPalUI")
     #endif

--- a/Sources/PayPalUI/PaymentButton.swift
+++ b/Sources/PayPalUI/PaymentButton.swift
@@ -10,8 +10,8 @@ public class PaymentButton: UIButton {
     static let bundle: Bundle = {
         let frameworkBundle = Bundle(for: PaymentButton.self)
         let bundleURL = frameworkBundle.resourceURL?.appendingPathComponent("PayPalSDK.bundle")
-        return Bundle(url: bundleURL!)
-    }
+        return Bundle(url: bundleURL!)!
+    }()
     #else
     static let bundle = Bundle(identifier: "com.paypal.ios-sdk.PayPalUI")
     #endif

--- a/Sources/PayPalUI/PaymentButton.swift
+++ b/Sources/PayPalUI/PaymentButton.swift
@@ -5,11 +5,15 @@ public class PaymentButton: UIButton {
 
     // asset identifier path for image and color button assets
     #if SWIFT_PACKAGE
-    static var bundle = Bundle.module
+    static let bundle = Bundle.module
     #elseif COCOAPODS
-    static var bundle = Bundle(identifier: "PayPalSDK")
+    static let bundle: Bundle = {
+        let frameworkBundle = Bundle(for: PaymentButton.self)
+        let bundleURL = frameworkBundle.resourceURL?.appendingPathComponent("PayPalSDK.bundle")
+        return Bundle(url: bundleURL!)
+    }
     #else
-    static var bundle = Bundle(identifier: "com.paypal.ios-sdk.PayPalUI")
+    static let bundle = Bundle(identifier: "com.paypal.ios-sdk.PayPalUI")
     #endif
 
     // MARK: - Init

--- a/Sources/PayPalUI/PaymentButton.swift
+++ b/Sources/PayPalUI/PaymentButton.swift
@@ -9,9 +9,9 @@ public class PaymentButton: UIButton {
     #elseif COCOAPODS
     static let bundle: Bundle = {
         let frameworkBundle = Bundle(for: PaymentButton.self)
-//        if let bundleURL = frameworkBundle.resourceURL?.appendingPathComponent("PayPalSDK.bundle") {
-//            return Bundle(url: bundleURL)
-//        }
+        if let bundleURL = frameworkBundle.resourceURL?.appendingPathComponent("PayPalSDK.bundle") {
+            return Bundle(url: bundleURL)
+        }
         return frameworkBundle
     }()
     #else

--- a/Sources/PayPalUI/PaymentButton.swift
+++ b/Sources/PayPalUI/PaymentButton.swift
@@ -10,7 +10,9 @@ public class PaymentButton: UIButton {
     static let bundle: Bundle = {
         let frameworkBundle = Bundle(for: PaymentButton.self)
         if let bundleURL = frameworkBundle.resourceURL?.appendingPathComponent("PayPalSDK.bundle") {
-            return Bundle(url: bundleURL)
+            if let bundle = Bundle(url: bundleURL) {
+                return bundle
+            }
         }
         return frameworkBundle
     }()

--- a/Sources/PayPalUI/PaymentButton.swift
+++ b/Sources/PayPalUI/PaymentButton.swift
@@ -9,11 +9,13 @@ public class PaymentButton: UIButton {
     #elseif COCOAPODS
     static let bundle: Bundle = {
         let frameworkBundle = Bundle(for: PaymentButton.self)
-        let bundleURL = frameworkBundle.resourceURL?.appendingPathComponent("PayPalSDK.bundle")
-        return Bundle(url: bundleURL!)!
+//        if let bundleURL = frameworkBundle.resourceURL?.appendingPathComponent("PayPalSDK.bundle") {
+//            return Bundle(url: bundleURL)
+//        }
+        return frameworkBundle
     }()
     #else
-    static let bundle = Bundle(identifier: "com.paypal.ios-sdk.PayPalUI")
+    static let bundle = Bundle(for: PaymentButton.self)
     #endif
 
     // MARK: - Init


### PR DESCRIPTION
### Reason for changes

PayPayUI assets are not being rendered when using COCOAPODS
Solution for bundle: https://stackoverflow.com/a/59667338


### Summary of changes

-  Add `resource_bundle` to PodSpec
-  Match Bundle in code, separating for `COCOAPODS`
- This change was tested with a test application.


| Before | After |
|-----|-----|
<img src="https://user-images.githubusercontent.com/20733831/212360754-0408d69a-174e-4870-8f62-e4cdf539b1bc.png" width="400" />|<img src="https://user-images.githubusercontent.com/20733831/212360782-3b2fc847-413d-40f4-be61-79c53252ba16.png" width="400" />


### Checklist

- [x] Added a changelog entry

### Authors
> List GitHub usernames for everyone who contributed to this pull request.

- @jcnoriega 