### PR TITLE
Address GMS feedback

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,7 +3,7 @@
 
 ## unreleased
 * Card
-  * Rename `Card.init()` param from to `cardholderName`
+  * Rename `Card.init()` parameter from `cardHolderName` to `cardholderName`
   * Remove unnecessary `Card.expiry` property
 
 ## 0.0.7 (2023-03-28)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,11 @@
 
 # PayPal iOS SDK Release Notes
 
+## unreleased
+* Card
+  * Rename `Card.init()` param from to `cardholderName`
+  * Remove unnecessary `Card.expiry` property
+
 ## 0.0.7 (2023-03-28)
 * PayPalNativePayments
   * Update `PayPalNativeCheckoutDelegate.paypal(_:didFinishWithResult:)` to use `PayPalNativeCheckoutResult` instead of `PayPalCheckout.Approval` type.

--- a/Sources/CardPayments/Models/Card.swift
+++ b/Sources/CardPayments/Models/Card.swift
@@ -14,10 +14,10 @@ public struct Card: Encodable {
     /// The primary account number (PAN) for the payment card.
     public var number: String
 
-    /// The card expiration month in `MM` format
+    /// The 2-digit card expiration month in `MM` format
     public var expirationMonth: String
 
-    /// The card expiration year in `YYYY` format
+    /// The 4-digit card expiration year in `YYYY` format
     public var expirationYear: String
 
     /// The three- or four-digit security code of the card. Also known as the CVV, CVC, CVN, CVE, or CID.
@@ -41,14 +41,14 @@ public struct Card: Encodable {
         expirationMonth: String,
         expirationYear: String,
         securityCode: String,
-        cardHolderName: String? = nil,
+        cardholderName: String? = nil,
         billingAddress: Address? = nil
     ) {
         self.number = number
         self.expirationMonth = expirationMonth
         self.expirationYear = expirationYear
         self.securityCode = securityCode
-        self.cardholderName = cardHolderName
+        self.cardholderName = cardholderName
         self.billingAddress = billingAddress
     }
 

--- a/Sources/CardPayments/Models/Card.swift
+++ b/Sources/CardPayments/Models/Card.swift
@@ -29,11 +29,6 @@ public struct Card: Encodable {
     /// Optional. The billing address
     public var billingAddress: Address?
 
-    /// The expiration year and month, in ISO-8601 `YYYY-MM` date format.
-    public var expiry: String {
-        "\(expirationYear)-\(expirationMonth)"
-    }
-
     internal var attributes: Attributes?
 
     public init(
@@ -55,7 +50,6 @@ public struct Card: Encodable {
     public func encode(to encoder: Encoder) throws {
         var container = encoder.container(keyedBy: CodingKeys.self)
         try container.encode(number, forKey: .number)
-        try container.encode(expiry, forKey: .expiry)
         try container.encode(securityCode, forKey: .securityCode)
         try container.encode(cardholderName, forKey: .cardholderName)
         try container.encode(billingAddress, forKey: .billingAddress)

--- a/Sources/CardPayments/Models/Card.swift
+++ b/Sources/CardPayments/Models/Card.swift
@@ -1,5 +1,6 @@
 import Foundation
 
+/// Represents raw credit or debit card data provided by the customer.
 public struct Card: Encodable {
 
     enum CodingKeys: String, CodingKey {

--- a/UnitTests/CardPaymentsTests/Card_Tests.swift
+++ b/UnitTests/CardPaymentsTests/Card_Tests.swift
@@ -20,7 +20,7 @@ class Card_Tests: XCTestCase {
             expirationMonth: "01",
             expirationYear: "2031",
             securityCode: "123",
-            cardHolderName: "Test Name",
+            cardholderName: "Test Name",
             billingAddress: Address(
                 addressLine1: "Test Line 1",
                 addressLine2: "Test Line 2",

--- a/UnitTests/CardPaymentsTests/Card_Tests.swift
+++ b/UnitTests/CardPaymentsTests/Card_Tests.swift
@@ -3,17 +3,6 @@ import XCTest
 
 class Card_Tests: XCTestCase {
 
-    func testCard_setsProperExpiryStringFormat() {
-        let card = Card(
-            number: "4111111111111111",
-            expirationMonth: "01",
-            expirationYear: "2031",
-            securityCode: "123"
-        )
-
-        XCTAssertEqual(card.expiry, "2031-01")
-    }
-
     func testCard_encodedToCorrectFormat() throws {
         var card = Card(
             number: "4111111111111111",
@@ -40,7 +29,7 @@ class Card_Tests: XCTestCase {
 
         // swiftlint:disable line_length
         let expectedCardJSON = """
-        {"number":"4111111111111111","billingAddress":{"admin_area_2":"Test City","addressLine1":"Test Line 1","countryCode":"Test Country","addressLine2":"Test Line 2","admin_area_1":"Test State","postalCode":"Test Zip"},"securityCode":"123","name":"Test Name","attributes":{"verification":{"method":"SCA_ALWAYS"}},"expiry":"2031-01"}
+        {"number":"4111111111111111","billingAddress":{"admin_area_2":"Test City","addressLine1":"Test Line 1","countryCode":"Test Country","addressLine2":"Test Line 2","admin_area_1":"Test State","postalCode":"Test Zip"},"securityCode":"123","name":"Test Name","attributes":{"verification":{"method":"SCA_ALWAYS"}}}
         """
         // swiftlint:enable line_length
 

--- a/UnitTests/CardPaymentsTests/ConfirmPaymentSourceRequest_Tests.swift
+++ b/UnitTests/CardPaymentsTests/ConfirmPaymentSourceRequest_Tests.swift
@@ -37,8 +37,7 @@ class ConfirmPaymentSourceRequest_Tests: XCTestCase {
                                 "verification": {
                                     "method": "SCA_WHEN_REQUIRED"
                                 }
-                            },
-                            "expiry": "2024-11"
+                            }
                         }
                     }
                 }

--- a/docs/CardPayments/README.md
+++ b/docs/CardPayments/README.md
@@ -85,7 +85,7 @@ Create a `Card` object containing the user's card details.
 let card = Card(
     number: "4111111111111111",
     expirationMonth: "01",
-    expirationYear: "25",
+    expirationYear: "2025",
     securityCode: "123",
     cardholderName: "Jane Smith",
     billingAddress: Address(
@@ -105,7 +105,7 @@ Attach the card and the order ID from [step 4](#4-create-an-order) to a `CardReq
 let cardRequest = CardRequest(
     orderID: "<ORDER_ID>",
     card: card,
-    sca: .always // default value is .whenRequired
+    sca: .scaAlways // default value is .scaWhenRequired
 )
 ```
 


### PR DESCRIPTION
### Reason for changes

- GMS (Global Merchant Services) gave us some helpful feedback when integrating with our SDKs. Their feedback was summarized [here](https://paypal.sharepoint.com/:w:/r/sites/BTSDK/_layouts/15/doc.aspx?sourcedoc=%7B21815a12-3b59-4648-9a32-263dc4747dea%7D&action=edit).
    - This PR addresses several of their callouts.

### Summary of changes

- Clarify that `Card` requires a 4 digit year and 2 digit month. Update docs accordingly.
- Add missing top-level `Card` docstring.
- Remove `Card.expiry` field to match Android.
- Rename `cardHolderName` --> `cardholderName` to match Android and docs snippets.
- Fix `sca` enum typo in docs.

### Checklist

- [X] Added a changelog entry

### Authors
@scannillo 