### PR TITLE
PayPal Native Payments - Analytics

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@
 * PayPalUI
     * Fix issue where label was not being shown
 * Rename `Environment.production` enum case to `Environment.live`
+* Send analytic events for `PayPalNativePayments` flow
 
 ## 0.0.4 (2023-01-17)
 * Card

--- a/Sources/CorePayments/AnalyticsEventData.swift
+++ b/Sources/CorePayments/AnalyticsEventData.swift
@@ -41,7 +41,7 @@ struct AnalyticsEventData: Encodable {
 
     let clientOS: String = UIDevice.current.systemName + " " + UIDevice.current.systemVersion
 
-    let component = "ppunifiedsdk"
+    let component = "ppcpmobilesdk"
 
     let deviceManufacturer = "Apple"
 

--- a/Sources/CorePayments/Networking/APIClient.swift
+++ b/Sources/CorePayments/Networking/APIClient.swift
@@ -43,14 +43,18 @@ public class APIClient {
     }
     
     /// :nodoc: This method is exposed for internal PayPal use only. Do not use. It is not covered by Semantic Versioning and may change or be removed at any time.
+    ///
+    /// Sends analytics event to https://api.paypal.com/v1/tracking/events/ via a background task.
     /// - Parameter name: Event name string used to identify this unique event in FPTI.
-    public func sendAnalyticsEvent(_ name: String) async {
-        do {
-            let clientID = try await fetchCachedOrRemoteClientID()
-            let analyticsService = AnalyticsService.sharedInstance(http: http)
-            await analyticsService.sendEvent(name: name, clientID: clientID)
-        } catch {
-            NSLog("[PayPal SDK] Failed to send analytics due to missing clientID: %@", error.localizedDescription)
+    public func sendAnalyticsEvent(_ name: String) {
+        Task(priority: .background) {
+            do {
+                let clientID = try await fetchCachedOrRemoteClientID()
+                let analyticsService = AnalyticsService.sharedInstance(http: http)
+                await analyticsService.sendEvent(name: name, clientID: clientID)
+            } catch {
+                NSLog("[PayPal SDK] Failed to send analytics due to missing clientID: %@", error.localizedDescription.debugDescription)
+            }
         }
     }
 }

--- a/Sources/CorePayments/Networking/APIClientDecoder.swift
+++ b/Sources/CorePayments/Networking/APIClientDecoder.swift
@@ -10,6 +10,14 @@ class APIClientDecoder {
     }
 
     func decode<T: APIRequest>(_ type: T.Type, from data: Data) throws -> T.ResponseType {
+        guard !data.isEmpty else {
+            if let emptyResponse = EmptyResponse() as? T.ResponseType {
+                return emptyResponse
+            } else {
+                throw APIClientError.noResponseDataError
+            }
+        }
+        
         do {
             return try self.decoder.decode(T.ResponseType.self, from: data)
         } catch {
@@ -20,13 +28,6 @@ class APIClientDecoder {
     func decode(from data: Data) throws -> ErrorResponse {
         do {
             return try self.decoder.decode(ErrorResponse.self, from: data)
-        } catch {
-            throw APIClientError.unknownError
-        }
-    }
-    func decode<T: Decodable>(from data: Data) throws -> T {
-        do {
-            return try self.decoder.decode(T.self, from: data)
         } catch {
             throw APIClientError.unknownError
         }

--- a/Sources/PayPalNativePayments/PayPalNativeCheckoutClient.swift
+++ b/Sources/PayPalNativePayments/PayPalNativeCheckoutClient.swift
@@ -51,7 +51,7 @@ public class PayPalNativeCheckoutClient {
             )
             delegate?.paypalWillStart(self)
             
-            apiClient.sendAnalyticsEvent("paypal-native-checkout:started")
+            apiClient.sendAnalyticsEvent("paypal-native-payments:started")
             self.nativeCheckoutProvider.start(
                 presentingViewController: presentingViewController,
                 createOrder: createOrder,
@@ -73,26 +73,26 @@ public class PayPalNativeCheckoutClient {
     }
 
     private func notifySuccess(for approval: PayPalCheckout.Approval) {
-        apiClient.sendAnalyticsEvent("paypal-native-checkout:succeeded")
+        apiClient.sendAnalyticsEvent("paypal-native-payments:succeeded")
         
         delegate?.paypal(self, didFinishWithResult: approval)
     }
 
     private func notifyFailure(with errorInfo: PayPalCheckoutErrorInfo) {
-        apiClient.sendAnalyticsEvent("paypal-native-checkout:failed")
+        apiClient.sendAnalyticsEvent("paypal-native-payments:failed")
         
         let error = PayPalError.nativeCheckoutSDKError(errorInfo)
         delegate?.paypal(self, didFinishWithError: error)
     }
 
     private func notifyCancellation() {
-        apiClient.sendAnalyticsEvent("paypal-native-checkout:canceled")
+        apiClient.sendAnalyticsEvent("paypal-native-payments:canceled")
         
         delegate?.paypalDidCancel(self)
     }
 
     private func notifyShippingChange(shippingChange: ShippingChange, shippingChangeAction: ShippingChangeAction) {
-        apiClient.sendAnalyticsEvent("paypal-native-checkout:shipping-address-changed")
+        apiClient.sendAnalyticsEvent("paypal-native-payments:shipping-address-changed")
         
         delegate?.paypalDidShippingAddressChange(self, shippingChange: shippingChange, shippingChangeAction: shippingChangeAction)
     }

--- a/Sources/PayPalNativePayments/PayPalNativeCheckoutClient.swift
+++ b/Sources/PayPalNativePayments/PayPalNativeCheckoutClient.swift
@@ -50,6 +50,8 @@ public class PayPalNativeCheckoutClient {
                 environment: config.environment.toNativeCheckoutSDKEnvironment()
             )
             delegate?.paypalWillStart(self)
+            
+            apiClient.sendAnalyticsEvent("paypal-native-checkout:started")
             self.nativeCheckoutProvider.start(
                 presentingViewController: presentingViewController,
                 createOrder: createOrder,
@@ -71,19 +73,27 @@ public class PayPalNativeCheckoutClient {
     }
 
     private func notifySuccess(for approval: PayPalCheckout.Approval) {
+        apiClient.sendAnalyticsEvent("paypal-native-checkout:succeeded")
+        
         delegate?.paypal(self, didFinishWithResult: approval)
     }
 
     private func notifyFailure(with errorInfo: PayPalCheckoutErrorInfo) {
+        apiClient.sendAnalyticsEvent("paypal-native-checkout:failed")
+        
         let error = PayPalError.nativeCheckoutSDKError(errorInfo)
         delegate?.paypal(self, didFinishWithError: error)
     }
 
     private func notifyCancellation() {
+        apiClient.sendAnalyticsEvent("paypal-native-checkout:canceled")
+        
         delegate?.paypalDidCancel(self)
     }
 
     private func notifyShippingChange(shippingChange: ShippingChange, shippingChangeAction: ShippingChangeAction) {
+        apiClient.sendAnalyticsEvent("paypal-native-checkout:shipping-address-changed")
+        
         delegate?.paypalDidShippingAddressChange(self, shippingChange: shippingChange, shippingChangeAction: shippingChangeAction)
     }
 }

--- a/UnitTests/PayPalNativePaymentsTests/PayPalClient_Tests.swift
+++ b/UnitTests/PayPalNativePaymentsTests/PayPalClient_Tests.swift
@@ -81,14 +81,14 @@ class PayPalClient_Tests: XCTestCase {
     
     func testAnalyticsEvent_whenClientStarted_isSent() async {
         await payPalClient.start { _ in }
-        XCTAssertEqual(apiClient.postedAnalyticsEvents.first, "paypal-native-checkout:started")
+        XCTAssertEqual(apiClient.postedAnalyticsEvents.first, "paypal-native-payments:started")
     }
     
     func testAnalyticsEvent_whenNXOCanceled_isSent() async {
         await payPalClient.start { _ in }
         
         mockNativeCheckoutProvider.triggerCancel()
-        XCTAssertEqual(apiClient.postedAnalyticsEvents[1], "paypal-native-checkout:canceled")
+        XCTAssertEqual(apiClient.postedAnalyticsEvents[1], "paypal-native-payments:canceled")
     }
     
     // TODO: - The following tests are blocked by inability to mock PayPalCheckout final classes.

--- a/UnitTests/PayPalNativePaymentsTests/PayPalClient_Tests.swift
+++ b/UnitTests/PayPalNativePaymentsTests/PayPalClient_Tests.swift
@@ -39,6 +39,7 @@ class PayPalClient_Tests: XCTestCase {
     }
 
     // todo: check for approval result instead of cancel
+    // JIRA ticket DTNOR-259
     func testStart_whenNativeSDKOnApproveCalled_returnsPayPalResult() async {
 
         let mockPayPalDelegate = MockPayPalDelegate()
@@ -66,6 +67,7 @@ class PayPalClient_Tests: XCTestCase {
     }
 
     // todo: check for error case instead of cancel
+    // JIRA ticket DTNOR-259
     func testStart_whenNativeSDKOnErrorCalled_returnsCheckoutError() async {
 
         let mockPayPalDelegate = MockPayPalDelegate()
@@ -74,4 +76,27 @@ class PayPalClient_Tests: XCTestCase {
         mockNativeCheckoutProvider.triggerCancel()
         XCTAssert(mockPayPalDelegate.paypalDidCancel)
     }
+    
+    // MARK: - Analytics
+    
+    func testAnalyticsEvent_whenClientStarted_isSent() async {
+        await payPalClient.start { _ in }
+        XCTAssertEqual(apiClient.postedAnalyticsEvents.first, "paypal-native-checkout:started")
+    }
+    
+    func testAnalyticsEvent_whenNXOCanceled_isSent() async {
+        await payPalClient.start { _ in }
+        
+        mockNativeCheckoutProvider.triggerCancel()
+        XCTAssertEqual(apiClient.postedAnalyticsEvents[1], "paypal-native-checkout:canceled")
+    }
+    
+    // TODO: - The following tests are blocked by inability to mock PayPalCheckout final classes.
+    // JIRA ticket DTNOR-259
+    
+    func pendAnalyticsEvent_whenNXOError_isSent() async { }
+    
+    func pendAnalyticsEvent_whenNXOSucceeded_isSent() { }
+    
+    func pendAnalyticsEvent_whenNXOShippingAddressChanged_isSent() { }
 }

--- a/UnitTests/PaymentsCoreTests/AnalyticsEventRequest_Tests.swift
+++ b/UnitTests/PaymentsCoreTests/AnalyticsEventRequest_Tests.swift
@@ -35,7 +35,7 @@ class AnalyticsEventRequest_Tests: XCTestCase {
         XCTAssertEqual(eventParams["app_name"] as? String, "xctest")
         XCTAssertTrue((eventParams["c_sdk_ver"] as! String).matches("^\\d+\\.\\d+\\.\\d+(-[0-9a-zA-Z-]+)?$"))
         XCTAssertTrue((eventParams["client_os"] as! String).matches("iOS \\d+\\.\\d+|iPadOS \\d+\\.\\d+"))
-        XCTAssertEqual(eventParams["comp"] as? String, "ppunifiedsdk")
+        XCTAssertEqual(eventParams["comp"] as? String, "ppcpmobilesdk")
         XCTAssertEqual(eventParams["device_manufacturer"] as? String, "Apple")
         XCTAssertEqual(eventParams["merchant_app_environment"] as? String, "fake-env")
         XCTAssertEqual(eventParams["event_name"] as? String, "fake-name")

--- a/UnitTests/TestShared/MockAPIClient.swift
+++ b/UnitTests/TestShared/MockAPIClient.swift
@@ -9,6 +9,8 @@ class MockAPIClient: APIClient {
     var cannedJSONResponse: String?
     var cannedFetchError: Error?
     
+    var postedAnalyticsEvents: [String] = []
+    
     override convenience init(coreConfig: CoreConfig) {
         self.init(http: HTTP(urlSession: MockURLSession(), coreConfig: coreConfig))
     }
@@ -27,5 +29,9 @@ class MockAPIClient: APIClient {
             throw cannedClientIDError
         }
         return cannedClientID
+    }
+    
+    override func sendAnalyticsEvent(_ name: String) {
+        postedAnalyticsEvents.append(name)
     }
 }


### PR DESCRIPTION
### Reason for changes

DTNOR-630

### Summary of changes

- Change component name to `ppcpmobilesdk` to pass Lighthouse IQ validations
- Update `APIClient.sendAnalyticsEvent()` to send analytics in a background task 
- Remove unused `APIClientDecoder.decode()` function
- Add [our pre-defined analytic events](https://paypal.sharepoint.com/:x:/r/sites/BTSDK/_layouts/15/Doc.aspx?sourcedoc=%7BAAA7C353-5744-4F21-AC7D-DF85D8605817%7D&file=Northstar%20Analytics%20Events.xlsx&action=default&mobileredirect=true&cid=1b0afccd-68ab-448f-9760-60ed14df9811) to the PayPal Native Payments flow

### Checklist

- [X] Added a changelog entry

### Authors
@scannillo