### PR TITLE
Update import instructions in docs

### DIFF
--- a/docs/CardPayments/README.md
+++ b/docs/CardPayments/README.md
@@ -14,7 +14,6 @@ You will need to set up authorization to use the PayPal Payments SDK.
 Follow the steps in [Get Started](https://developer.paypal.com/api/rest/#link-getstarted) to create a client ID and generate an access token. 
 
 You will need a server integration to create an order and capture the funds using [PayPal Orders v2 API](https://developer.paypal.com/docs/api/orders/v2). 
-For initial setup, the `curl` commands below can be used in place of a server SDK.
 
 ## Add CardPayments Module
 
@@ -22,26 +21,14 @@ For initial setup, the `curl` commands below can be used in place of a server SD
 
 #### Swift Package Manager
 
-In Xcode, add the PayPal SDK as a [package dependency](https://developer.apple.com/documentation/swift_packages/adding_package_dependencies_to_your_app) to your Xcode project. Enter https://github.com/paypal/iOS-SDK as the package URL. Tick the "CardPayments" checkbox to add the CardPayments package to your app.
-
-In your app's source code files, use the following import syntax to include the PayPal CardPayments module:
-
-```swift
-import CardPayments
-```
+In Xcode, add the PayPal SDK as a [package dependency](https://developer.apple.com/documentation/swift_packages/adding_package_dependencies_to_your_app) to your Xcode project. Enter https://github.com/paypal/iOS-SDK as the package URL. Tick the `CardPayments` checkbox to add the Card Payments library to your app.
 
 #### CocoaPods
 
-Include the PayPal pod in your `Podfile`.
+Include the `CardPayments` sub-module in your `Podfile`:
 
 ```ruby
-pod 'PayPal'
-```
-
-In your app's source files, use the following import syntax to include PayPal's Card library:
-
-```swift
-import CardPayments
+pod 'PayPal/CardPayments'
 ```
 
 ### 2. Initiate the CardPayments SDK

--- a/docs/PayPalNativePayments/README.md
+++ b/docs/PayPalNativePayments/README.md
@@ -15,7 +15,6 @@ You will need to set up authorization to use the PayPal Payments SDK.
 Follow the steps in [Get Started](https://developer.paypal.com/api/rest/#link-getstarted) to create a client ID. 
 
 You will need a server integration to create an order to capture funds using the [PayPal Orders v2 API](https://developer.paypal.com/docs/api/orders/v2). 
-For initial setup, the `curl` commands below can be used as a reference for making server-side RESTful API calls.
 
 ## Add PayPal Native Payment Module
 
@@ -23,26 +22,14 @@ For initial setup, the `curl` commands below can be used as a reference for maki
 
 #### Swift Package Manager
 
-In Xcode, add the PayPal SDK as a [package dependency](https://developer.apple.com/documentation/swift_packages/adding_package_dependencies_to_your_app) to your Xcode project. Enter https://github.com/paypal/iOS-SDK as the package URL. Tick the "PayPalNativePayments" checkbox to add the PayPal Native Payments package to your app.
-
-In your app's source code files, use the following import syntax to include the PayPal Native Payments module:
-
-```swift
-import PayPalNativePayments
-```
+In Xcode, add the PayPal SDK as a [package dependency](https://developer.apple.com/documentation/swift_packages/adding_package_dependencies_to_your_app) to your Xcode project. Enter https://github.com/paypal/iOS-SDK as the package URL. Tick the `PayPalNativePayments` checkbox to add the PayPal Native Payments library to your app.
 
 #### CocoaPods
 
-Include the PayPal Native Payment pod in your `Podfile`.
+Include the `PayPalNativePayments` sub-module in your `Podfile`:
 
 ```ruby
-pod 'PayPalNativePayments'
-```
-
-In your app's source files, use the following import syntax to include PayPal's libraries:
-
-```swift
-import PayPalNativePayments
+pod 'PayPal/PayPalNativePayments'
 ```
 
 ### 2. Initiate the Payments SDK

--- a/docs/PayPalWebPayments/README.md
+++ b/docs/PayPalWebPayments/README.md
@@ -14,7 +14,6 @@ You will need to set up authorization to use the PayPal Payments SDK.
 Follow the steps in [Get Started](https://developer.paypal.com/api/rest/#link-getstarted) to create a client ID. 
 
 You will need a server integration to create an order to capture funds using the [PayPal Orders v2 API](https://developer.paypal.com/docs/api/orders/v2). 
-For initial setup, the `curl` commands below can be used as a reference for making server-side RESTful API calls.
 
 ## Add PayPal Web Payments Module
 
@@ -22,26 +21,14 @@ For initial setup, the `curl` commands below can be used as a reference for maki
 
 #### Swift Package Manager
 
-In Xcode, add the PayPal SDK as a [package dependency](https://developer.apple.com/documentation/swift_packages/adding_package_dependencies_to_your_app) to your Xcode project. Enter https://github.com/paypal/iOS-SDK as the package URL. Tick the "PayPalWebPayments" checkbox to add the PayPal Web Payments package to your app.
-
-In your app's source code files, use the following import syntax to include the PayPal Web Payments module:
-
-```swift
-import PayPalWebPayments
-```
+In Xcode, add the PayPal SDK as a [package dependency](https://developer.apple.com/documentation/swift_packages/adding_package_dependencies_to_your_app) to your Xcode project. Enter https://github.com/paypal/iOS-SDK as the package URL. Tick the `PayPalWebPayments` checkbox to add the PayPal Web Payments library to your app.
 
 #### CocoaPods
 
-Include the PayPal Web Payments pod in your `Podfile`.
+Include the `PayPalWebPayments` sub-module in your `Podfile`:
 
 ```ruby
-pod 'PayPalWebPayments'
-```
-
-In your app's source files, use the following import syntax to include PayPal's libraries:
-
-```swift
-import PayPalWebPayments
+pod 'PayPal/PayPalWebPayments'
 ```
 
 ### 2. Initiate the Payments SDK

--- a/docs/PaymentButtons/README.md
+++ b/docs/PaymentButtons/README.md
@@ -8,26 +8,14 @@
 
 #### Swift Package Manager
 
-In Xcode, follow the guide to [add package dependencies to your app](https://developer.apple.com/documentation/swift_packages/adding_package_dependencies_to_your_app) and enter https://github.com/paypal/iOS-SDK as the repository URL. Select the checkboxes for each specific PayPal library you wish to include in your project.
-
-In your app's source files, use the following import syntax to include PayPal's libraries:
-
-```swift
-import PaymentButtons
-```
+In Xcode, follow the guide to [add package dependencies to your app](https://developer.apple.com/documentation/swift_packages/adding_package_dependencies_to_your_app) and enter https://github.com/paypal/iOS-SDK as the repository URL. Tick the `PaymentButtons` checkbox to add the Payment Buttons library to your app.
 
 #### CocoaPods
 
-Include the PayPal pod in your `Podfile`.
+Include the `PaymentButtons` sub-mobule in your `Podfile`.
 
 ```ruby
-pod 'PayPal'
-```
-
-In your app's source files, use the following import syntax to include PayPal's libraries:
-
-```swift
-import PaymentButtons
+pod 'PayPal/PaymentButtons'
 ```
 
 ### 2. Render PayPal buttons


### PR DESCRIPTION
### Reason for changes

- Our docs had some inaccurate `import` statement instructions, which differ per package manager.
    - These were revealed via GMS/GPS feedback

### Summary of changes

- Remove source code `import` instructions. 
    - This is not something we include in Braintree docs. Merchants using each package manager should know (and defer to package manager documentation) for how to import modules into source code.
- Update incorrect Podfile snippets
- Use consistent wording for SPM instructions

### Checklist

- ~Added a changelog entry~

### Authors
@scannillo