### PR TITLE
Use Xcode 14 for tests & releases

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -6,22 +6,22 @@ concurrency:
 jobs:
   cocoapods:
     name: CocoaPods
-    runs-on: macos-12
+    runs-on: macos-latest
     steps:
       - name: Check out repository
         uses: actions/checkout@v2
       - name: Use Xcode 14
-        run: sudo xcode-select -switch /Applications/Xcode_14.0.1.app
+        run: sudo xcode-select -switch /Applications/Xcode_14.2.app
       - name: Run pod lib lint
         run: pod lib lint
   spm:
     name: Swift Package Manager
-    runs-on: macos-12
+    runs-on: macos-latest
     steps:
       - name: Check out repository
         uses: actions/checkout@v2
       - name: Use Xcode 14
-        run: sudo xcode-select -switch /Applications/Xcode_14.0.1.app
+        run: sudo xcode-select -switch /Applications/Xcode_14.2.app
       - name: Use current branch
         run: sed -i '' 's/branch = .*/branch = \"'"$GITHUB_HEAD_REF"'\";/' SampleApps/SPMTest/SPMTest.xcodeproj/project.pbxproj
       - name: Run swift package resolve

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -14,8 +14,8 @@ jobs:
         uses: actions/checkout@v2
         with:
           fetch-depth: 0
-      - name: Use Xcode 13
-        run: sudo xcode-select -switch /Applications/Xcode_13.2.1.app
+      - name: Use Xcode 14
+        run: sudo xcode-select -switch /Applications/Xcode_14.2.app
       - name: Check for unreleased section in changelog
         run: grep "## unreleased" CHANGELOG.md || (echo "::error::No unreleased section found in CHANGELOG" && exit 1)
       - name: Set git username and email

--- a/.github/workflows/swiftlint.yml
+++ b/.github/workflows/swiftlint.yml
@@ -10,8 +10,8 @@ jobs:
     steps:
       - name: Check out repository
         uses: actions/checkout@v2
-      - name: Use Xcode 13
-        run: sudo xcode-select -switch /Applications/Xcode_13.2.1.app
+      - name: Use Xcode 14
+        run: sudo xcode-select -switch /Applications/Xcode_14.2.app
       - name: Install Dependencies
         run: bundle install
       - name: Run SwiftLint

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -6,12 +6,12 @@ concurrency:
 jobs:
   unit_test_job:
     name: Unit
-    runs-on: macOS-12
+    runs-on: macOS-latest
     steps:
       - name: Checkout repository
         uses: actions/checkout@v2
-      - name: Use Xcode 13
-        run: sudo xcode-select -switch /Applications/Xcode_14.0.1.app
+      - name: Use Xcode 14
+        run: sudo xcode-select -switch /Applications/Xcode_14.2.app
       - name: Install Dependencies
         run: bundle install
       - name: Run Unit Tests

--- a/Sources/CorePayments/Networking/AnalyticsService.swift
+++ b/Sources/CorePayments/Networking/AnalyticsService.swift
@@ -33,7 +33,7 @@ class AnalyticsService {
     }
         
     func sendEvent(name: String, clientID: String) async {
-        guard let http = http else {
+        guard let http else {
             NSLog("[PayPal SDK]", "Failed to send analytics due to nil HTTP client.")
             return
         }


### PR DESCRIPTION
### Reason for changes

- Our README calls out that we required Xcode 14+
- Let's us take advantage of new Swift 5.7 language features

### Summary of changes

- Bump Xcode version in GH Action workflow scripts
- Use new guard let self syntax

### Checklist

- ~Added a changelog entry~

### Authors
@scannillo 