### PR TITLE
Add environment to analytic events

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@
 * Rename `Card` to `CardPayments`
 * PayPalUI
     * Fix issue where label was not being shown
+* Rename `Environment.production` enum case to `Environment.live`
 
 ## 0.0.4 (2023-01-17)
 * Card

--- a/Demo/Demo/DemoSettings/DemoSettings.swift
+++ b/Demo/Demo/DemoSettings/DemoSettings.swift
@@ -47,7 +47,7 @@ enum DemoSettings {
         switch environment {
         case .sandbox:
             return "AcXwOk3dof7NCNcriyS8RVh5q39ozvdWUF9oHPrWqfyrDS4AwVdKe32Axuk2ADo6rI_31Vv6MGgOyzRt"
-        case .production:
+        case .live:
             // TODO: Investigate getting a prod testing account that doesn't charge real money
             return "TODO"
         }

--- a/Demo/Demo/DemoSettings/Environment.swift
+++ b/Demo/Demo/DemoSettings/Environment.swift
@@ -2,13 +2,13 @@ import CorePayments
 
 enum Environment: String {
     case sandbox
-    case production
+    case live
 
     var baseURL: String {
         switch self {
         case .sandbox:
             return "https://sdk-sample-merchant-server.herokuapp.com"
-        case .production:
+        case .live:
             return "https://sdk-sample-merchant-server.herokuapp.com"
         }
     }
@@ -17,8 +17,8 @@ enum Environment: String {
         switch self {
         case .sandbox:
             return .sandbox
-        case .production:
-            return .production
+        case .live:
+            return .live
         }
     }
 }

--- a/Demo/Demo/SceneDelegate.swift
+++ b/Demo/Demo/SceneDelegate.swift
@@ -51,8 +51,8 @@ class SceneDelegate: UIResponder, UIWindowSceneDelegate {
 
         if launchArgs.contains("-EnvironmentSandbox") {
             DemoSettings.environment = .sandbox
-        } else if launchArgs.contains("-EnvironmentProduction") {
-            DemoSettings.environment = .production
+        } else if launchArgs.contains("-EnvironmentLive") {
+            DemoSettings.environment = .live
         }
 
         if launchArgs.contains("-DemoTypeCard") {

--- a/Demo/Settings.bundle/Root.plist
+++ b/Demo/Settings.bundle/Root.plist
@@ -24,12 +24,12 @@
 			<key>Titles</key>
 			<array>
 				<string>Sandbox</string>
-				<string>Production</string>
+				<string>Live</string>
 			</array>
 			<key>Values</key>
 			<array>
 				<string>sandbox</string>
-				<string>production</string>
+				<string>live</string>
 			</array>
 		</dict>
 		<dict>

--- a/Sources/CorePayments/AnalyticsEventData.swift
+++ b/Sources/CorePayments/AnalyticsEventData.swift
@@ -18,6 +18,7 @@ struct AnalyticsEventData: Encodable {
         case clientOS = "client_os"
         case component = "comp"
         case deviceManufacturer = "device_manufacturer"
+        case environment = "merchant_app_environment"
         case eventName = "event_name"
         case eventSource = "event_source"
         case packageManager = "ios_package_manager"
@@ -47,6 +48,8 @@ struct AnalyticsEventData: Encodable {
     let eventName: String
 
     let eventSource = "mobile-native"
+    
+    let environment: String
 
     let packageManager: String = {
         #if COCOAPODS
@@ -87,7 +90,8 @@ struct AnalyticsEventData: Encodable {
 
     let tenantName = "PayPal"
     
-    init(eventName: String, clientID: String, sessionID: String) {
+    init(environment: String, eventName: String, clientID: String, sessionID: String) {
+        self.environment = environment
         self.eventName = eventName
         self.clientID = clientID
         self.sessionID = sessionID
@@ -105,6 +109,7 @@ struct AnalyticsEventData: Encodable {
         try eventParameters.encode(clientOS, forKey: .clientOS)
         try eventParameters.encode(component, forKey: .component)
         try eventParameters.encode(deviceManufacturer, forKey: .deviceManufacturer)
+        try eventParameters.encode(environment, forKey: .environment)
         try eventParameters.encode(eventName, forKey: .eventName)
         try eventParameters.encode(eventSource, forKey: .eventSource)
         try eventParameters.encode(packageManager, forKey: .packageManager)

--- a/Sources/CorePayments/AnalyticsEventRequest.swift
+++ b/Sources/CorePayments/AnalyticsEventRequest.swift
@@ -19,7 +19,7 @@ struct AnalyticsEventRequest: APIRequest {
     
     // api.sandbox.paypal.com does not currently send FPTI events to BigQuery/Looker
     func toURLRequest(environment: Environment) -> URLRequest? {
-        composeURLRequest(environment: .production)
+        composeURLRequest(environment: .live)
     }
 }
 

--- a/Sources/CorePayments/Networking/AnalyticsService.swift
+++ b/Sources/CorePayments/Networking/AnalyticsService.swift
@@ -33,7 +33,13 @@ class AnalyticsService {
     }
         
     func sendEvent(name: String, clientID: String) async {
+        guard let http else { // Will never occur
+            NSLog("[PayPal SDK]", "Failed to send analytics due to malformed HTTP client.")
+            return
+        }
+        
         let eventData = AnalyticsEventData(
+            environment: http.coreConfig.environment.toString,
             eventName: name,
             clientID: clientID,
             sessionID: sessionID
@@ -41,7 +47,7 @@ class AnalyticsService {
         
         do {
             let analyticsEventRequest = try AnalyticsEventRequest(eventData: eventData)
-            let (_) = try await http?.performRequest(analyticsEventRequest)
+            let (_) = try await http.performRequest(analyticsEventRequest)
         } catch {
             NSLog("[PayPal SDK] Failed to send analytics: %@", error.localizedDescription)
         }

--- a/Sources/CorePayments/Networking/AnalyticsService.swift
+++ b/Sources/CorePayments/Networking/AnalyticsService.swift
@@ -33,8 +33,8 @@ class AnalyticsService {
     }
         
     func sendEvent(name: String, clientID: String) async {
-        guard let http else { // Will never occur
-            NSLog("[PayPal SDK]", "Failed to send analytics due to malformed HTTP client.")
+        guard let http else {
+            NSLog("[PayPal SDK]", "Failed to send analytics due to nil HTTP client.")
             return
         }
         

--- a/Sources/CorePayments/Networking/Enums/Environment.swift
+++ b/Sources/CorePayments/Networking/Enums/Environment.swift
@@ -22,4 +22,13 @@ public enum Environment {
             return URL(string: "https://paypal.com/graphql")!
         }
     }
+    
+    public var toString: String {
+        switch self {
+        case .sandbox:
+            return "sandbox"
+        case .production:
+            return "production"
+        }
+    }
 }

--- a/Sources/CorePayments/Networking/Enums/Environment.swift
+++ b/Sources/CorePayments/Networking/Enums/Environment.swift
@@ -2,14 +2,14 @@ import Foundation
 
 public enum Environment {
     case sandbox
-    case production
+    case live
 
     // swiftlint:disable force_unwrapping
     var baseURL: URL {
         switch self {
         case .sandbox:
             return URL(string: "https://api.sandbox.paypal.com")!
-        case .production:
+        case .live:
             return URL(string: "https://api.paypal.com")!
         }
     }
@@ -18,7 +18,7 @@ public enum Environment {
         switch self {
         case .sandbox:
             return URL(string: "https://www.sandbox.paypal.com/graphql")!
-        case .production:
+        case .live:
             return URL(string: "https://paypal.com/graphql")!
         }
     }
@@ -27,8 +27,8 @@ public enum Environment {
         switch self {
         case .sandbox:
             return "sandbox"
-        case .production:
-            return "production"
+        case .live:
+            return "live"
         }
     }
 }

--- a/Sources/FraudProtection/PayPalDataCollectorEnvironment.swift
+++ b/Sources/FraudProtection/PayPalDataCollectorEnvironment.swift
@@ -3,13 +3,13 @@ import PPRiskMagnes
 /// Enum of environments to use with PayPalDataCollector
 public enum PayPalDataCollectorEnvironment {
     case sandbox
-    case production
+    case live
 
     var magnesEnvironment: MagnesSDK.Environment {
         switch self {
         case .sandbox:
             return .SANDBOX
-        case .production:
+        case .live:
             return .LIVE
         }
     }

--- a/Sources/PayPalNativePayments/Extensions/Environment+Extension.swift
+++ b/Sources/PayPalNativePayments/Extensions/Environment+Extension.swift
@@ -16,7 +16,7 @@ extension PayPalEnvironment {
         switch self {
         case .sandbox:
             return .sandbox
-        case .production:
+        case .live:
             return .live
         }
     }

--- a/Sources/PayPalWebPayments/Environment+PayPalWebCheckout.swift
+++ b/Sources/PayPalWebPayments/Environment+PayPalWebCheckout.swift
@@ -11,7 +11,7 @@ extension Environment {
         switch self {
         case .sandbox:
             return URL(string: "https://www.sandbox.paypal.com")!
-        case .production:
+        case .live:
             return URL(string: "https://www.paypal.com")!
         }
     }

--- a/UnitTests/FraudProtectionTests/PayPalDataCollector_Tests.swift
+++ b/UnitTests/FraudProtectionTests/PayPalDataCollector_Tests.swift
@@ -14,7 +14,7 @@ class PayPalDataCollector_Tests: XCTestCase {
     }
 
     func testCollectDeviceData_setsMagnesEnvironmentToLIVE() {
-        let sut = PayPalDataCollector(environment: .production, magnesSDK: magnesSDK, deviceInspector: deviceInspector)
+        let sut = PayPalDataCollector(environment: .live, magnesSDK: magnesSDK, deviceInspector: deviceInspector)
         _ = sut.collectDeviceData()
 
         XCTAssertEqual(.LIVE, magnesSDK.capturedSetupParams?.env)

--- a/UnitTests/PayPalNativePaymentsTests/PayPalEnvironment_Tests.swift
+++ b/UnitTests/PayPalNativePaymentsTests/PayPalEnvironment_Tests.swift
@@ -6,9 +6,9 @@ class PayPalEnvironment_Tests: XCTestCase {
 
     func testPayPalEnvironment_convertsToPayPalCheckoutEnvironmentCorrectly() {
         let sandbox = Environment.sandbox
-        let prod = Environment.production
+        let live = Environment.live
 
         XCTAssertEqual(sandbox.toNativeCheckoutSDKEnvironment(), .sandbox)
-        XCTAssertEqual(prod.toNativeCheckoutSDKEnvironment(), .live)
+        XCTAssertEqual(live.toNativeCheckoutSDKEnvironment(), .live)
     }
 }

--- a/UnitTests/PayPalWebPaymentsTests/Environment+PayPalWebCheckout_Tests.swift
+++ b/UnitTests/PayPalWebPaymentsTests/Environment+PayPalWebCheckout_Tests.swift
@@ -6,9 +6,9 @@ class Environment_PayPalWebCheckout_Tests: XCTestCase {
 
     func testPayPalEnvironment_returnsCorrectBaseURL() {
         let sandbox = Environment.sandbox
-        let production = Environment.production
+        let live = Environment.live
 
         XCTAssertEqual(sandbox.payPalBaseURL.absoluteString, "https://www.sandbox.paypal.com")
-        XCTAssertEqual(production.payPalBaseURL.absoluteString, "https://www.paypal.com")
+        XCTAssertEqual(live.payPalBaseURL.absoluteString, "https://www.paypal.com")
     }
 }

--- a/UnitTests/PaymentsCoreTests/AnalyticsEventRequest_Tests.swift
+++ b/UnitTests/PaymentsCoreTests/AnalyticsEventRequest_Tests.swift
@@ -13,6 +13,7 @@ class AnalyticsEventRequest_Tests: XCTestCase {
     override func setUp() {
         super.setUp()
         fakeAnalyticsEventData = AnalyticsEventData(
+            environment: "fake-env",
             eventName: "fake-name",
             clientID: "fake-client-id",
             sessionID: "fake-session"
@@ -36,6 +37,7 @@ class AnalyticsEventRequest_Tests: XCTestCase {
         XCTAssertTrue((eventParams["client_os"] as! String).matches("iOS \\d+\\.\\d+|iPadOS \\d+\\.\\d+"))
         XCTAssertEqual(eventParams["comp"] as? String, "ppunifiedsdk")
         XCTAssertEqual(eventParams["device_manufacturer"] as? String, "Apple")
+        XCTAssertEqual(eventParams["merchant_app_environment"] as? String, "fake-env")
         XCTAssertEqual(eventParams["event_name"] as? String, "fake-name")
         XCTAssertEqual(eventParams["event_source"] as? String, "mobile-native")
         XCTAssertTrue((eventParams["ios_package_manager"] as! String).matches("Carthage or Other|CocoaPods|Swift Package Manager"))

--- a/UnitTests/PaymentsCoreTests/AnalyticsService_Tests.swift
+++ b/UnitTests/PaymentsCoreTests/AnalyticsService_Tests.swift
@@ -32,6 +32,21 @@ class AnalyticsService_Tests: XCTestCase {
         XCTAssert(mockHTTP.lastAPIRequest is AnalyticsEventRequest)
     }
     
+    func testSendEvent_whenProduction_sendsProperTag() async {
+        let fakeConfig = CoreConfig(accessToken: "fake-token-1", environment: .production)
+        let mockHTTP = MockHTTP(urlSession: mockURLSession, coreConfig: fakeConfig)
+
+        let analyticsService = AnalyticsService.sharedInstance(http: mockHTTP)
+        await analyticsService.sendEvent(name: "fake-event", clientID: "fake-client-id")
+        
+        guard let eventParams = (mockHTTP.lastPOSTParameters?["events"] as! [String: [String: Any]])["event_params"] else {
+            XCTFail("JSON body missing `event_params` key.")
+            return
+        }
+        
+        XCTAssertEqual(eventParams["merchant_app_environment"] as? String, "production")
+    }
+    
     // MARK: - sharedInstance()
 
     func testSharedInstance_withDifferentAccessToken_postsUniqueSessionID() async {

--- a/UnitTests/PaymentsCoreTests/AnalyticsService_Tests.swift
+++ b/UnitTests/PaymentsCoreTests/AnalyticsService_Tests.swift
@@ -32,8 +32,8 @@ class AnalyticsService_Tests: XCTestCase {
         XCTAssert(mockHTTP.lastAPIRequest is AnalyticsEventRequest)
     }
     
-    func testSendEvent_whenProduction_sendsProperTag() async {
-        let fakeConfig = CoreConfig(accessToken: "fake-token-1", environment: .production)
+    func testSendEvent_whenLive_sendsProperTag() async {
+        let fakeConfig = CoreConfig(accessToken: "fake-token-1", environment: .live)
         let mockHTTP = MockHTTP(urlSession: mockURLSession, coreConfig: fakeConfig)
 
         let analyticsService = AnalyticsService.sharedInstance(http: mockHTTP)
@@ -44,7 +44,7 @@ class AnalyticsService_Tests: XCTestCase {
             return
         }
         
-        XCTAssertEqual(eventParams["merchant_app_environment"] as? String, "production")
+        XCTAssertEqual(eventParams["merchant_app_environment"] as? String, "live")
     }
     
     func testSendEvent_whenSandbox_sendsProperTag() async {

--- a/UnitTests/PaymentsCoreTests/AnalyticsService_Tests.swift
+++ b/UnitTests/PaymentsCoreTests/AnalyticsService_Tests.swift
@@ -47,6 +47,21 @@ class AnalyticsService_Tests: XCTestCase {
         XCTAssertEqual(eventParams["merchant_app_environment"] as? String, "production")
     }
     
+    func testSendEvent_whenSandbox_sendsProperTag() async {
+        let fakeConfig = CoreConfig(accessToken: "fake-token-1", environment: .sandbox)
+        let mockHTTP = MockHTTP(urlSession: mockURLSession, coreConfig: fakeConfig)
+
+        let analyticsService = AnalyticsService.sharedInstance(http: mockHTTP)
+        await analyticsService.sendEvent(name: "fake-event", clientID: "fake-client-id")
+        
+        guard let eventParams = (mockHTTP.lastPOSTParameters?["events"] as! [String: [String: Any]])["event_params"] else {
+            XCTFail("JSON body missing `event_params` key.")
+            return
+        }
+        
+        XCTAssertEqual(eventParams["merchant_app_environment"] as? String, "sandbox")
+    }
+    
     // MARK: - sharedInstance()
 
     func testSharedInstance_withDifferentAccessToken_postsUniqueSessionID() async {

--- a/UnitTests/PaymentsCoreTests/Environment_Tests.swift
+++ b/UnitTests/PaymentsCoreTests/Environment_Tests.swift
@@ -8,8 +8,8 @@ class Environment_Tests: XCTestCase {
         XCTAssertEqual(Environment.sandbox.baseURL.absoluteString, expectedUrlString)
     }
 
-    func testEnvironment_productionURL_matchesExpectation() throws {
+    func testEnvironment_liveURL_matchesExpectation() throws {
         let expectedUrlString = "https://api.paypal.com"
-        XCTAssertEqual(Environment.production.baseURL.absoluteString, expectedUrlString)
+        XCTAssertEqual(Environment.live.baseURL.absoluteString, expectedUrlString)
     }
 }


### PR DESCRIPTION
### Reason for changes

Due to FPTI sandbox tooling limitations, we decided (summarized in [this doc](https://paypal-my.sharepoint.com/:w:/r/personal/scannillo_paypal_com1/_layouts/15/Doc.aspx?sourcedoc=%7B5D9C9200-40CD-4F09-B16D-2C313787AD04%7D&file=FPTI%20Data%20Tooling%20Summary%20%26%20Discussion.docx&nav=eyJjIjoxMTE0NjY2NDQxfQ&action=default&mobileredirect=true)) all analytic events will be sent to `https://api.paypal.com/`.

### Summary of changes

- Add `merchant_app_environment` parameter to distinguish sandbox vs production events.

### Checklist

- ~Added a changelog entry~

### Authors
@scannillo