### PR TITLE
Remove always-nil shipping address fields

### DIFF
--- a/Sources/PayPalNativePayments/PayPalNativeShippingAddress.swift
+++ b/Sources/PayPalNativePayments/PayPalNativeShippingAddress.swift
@@ -6,9 +6,6 @@ public struct PayPalNativeShippingAddress {
     
     /// The ID of the shipping address
     public internal(set) var addressID: String?
-
-    /// The full name of the recipient for the shipping address
-    public internal(set) var fullName: String?
     
     /// The highest level sub-division in a country, which is usually a province, state, or ISO-3166-2 subdivision.
     /// Format for postal delivery. For example, `CA` and not `California`. Value, by country, is:
@@ -19,19 +16,9 @@ public struct PayPalNativeShippingAddress {
     /// - Switzerland: A kanton.
     public internal(set) var adminArea1: String?
 
-    /// The city, town, or village. Smaller than `adminArea1`.
+    /// The city, town, or village.
     public internal(set) var adminArea2: String?
 
-    /// A sub-locality, suburb, neighborhood, or district. Smaller than `adminArea2`. Value is:
-    /// - Brazil: Suburb, bairro, or neighborhood.
-    /// - India: Sub-locality or district. Street name information is not always available but a sub-locality or district can be a very small area.
-    public internal(set) var adminArea3: String?
-
-    /// The neighborhood, ward, or district. Smaller than `adminArea3` or sub-locality. Value is:
-    /// - The postal sorting code for Guernsey and many French territories, such as French Guiana.
-    /// - The fine-grained administrative levels in China.
-    public internal(set) var adminArea4: String?
-    
     /// The postal code, which is the zip code or equivalent. Typically required for countries with a postal code or an equivalent.
     public internal(set) var postalCode: String?
 
@@ -41,11 +28,8 @@ public struct PayPalNativeShippingAddress {
     
     init(_ shippingChangeAddress: PayPalCheckout.ShippingChangeAddress) {
         self.addressID = shippingChangeAddress.addressID
-        self.fullName = shippingChangeAddress.fullName
         self.adminArea1 = shippingChangeAddress.adminArea1
         self.adminArea2 = shippingChangeAddress.adminArea2
-        self.adminArea3 = shippingChangeAddress.adminArea3
-        self.adminArea4 = shippingChangeAddress.adminArea4
         self.postalCode = shippingChangeAddress.postalCode
         self.countryCode = shippingChangeAddress.countryCode
     }

--- a/UnitTests/PayPalNativePaymentsTests/PayPalNativeShippingAddress_Tests.swift
+++ b/UnitTests/PayPalNativePaymentsTests/PayPalNativeShippingAddress_Tests.swift
@@ -7,22 +7,16 @@ class PayPalNativeShippingAddress_Tests: XCTestCase {
     func testInit_convertsFromNXOTypeCorrectly() {
         let nxoShippingAddress = PayPalCheckout.ShippingChangeAddress(
             addressID: "fake-address-id",
-            fullName: "fake-full-name",
             adminArea1: "fake-admin-area-1",
             adminArea2: "fake-admin-area-2",
-            adminArea3: "fake-admin-area-3",
-            adminArea4: "fake-admin-area-4",
             postalCode: "fake-postal-code",
             countryCode: "fake-country-code"
         )
         
         let sut = PayPalNativeShippingAddress(nxoShippingAddress)
         XCTAssertEqual(sut.addressID, "fake-address-id")
-        XCTAssertEqual(sut.fullName, "fake-full-name")
         XCTAssertEqual(sut.adminArea1, "fake-admin-area-1")
         XCTAssertEqual(sut.adminArea2, "fake-admin-area-2")
-        XCTAssertEqual(sut.adminArea3, "fake-admin-area-3")
-        XCTAssertEqual(sut.adminArea4, "fake-admin-area-4")
         XCTAssertEqual(sut.postalCode, "fake-postal-code")
         XCTAssertEqual(sut.countryCode, "fake-country-code")
     }


### PR DESCRIPTION
### Reason for changes

- The PP NXO SDK always returns `nil` for the following fields:
    - `PayPalCheckout.ShippingChangeAddress.adminArea3`
    - `PayPalCheckout.ShippingChangeAddress.adminArea4`
    - `PayPalCheckout.ShippingChangeAddress.fullName`
- NXO doesn't currently set these values, to match the [JS SDK](https://developer.paypal.com/docs/regional/th/checkout/integration-features/shipping-callback/)

### Summary of changes

- Remove these values from `PayPalNativeShippingAddress`, until the NXO SDK properly sets them

### Checklist

- ~Added a changelog entry~ No changelog needed since unreleased

### Authors
@scannillo 