### PR TITLE
Add analytic events for PPWeb, PP NXO, and Card flows

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@
 * PayPalUI
     * Fix issue where label was not being shown
 * Rename `Environment.production` enum case to `Environment.live`
+* Send analytic events for `PayPalNativePayments` flow
 
 ## 0.0.4 (2023-01-17)
 * Card

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,7 +11,7 @@
 * PayPalUI
     * Fix issue where label was not being shown
 * Rename `Environment.production` enum case to `Environment.live`
-* Send analytic events for `PayPalNativePayments` flow
+* Send analytic events for `PayPalNativePayments`, `PayPalWebPayments`, and `CardPayments` flows
 
 ## 0.0.4 (2023-01-17)
 * Card

--- a/Sources/CardPayments/CardClient.swift
+++ b/Sources/CardPayments/CardClient.swift
@@ -51,7 +51,6 @@ public class CardClient: NSObject {
                 if let url: String = result.links?.first(where: { $0.rel == "payer-action" })?.href {
                     apiClient.sendAnalyticsEvent("card-payments:3ds:confirm-payment-source:challenge-required")
                     
-                    delegate?.cardThreeDSecureWillLaunch(self)
                     startThreeDSecureChallenge(url: url, orderId: result.id)
                 } else {
                     apiClient.sendAnalyticsEvent("card-payments:3ds:confirm-payment-source:succeeded")
@@ -79,6 +78,8 @@ public class CardClient: NSObject {
             self.notifyFailure(with: CardClientError.threeDSecureURLError)
             return
         }
+        
+        delegate?.cardThreeDSecureWillLaunch(self)
         
         webAuthenticationSession.start(
             url: threeDSURL,

--- a/Sources/CardPayments/CardClient.swift
+++ b/Sources/CardPayments/CardClient.swift
@@ -99,12 +99,10 @@ public class CardClient: NSObject {
                         self.notifyCancellation()
                         return
                     default:
-                        self.apiClient.sendAnalyticsEvent("card-payments:3ds:challenge:failed")
                         self.notifyFailure(with: CardClientError.threeDSecureError(error))
                         return
                     }
                 }
-                self.apiClient.sendAnalyticsEvent("card-payments:3ds:challenge:succeeded")
                 self.getOrderInfo(id: orderId)
             }
         )

--- a/Sources/CardPayments/CardClientError.swift
+++ b/Sources/CardPayments/CardClientError.swift
@@ -40,5 +40,4 @@ enum CardClientError {
         domain: domain,
         errorDescription: "An invalid 3DS URL was returned. Contact developer.paypal.com/support."
     )
-
 }

--- a/Sources/CardPayments/CardClientError.swift
+++ b/Sources/CardPayments/CardClientError.swift
@@ -16,6 +16,9 @@ enum CardClientError {
 
         /// 2. An error occurred during 3DS challenge.
         case threeDSecureError
+        
+        /// 3 . An invalid 3DS challenge URL was returned by `/confirm-payment-source`
+        case threeDSecureURLError
     }
 
     static let encodingError = CoreSDKError(
@@ -31,4 +34,11 @@ enum CardClientError {
             errorDescription: error.localizedDescription
         )
     }
+    
+    static let threeDSecureURLError = CoreSDKError(
+        code: Code.threeDSecureURLError.rawValue,
+        domain: domain,
+        errorDescription: "An invalid 3DS URL was returned. Contact developer.paypal.com/support."
+    )
+
 }

--- a/Sources/CorePayments/AnalyticsEventData.swift
+++ b/Sources/CorePayments/AnalyticsEventData.swift
@@ -41,7 +41,7 @@ struct AnalyticsEventData: Encodable {
 
     let clientOS: String = UIDevice.current.systemName + " " + UIDevice.current.systemVersion
 
-    let component = "ppunifiedsdk"
+    let component = "ppcpmobilesdk"
 
     let deviceManufacturer = "Apple"
 

--- a/Sources/CorePayments/Networking/APIClient.swift
+++ b/Sources/CorePayments/Networking/APIClient.swift
@@ -43,14 +43,18 @@ public class APIClient {
     }
     
     /// :nodoc: This method is exposed for internal PayPal use only. Do not use. It is not covered by Semantic Versioning and may change or be removed at any time.
+    ///
+    /// Sends analytics event to https://api.paypal.com/v1/tracking/events/ via a background task.
     /// - Parameter name: Event name string used to identify this unique event in FPTI.
-    public func sendAnalyticsEvent(_ name: String) async {
-        do {
-            let clientID = try await fetchCachedOrRemoteClientID()
-            let analyticsService = AnalyticsService.sharedInstance(http: http)
-            await analyticsService.sendEvent(name: name, clientID: clientID)
-        } catch {
-            NSLog("[PayPal SDK] Failed to send analytics due to missing clientID: %@", error.localizedDescription)
+    public func sendAnalyticsEvent(_ name: String) {
+        Task(priority: .background) {
+            do {
+                let clientID = try await fetchCachedOrRemoteClientID()
+                let analyticsService = AnalyticsService.sharedInstance(http: http)
+                await analyticsService.sendEvent(name: name, clientID: clientID)
+            } catch {
+                NSLog("[PayPal SDK] Failed to send analytics due to missing clientID: %@", error.localizedDescription.debugDescription)
+            }
         }
     }
 }

--- a/Sources/CorePayments/Networking/APIClientDecoder.swift
+++ b/Sources/CorePayments/Networking/APIClientDecoder.swift
@@ -10,6 +10,14 @@ class APIClientDecoder {
     }
 
     func decode<T: APIRequest>(_ type: T.Type, from data: Data) throws -> T.ResponseType {
+        guard !data.isEmpty else {
+            if let emptyResponse = EmptyResponse() as? T.ResponseType {
+                return emptyResponse
+            } else {
+                throw APIClientError.noResponseDataError
+            }
+        }
+        
         do {
             return try self.decoder.decode(T.ResponseType.self, from: data)
         } catch {
@@ -20,13 +28,6 @@ class APIClientDecoder {
     func decode(from data: Data) throws -> ErrorResponse {
         do {
             return try self.decoder.decode(ErrorResponse.self, from: data)
-        } catch {
-            throw APIClientError.unknownError
-        }
-    }
-    func decode<T: Decodable>(from data: Data) throws -> T {
-        do {
-            return try self.decoder.decode(T.self, from: data)
         } catch {
             throw APIClientError.unknownError
         }

--- a/Sources/CorePayments/WebAuthenticationSession.swift
+++ b/Sources/CorePayments/WebAuthenticationSession.swift
@@ -6,7 +6,7 @@ public class WebAuthenticationSession: NSObject {
     public func start(
         url: URL,
         context: ASWebAuthenticationPresentationContextProviding,
-        sessionDidDisplay: ((Bool) -> Void)? = nil,
+        sessionDidDisplay: @escaping (Bool) -> Void,
         sessionDidComplete: @escaping (URL?, Error?) -> Void
     ) {
         let authenticationSession = ASWebAuthenticationSession(
@@ -19,12 +19,7 @@ public class WebAuthenticationSession: NSObject {
         authenticationSession.presentationContextProvider = context
 
         DispatchQueue.main.async {
-            // TODO: - Make sessionDidDisplay non-optional after implementing analytics for PayPalWebCheckout
-            if let sessionDidDisplay {
-                sessionDidDisplay(authenticationSession.start())
-            } else {
-                authenticationSession.start()
-            }
+            sessionDidDisplay(authenticationSession.start())
         }
     }
 }

--- a/Sources/CorePayments/WebAuthenticationSession.swift
+++ b/Sources/CorePayments/WebAuthenticationSession.swift
@@ -6,19 +6,25 @@ public class WebAuthenticationSession: NSObject {
     public func start(
         url: URL,
         context: ASWebAuthenticationPresentationContextProviding,
-        completion: @escaping (URL?, Error?) -> Void
+        sessionDidDisplay: ((Bool) -> Void)? = nil,
+        sessionDidComplete: @escaping (URL?, Error?) -> Void
     ) {
         let authenticationSession = ASWebAuthenticationSession(
             url: url,
             callbackURLScheme: PayPalCoreConstants.callbackURLScheme,
-            completionHandler: completion
+            completionHandler: sessionDidComplete
         )
 
         authenticationSession.prefersEphemeralWebBrowserSession = true
         authenticationSession.presentationContextProvider = context
 
         DispatchQueue.main.async {
-            authenticationSession.start()
+            // TODO: - Make sessionDidDisplay non-optional after implementing analytics for PayPalWebCheckout
+            if let sessionDidDisplay {
+                sessionDidDisplay(authenticationSession.start())
+            } else {
+                authenticationSession.start()
+            }
         }
     }
 }

--- a/Sources/PayPalNativePayments/PayPalNativeCheckoutClient.swift
+++ b/Sources/PayPalNativePayments/PayPalNativeCheckoutClient.swift
@@ -51,7 +51,7 @@ public class PayPalNativeCheckoutClient {
             )
             delegate?.paypalWillStart(self)
             
-            apiClient.sendAnalyticsEvent("paypal-native-checkout:started")
+            apiClient.sendAnalyticsEvent("paypal-native-payments:started")
             self.nativeCheckoutProvider.start(
                 presentingViewController: presentingViewController,
                 createOrder: createOrder,
@@ -73,26 +73,26 @@ public class PayPalNativeCheckoutClient {
     }
 
     private func notifySuccess(for approval: PayPalCheckout.Approval) {
-        apiClient.sendAnalyticsEvent("paypal-native-checkout:succeeded")
+        apiClient.sendAnalyticsEvent("paypal-native-payments:succeeded")
         
         delegate?.paypal(self, didFinishWithResult: approval)
     }
 
     private func notifyFailure(with errorInfo: PayPalCheckoutErrorInfo) {
-        apiClient.sendAnalyticsEvent("paypal-native-checkout:failed")
+        apiClient.sendAnalyticsEvent("paypal-native-payments:failed")
         
         let error = PayPalError.nativeCheckoutSDKError(errorInfo)
         delegate?.paypal(self, didFinishWithError: error)
     }
 
     private func notifyCancellation() {
-        apiClient.sendAnalyticsEvent("paypal-native-checkout:canceled")
+        apiClient.sendAnalyticsEvent("paypal-native-payments:canceled")
         
         delegate?.paypalDidCancel(self)
     }
 
     private func notifyShippingChange(shippingChange: ShippingChange, shippingChangeAction: ShippingChangeAction) {
-        apiClient.sendAnalyticsEvent("paypal-native-checkout:shipping-address-changed")
+        apiClient.sendAnalyticsEvent("paypal-native-payments:shipping-address-changed")
         
         delegate?.paypalDidShippingAddressChange(self, shippingChange: shippingChange, shippingChangeAction: shippingChangeAction)
     }

--- a/Sources/PayPalNativePayments/PayPalNativeCheckoutClient.swift
+++ b/Sources/PayPalNativePayments/PayPalNativeCheckoutClient.swift
@@ -74,7 +74,6 @@ public class PayPalNativeCheckoutClient {
 
     private func notifySuccess(for approval: PayPalCheckout.Approval) {
         apiClient.sendAnalyticsEvent("paypal-native-payments:succeeded")
-        
         delegate?.paypal(self, didFinishWithResult: approval)
     }
 
@@ -87,13 +86,11 @@ public class PayPalNativeCheckoutClient {
 
     private func notifyCancellation() {
         apiClient.sendAnalyticsEvent("paypal-native-payments:canceled")
-        
         delegate?.paypalDidCancel(self)
     }
 
     private func notifyShippingChange(shippingChange: ShippingChange, shippingChangeAction: ShippingChangeAction) {
         apiClient.sendAnalyticsEvent("paypal-native-payments:shipping-address-changed")
-        
         delegate?.paypalDidShippingAddressChange(self, shippingChange: shippingChange, shippingChangeAction: shippingChangeAction)
     }
 }

--- a/Sources/PayPalNativePayments/PayPalNativeCheckoutClient.swift
+++ b/Sources/PayPalNativePayments/PayPalNativeCheckoutClient.swift
@@ -50,6 +50,8 @@ public class PayPalNativeCheckoutClient {
                 environment: config.environment.toNativeCheckoutSDKEnvironment()
             )
             delegate?.paypalWillStart(self)
+            
+            apiClient.sendAnalyticsEvent("paypal-native-checkout:started")
             self.nativeCheckoutProvider.start(
                 presentingViewController: presentingViewController,
                 createOrder: createOrder,
@@ -71,19 +73,27 @@ public class PayPalNativeCheckoutClient {
     }
 
     private func notifySuccess(for approval: PayPalCheckout.Approval) {
+        apiClient.sendAnalyticsEvent("paypal-native-checkout:succeeded")
+        
         delegate?.paypal(self, didFinishWithResult: approval)
     }
 
     private func notifyFailure(with errorInfo: PayPalCheckoutErrorInfo) {
+        apiClient.sendAnalyticsEvent("paypal-native-checkout:failed")
+        
         let error = PayPalError.nativeCheckoutSDKError(errorInfo)
         delegate?.paypal(self, didFinishWithError: error)
     }
 
     private func notifyCancellation() {
+        apiClient.sendAnalyticsEvent("paypal-native-checkout:canceled")
+        
         delegate?.paypalDidCancel(self)
     }
 
     private func notifyShippingChange(shippingChange: ShippingChange, shippingChangeAction: ShippingChangeAction) {
+        apiClient.sendAnalyticsEvent("paypal-native-checkout:shipping-address-changed")
+        
         delegate?.paypalDidShippingAddressChange(self, shippingChange: shippingChange, shippingChangeAction: shippingChangeAction)
     }
 }

--- a/Sources/PayPalWebPayments/PayPalWebCheckoutClient.swift
+++ b/Sources/PayPalWebPayments/PayPalWebCheckoutClient.swift
@@ -31,6 +31,8 @@ public class PayPalWebCheckoutClient: NSObject {
     /// - Parameters:
     ///   - request: the PayPalRequest for the transaction
     public func start(request: PayPalWebCheckoutRequest) {
+        apiClient.sendAnalyticsEvent("paypal-web-payments:started")
+        
         Task {
             do {
                 _ = try await apiClient.fetchCachedOrRemoteClientID()
@@ -97,14 +99,17 @@ public class PayPalWebCheckoutClient: NSObject {
 
     private func notifySuccess(for result: PayPalWebCheckoutResult) {
         let payPalResult = PayPalWebCheckoutResult(orderID: result.orderID, payerID: result.payerID)
+        apiClient.sendAnalyticsEvent("paypal-web-payments:succeeded")
         delegate?.payPal(self, didFinishWithResult: payPalResult)
     }
 
     private func notifyFailure(with error: CoreSDKError) {
+        apiClient.sendAnalyticsEvent("paypal-web-payments:failed")
         delegate?.payPal(self, didFinishWithError: error)
     }
 
     private func notifyCancellation() {
+        apiClient.sendAnalyticsEvent("paypal-web-payments:browser-login:canceled")
         delegate?.payPalDidCancel(self)
     }
 }

--- a/UnitTests/CardPaymentsTests/CardClient_Tests.swift
+++ b/UnitTests/CardPaymentsTests/CardClient_Tests.swift
@@ -68,7 +68,7 @@ class CardClient_Tests: XCTestCase {
     }
     
     func testApproveOrder_withInvalid3DSURL_returnsError() {
-        mockAPIClient.cannedJSONResponse = CardResponses.confirmPaymentSourceJsonWithInvalid3DSURL.rawValue
+        mockAPIClient.cannedJSONResponse = CardResponses.confirmPaymentSourceJsonInvalid3DSURL.rawValue
         
         let expectation = expectation(description: "approveOrder() completed")
 

--- a/UnitTests/CardPaymentsTests/CardClient_Tests.swift
+++ b/UnitTests/CardPaymentsTests/CardClient_Tests.swift
@@ -66,6 +66,28 @@ class CardClient_Tests: XCTestCase {
 
         waitForExpectations(timeout: 10)
     }
+    
+    func testApproveOrder_withInvalid3DSURL_returnsError() {
+        mockAPIClient.cannedJSONResponse = CardResponses.confirmPaymentSourceJsonWithInvalid3DSURL.rawValue
+        
+        let expectation = expectation(description: "approveOrder() completed")
+
+        let mockCardDelegate = MockCardDelegate(success: {_, _ in
+            XCTFail("Invoked success() callback. Should invoke error().")
+        }, error: { _, err in
+            XCTAssertEqual(err.code, 3)
+            XCTAssertEqual(err.domain, "CardClientErrorDomain")
+            XCTAssertEqual(err.errorDescription, "An invalid 3DS URL was returned. Contact developer.paypal.com/support.")
+            expectation.fulfill()
+        }, threeDSWillLaunch: { _ in
+            XCTFail("Invoked willLaunch() callback. Should invoke error().")
+        })
+
+        cardClient.delegate = mockCardDelegate
+        cardClient.approveOrder(request: cardRequest)
+
+        waitForExpectations(timeout: 10)
+    }
 
     func testApproveOrder_withNoThreeDSecure_returnsOrderData() {
         mockAPIClient.cannedJSONResponse = CardResponses.confirmPaymentSourceJson.rawValue

--- a/UnitTests/CardPaymentsTests/CardResponses.swift
+++ b/UnitTests/CardPaymentsTests/CardResponses.swift
@@ -33,7 +33,7 @@ enum CardResponses: String {
         }
         """
     
-    case confirmPaymentSourceJsonWithInvalid3DSURL = """
+    case confirmPaymentSourceJsonInvalid3DSURL = """
         {
             "id": "testOrderId",
             "status": "APPROVED",

--- a/UnitTests/CardPaymentsTests/CardResponses.swift
+++ b/UnitTests/CardPaymentsTests/CardResponses.swift
@@ -32,6 +32,26 @@ enum CardResponses: String {
             ]
         }
         """
+    
+    case confirmPaymentSourceJsonWithInvalid3DSURL = """
+        {
+            "id": "testOrderId",
+            "status": "APPROVED",
+            "payment_source": {
+                "card": {
+                    "last_four_digits": "7321",
+                    "brand": "VISA",
+                    "type": "CREDIT"
+                }
+            },
+            "links": [
+                {
+                    "rel": "payer-action",
+                    "href": ""
+                }
+            ]
+        }
+        """
 
     case successfullGetOrderJson = """
         {

--- a/UnitTests/PayPalNativePaymentsTests/PayPalClient_Tests.swift
+++ b/UnitTests/PayPalNativePaymentsTests/PayPalClient_Tests.swift
@@ -81,14 +81,14 @@ class PayPalClient_Tests: XCTestCase {
     
     func testAnalyticsEvent_whenClientStarted_isSent() async {
         await payPalClient.start { _ in }
-        XCTAssertEqual(apiClient.postedAnalyticsEvents.first, "paypal-native-checkout:started")
+        XCTAssertEqual(apiClient.postedAnalyticsEvents.first, "paypal-native-payments:started")
     }
     
     func testAnalyticsEvent_whenNXOCanceled_isSent() async {
         await payPalClient.start { _ in }
         
         mockNativeCheckoutProvider.triggerCancel()
-        XCTAssertEqual(apiClient.postedAnalyticsEvents[1], "paypal-native-checkout:canceled")
+        XCTAssertEqual(apiClient.postedAnalyticsEvents[1], "paypal-native-payments:canceled")
     }
     
     // TODO: - The following tests are blocked by inability to mock PayPalCheckout final classes.

--- a/UnitTests/PayPalNativePaymentsTests/PayPalClient_Tests.swift
+++ b/UnitTests/PayPalNativePaymentsTests/PayPalClient_Tests.swift
@@ -39,6 +39,7 @@ class PayPalClient_Tests: XCTestCase {
     }
 
     // todo: check for approval result instead of cancel
+    // JIRA ticket DTNOR-259
     func testStart_whenNativeSDKOnApproveCalled_returnsPayPalResult() async {
 
         let mockPayPalDelegate = MockPayPalDelegate()
@@ -66,6 +67,7 @@ class PayPalClient_Tests: XCTestCase {
     }
 
     // todo: check for error case instead of cancel
+    // JIRA ticket DTNOR-259
     func testStart_whenNativeSDKOnErrorCalled_returnsCheckoutError() async {
 
         let mockPayPalDelegate = MockPayPalDelegate()
@@ -74,4 +76,27 @@ class PayPalClient_Tests: XCTestCase {
         mockNativeCheckoutProvider.triggerCancel()
         XCTAssert(mockPayPalDelegate.paypalDidCancel)
     }
+    
+    // MARK: - Analytics
+    
+    func testAnalyticsEvent_whenClientStarted_isSent() async {
+        await payPalClient.start { _ in }
+        XCTAssertEqual(apiClient.postedAnalyticsEvents.first, "paypal-native-checkout:started")
+    }
+    
+    func testAnalyticsEvent_whenNXOCanceled_isSent() async {
+        await payPalClient.start { _ in }
+        
+        mockNativeCheckoutProvider.triggerCancel()
+        XCTAssertEqual(apiClient.postedAnalyticsEvents[1], "paypal-native-checkout:canceled")
+    }
+    
+    // TODO: - The following tests are blocked by inability to mock PayPalCheckout final classes.
+    // JIRA ticket DTNOR-259
+    
+    func pendAnalyticsEvent_whenNXOError_isSent() async { }
+    
+    func pendAnalyticsEvent_whenNXOSucceeded_isSent() { }
+    
+    func pendAnalyticsEvent_whenNXOShippingAddressChanged_isSent() { }
 }

--- a/UnitTests/PayPalNativePaymentsTests/PayPalClient_Tests.swift
+++ b/UnitTests/PayPalNativePaymentsTests/PayPalClient_Tests.swift
@@ -39,7 +39,6 @@ class PayPalClient_Tests: XCTestCase {
     }
 
     // todo: check for approval result instead of cancel
-    // JIRA ticket DTNOR-259
     func testStart_whenNativeSDKOnApproveCalled_returnsPayPalResult() async {
 
         let mockPayPalDelegate = MockPayPalDelegate()
@@ -67,7 +66,6 @@ class PayPalClient_Tests: XCTestCase {
     }
 
     // todo: check for error case instead of cancel
-    // JIRA ticket DTNOR-259
     func testStart_whenNativeSDKOnErrorCalled_returnsCheckoutError() async {
 
         let mockPayPalDelegate = MockPayPalDelegate()
@@ -76,27 +74,4 @@ class PayPalClient_Tests: XCTestCase {
         mockNativeCheckoutProvider.triggerCancel()
         XCTAssert(mockPayPalDelegate.paypalDidCancel)
     }
-    
-    // MARK: - Analytics
-    
-    func testAnalyticsEvent_whenClientStarted_isSent() async {
-        await payPalClient.start { _ in }
-        XCTAssertEqual(apiClient.postedAnalyticsEvents.first, "paypal-native-payments:started")
-    }
-    
-    func testAnalyticsEvent_whenNXOCanceled_isSent() async {
-        await payPalClient.start { _ in }
-        
-        mockNativeCheckoutProvider.triggerCancel()
-        XCTAssertEqual(apiClient.postedAnalyticsEvents[1], "paypal-native-payments:canceled")
-    }
-    
-    // TODO: - The following tests are blocked by inability to mock PayPalCheckout final classes.
-    // JIRA ticket DTNOR-259
-    
-    func pendAnalyticsEvent_whenNXOError_isSent() async { }
-    
-    func pendAnalyticsEvent_whenNXOSucceeded_isSent() { }
-    
-    func pendAnalyticsEvent_whenNXOShippingAddressChanged_isSent() { }
 }

--- a/UnitTests/PaymentsCoreTests/AnalyticsEventRequest_Tests.swift
+++ b/UnitTests/PaymentsCoreTests/AnalyticsEventRequest_Tests.swift
@@ -35,7 +35,7 @@ class AnalyticsEventRequest_Tests: XCTestCase {
         XCTAssertEqual(eventParams["app_name"] as? String, "xctest")
         XCTAssertTrue((eventParams["c_sdk_ver"] as! String).matches("^\\d+\\.\\d+\\.\\d+(-[0-9a-zA-Z-]+)?$"))
         XCTAssertTrue((eventParams["client_os"] as! String).matches("iOS \\d+\\.\\d+|iPadOS \\d+\\.\\d+"))
-        XCTAssertEqual(eventParams["comp"] as? String, "ppunifiedsdk")
+        XCTAssertEqual(eventParams["comp"] as? String, "ppcpmobilesdk")
         XCTAssertEqual(eventParams["device_manufacturer"] as? String, "Apple")
         XCTAssertEqual(eventParams["merchant_app_environment"] as? String, "fake-env")
         XCTAssertEqual(eventParams["event_name"] as? String, "fake-name")

--- a/UnitTests/TestShared/MockAPIClient.swift
+++ b/UnitTests/TestShared/MockAPIClient.swift
@@ -9,6 +9,8 @@ class MockAPIClient: APIClient {
     var cannedJSONResponse: String?
     var cannedFetchError: Error?
     
+    var postedAnalyticsEvents: [String] = []
+    
     override convenience init(coreConfig: CoreConfig) {
         self.init(http: HTTP(urlSession: MockURLSession(), coreConfig: coreConfig))
     }
@@ -27,5 +29,9 @@ class MockAPIClient: APIClient {
             throw cannedClientIDError
         }
         return cannedClientID
+    }
+    
+    override func sendAnalyticsEvent(_ name: String) {
+        postedAnalyticsEvents.append(name)
     }
 }

--- a/UnitTests/TestShared/MockWebAuthenticationSession.swift
+++ b/UnitTests/TestShared/MockWebAuthenticationSession.swift
@@ -6,8 +6,15 @@ class MockWebAuthenticationSession: WebAuthenticationSession {
 
     var cannedResponseURL: URL?
     var cannedErrorResponse: Error?
+    var cannedDidDisplayResult = true
 
-    override func start(url: URL, context: ASWebAuthenticationPresentationContextProviding, completion: @escaping (URL?, Error?) -> Void) {
-        completion(cannedResponseURL, cannedErrorResponse)
+    override func start(
+        url: URL,
+        context: ASWebAuthenticationPresentationContextProviding,
+        sessionDidDisplay: ((Bool) -> Void)? = nil,
+        sessionDidComplete: @escaping (URL?, Error?) -> Void
+    ) {
+        sessionDidDisplay?(cannedDidDisplayResult)
+        sessionDidComplete(cannedResponseURL, cannedErrorResponse)
     }
 }

--- a/UnitTests/TestShared/MockWebAuthenticationSession.swift
+++ b/UnitTests/TestShared/MockWebAuthenticationSession.swift
@@ -11,10 +11,10 @@ class MockWebAuthenticationSession: WebAuthenticationSession {
     override func start(
         url: URL,
         context: ASWebAuthenticationPresentationContextProviding,
-        sessionDidDisplay: ((Bool) -> Void)? = nil,
+        sessionDidDisplay: @escaping (Bool) -> Void,
         sessionDidComplete: @escaping (URL?, Error?) -> Void
     ) {
-        sessionDidDisplay?(cannedDidDisplayResult)
+        sessionDidDisplay(cannedDidDisplayResult)
         sessionDidComplete(cannedResponseURL, cannedErrorResponse)
     }
 }


### PR DESCRIPTION
### Reason for changes

- Add analytics events to each payment method flow; unblock GA release
- Unit tests for analytics to be added in follow up PR - **DTNOR-825**

### Summary of changes
- Add [our pre-defined analytic events](https://paypal.sharepoint.com/:x:/r/sites/BTSDK/_layouts/15/Doc.aspx?sourcedoc=%7BAAA7C353-5744-4F21-AC7D-DF85D8605817%7D&file=Northstar%20Analytics%20Events.xlsx&action=default&mobileredirect=true&cid=1b0afccd-68ab-448f-9760-60ed14df9811) to PayPal Native, PayPal Web, and Card flows
- Other changes
    - Change component name to `ppcpmobilesdk` to pass Lighthouse IQ validations
    - Update `APIClient.sendAnalyticsEvent()` to send analytics in a background task 
    - Remove unused `APIClientDecoder.decode()` function
    - Add `CardClientError.threeDSecureURLError` for invalid 3DS url case

### Checklist

- [X] Added a changelog entry

### Follow ups
- Unit tests  **DTNOR-825**
- Add inspection on 3DS return URL for error details & add corresponding analytic events **DTNOR-827**

### Authors
@scannillo