### PR TITLE
Rename Production to Live

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@
 * Rename `Card` to `CardPayments`
 * PayPalUI
     * Fix issue where label was not being shown
+* Rename `Environment.production` enum case to `Environment.live`
 
 ## 0.0.4 (2023-01-17)
 * Card

--- a/Demo/Demo/DemoSettings/DemoSettings.swift
+++ b/Demo/Demo/DemoSettings/DemoSettings.swift
@@ -47,7 +47,7 @@ enum DemoSettings {
         switch environment {
         case .sandbox:
             return "AcXwOk3dof7NCNcriyS8RVh5q39ozvdWUF9oHPrWqfyrDS4AwVdKe32Axuk2ADo6rI_31Vv6MGgOyzRt"
-        case .production:
+        case .live:
             // TODO: Investigate getting a prod testing account that doesn't charge real money
             return "TODO"
         }

--- a/Demo/Demo/DemoSettings/Environment.swift
+++ b/Demo/Demo/DemoSettings/Environment.swift
@@ -2,13 +2,13 @@ import CorePayments
 
 enum Environment: String {
     case sandbox
-    case production
+    case live
 
     var baseURL: String {
         switch self {
         case .sandbox:
             return "https://sdk-sample-merchant-server.herokuapp.com"
-        case .production:
+        case .live:
             return "https://sdk-sample-merchant-server.herokuapp.com"
         }
     }
@@ -17,8 +17,8 @@ enum Environment: String {
         switch self {
         case .sandbox:
             return .sandbox
-        case .production:
-            return .production
+        case .live:
+            return .live
         }
     }
 }

--- a/Demo/Demo/SceneDelegate.swift
+++ b/Demo/Demo/SceneDelegate.swift
@@ -51,8 +51,8 @@ class SceneDelegate: UIResponder, UIWindowSceneDelegate {
 
         if launchArgs.contains("-EnvironmentSandbox") {
             DemoSettings.environment = .sandbox
-        } else if launchArgs.contains("-EnvironmentProduction") {
-            DemoSettings.environment = .production
+        } else if launchArgs.contains("-EnvironmentLive") {
+            DemoSettings.environment = .live
         }
 
         if launchArgs.contains("-DemoTypeCard") {

--- a/Demo/Settings.bundle/Root.plist
+++ b/Demo/Settings.bundle/Root.plist
@@ -24,12 +24,12 @@
 			<key>Titles</key>
 			<array>
 				<string>Sandbox</string>
-				<string>Production</string>
+				<string>Live</string>
 			</array>
 			<key>Values</key>
 			<array>
 				<string>sandbox</string>
-				<string>production</string>
+				<string>live</string>
 			</array>
 		</dict>
 		<dict>

--- a/Sources/CorePayments/AnalyticsEventRequest.swift
+++ b/Sources/CorePayments/AnalyticsEventRequest.swift
@@ -19,7 +19,7 @@ struct AnalyticsEventRequest: APIRequest {
     
     // api.sandbox.paypal.com does not currently send FPTI events to BigQuery/Looker
     func toURLRequest(environment: Environment) -> URLRequest? {
-        composeURLRequest(environment: .production)
+        composeURLRequest(environment: .live)
     }
 }
 

--- a/Sources/CorePayments/Networking/Enums/Environment.swift
+++ b/Sources/CorePayments/Networking/Enums/Environment.swift
@@ -2,14 +2,14 @@ import Foundation
 
 public enum Environment {
     case sandbox
-    case production
+    case live
 
     // swiftlint:disable force_unwrapping
     var baseURL: URL {
         switch self {
         case .sandbox:
             return URL(string: "https://api.sandbox.paypal.com")!
-        case .production:
+        case .live:
             return URL(string: "https://api.paypal.com")!
         }
     }
@@ -18,7 +18,7 @@ public enum Environment {
         switch self {
         case .sandbox:
             return URL(string: "https://www.sandbox.paypal.com/graphql")!
-        case .production:
+        case .live:
             return URL(string: "https://paypal.com/graphql")!
         }
     }
@@ -27,8 +27,8 @@ public enum Environment {
         switch self {
         case .sandbox:
             return "sandbox"
-        case .production:
-            return "production"
+        case .live:
+            return "live"
         }
     }
 }

--- a/Sources/FraudProtection/PayPalDataCollectorEnvironment.swift
+++ b/Sources/FraudProtection/PayPalDataCollectorEnvironment.swift
@@ -3,13 +3,13 @@ import PPRiskMagnes
 /// Enum of environments to use with PayPalDataCollector
 public enum PayPalDataCollectorEnvironment {
     case sandbox
-    case production
+    case live
 
     var magnesEnvironment: MagnesSDK.Environment {
         switch self {
         case .sandbox:
             return .SANDBOX
-        case .production:
+        case .live:
             return .LIVE
         }
     }

--- a/Sources/PayPalNativePayments/Extensions/Environment+Extension.swift
+++ b/Sources/PayPalNativePayments/Extensions/Environment+Extension.swift
@@ -16,7 +16,7 @@ extension PayPalEnvironment {
         switch self {
         case .sandbox:
             return .sandbox
-        case .production:
+        case .live:
             return .live
         }
     }

--- a/Sources/PayPalWebPayments/Environment+PayPalWebCheckout.swift
+++ b/Sources/PayPalWebPayments/Environment+PayPalWebCheckout.swift
@@ -11,7 +11,7 @@ extension Environment {
         switch self {
         case .sandbox:
             return URL(string: "https://www.sandbox.paypal.com")!
-        case .production:
+        case .live:
             return URL(string: "https://www.paypal.com")!
         }
     }

--- a/UnitTests/FraudProtectionTests/PayPalDataCollector_Tests.swift
+++ b/UnitTests/FraudProtectionTests/PayPalDataCollector_Tests.swift
@@ -14,7 +14,7 @@ class PayPalDataCollector_Tests: XCTestCase {
     }
 
     func testCollectDeviceData_setsMagnesEnvironmentToLIVE() {
-        let sut = PayPalDataCollector(environment: .production, magnesSDK: magnesSDK, deviceInspector: deviceInspector)
+        let sut = PayPalDataCollector(environment: .live, magnesSDK: magnesSDK, deviceInspector: deviceInspector)
         _ = sut.collectDeviceData()
 
         XCTAssertEqual(.LIVE, magnesSDK.capturedSetupParams?.env)

--- a/UnitTests/PayPalNativePaymentsTests/PayPalEnvironment_Tests.swift
+++ b/UnitTests/PayPalNativePaymentsTests/PayPalEnvironment_Tests.swift
@@ -6,9 +6,9 @@ class PayPalEnvironment_Tests: XCTestCase {
 
     func testPayPalEnvironment_convertsToPayPalCheckoutEnvironmentCorrectly() {
         let sandbox = Environment.sandbox
-        let prod = Environment.production
+        let live = Environment.live
 
         XCTAssertEqual(sandbox.toNativeCheckoutSDKEnvironment(), .sandbox)
-        XCTAssertEqual(prod.toNativeCheckoutSDKEnvironment(), .live)
+        XCTAssertEqual(live.toNativeCheckoutSDKEnvironment(), .live)
     }
 }

--- a/UnitTests/PayPalWebPaymentsTests/Environment+PayPalWebCheckout_Tests.swift
+++ b/UnitTests/PayPalWebPaymentsTests/Environment+PayPalWebCheckout_Tests.swift
@@ -6,9 +6,9 @@ class Environment_PayPalWebCheckout_Tests: XCTestCase {
 
     func testPayPalEnvironment_returnsCorrectBaseURL() {
         let sandbox = Environment.sandbox
-        let production = Environment.production
+        let live = Environment.live
 
         XCTAssertEqual(sandbox.payPalBaseURL.absoluteString, "https://www.sandbox.paypal.com")
-        XCTAssertEqual(production.payPalBaseURL.absoluteString, "https://www.paypal.com")
+        XCTAssertEqual(live.payPalBaseURL.absoluteString, "https://www.paypal.com")
     }
 }

--- a/UnitTests/PaymentsCoreTests/AnalyticsService_Tests.swift
+++ b/UnitTests/PaymentsCoreTests/AnalyticsService_Tests.swift
@@ -32,8 +32,8 @@ class AnalyticsService_Tests: XCTestCase {
         XCTAssert(mockHTTP.lastAPIRequest is AnalyticsEventRequest)
     }
     
-    func testSendEvent_whenProduction_sendsProperTag() async {
-        let fakeConfig = CoreConfig(accessToken: "fake-token-1", environment: .production)
+    func testSendEvent_whenLive_sendsProperTag() async {
+        let fakeConfig = CoreConfig(accessToken: "fake-token-1", environment: .live)
         let mockHTTP = MockHTTP(urlSession: mockURLSession, coreConfig: fakeConfig)
 
         let analyticsService = AnalyticsService.sharedInstance(http: mockHTTP)
@@ -44,7 +44,7 @@ class AnalyticsService_Tests: XCTestCase {
             return
         }
         
-        XCTAssertEqual(eventParams["merchant_app_environment"] as? String, "production")
+        XCTAssertEqual(eventParams["merchant_app_environment"] as? String, "live")
     }
     
     func testSendEvent_whenSandbox_sendsProperTag() async {

--- a/UnitTests/PaymentsCoreTests/Environment_Tests.swift
+++ b/UnitTests/PaymentsCoreTests/Environment_Tests.swift
@@ -8,8 +8,8 @@ class Environment_Tests: XCTestCase {
         XCTAssertEqual(Environment.sandbox.baseURL.absoluteString, expectedUrlString)
     }
 
-    func testEnvironment_productionURL_matchesExpectation() throws {
+    func testEnvironment_liveURL_matchesExpectation() throws {
         let expectedUrlString = "https://api.paypal.com"
-        XCTAssertEqual(Environment.production.baseURL.absoluteString, expectedUrlString)
+        XCTAssertEqual(Environment.live.baseURL.absoluteString, expectedUrlString)
     }
 }


### PR DESCRIPTION
### Reason for changes

- I noticed a mismatch b/w iOS and Android for the public facing `Environment` that the merchant passes to their `CoreConfig`.
- I went with `Live` as I feel this name is commonly used to reference this environment throughout PayPal, and in our public docs. 

### Summary of changes

- Rename public `Environment.production` enum case to `Environment.live`
- Update demo app & test names where appropriate

### Checklist

- [X] Added a changelog entry

### Authors
@scannillo 