### PR TITLE
Disable lint rules for testing

### DIFF
--- a/Sources/CorePayments/CoreConfig.swift
+++ b/Sources/CorePayments/CoreConfig.swift
@@ -5,7 +5,7 @@ import Foundation
 public struct CoreConfig {
 
     public let environment: Environment
-    public let accessToken: String
+    public let accessToken: String!
 
     public init(accessToken: String, environment: Environment) {
         self.environment = environment

--- a/Sources/CorePayments/CoreConfig.swift
+++ b/Sources/CorePayments/CoreConfig.swift
@@ -5,7 +5,7 @@ import Foundation
 public struct CoreConfig {
 
     public let environment: Environment
-    public let accessToken: String!
+    public let accessToken: String
 
     public init(accessToken: String, environment: Environment) {
         self.environment = environment

--- a/UnitTests/.swiftlint.yml
+++ b/UnitTests/.swiftlint.yml
@@ -1,12 +1,6 @@
 # Reference: https://github.com/realm/SwiftLint
 # Required Swiftlint Version
 # swiftlint_version: 0.39.2
-
-# Paths to include in lint
-included:
-  - Demo
-  - Sources
-  - UnitTests
  
 disabled_rules:
   - todo

--- a/UnitTests/.swiftlint.yml
+++ b/UnitTests/.swiftlint.yml
@@ -1,0 +1,19 @@
+# Reference: https://github.com/realm/SwiftLint
+# Required Swiftlint Version
+# swiftlint_version: 0.39.2
+
+# Paths to include in lint
+included:
+  - Demo
+  - Sources
+  - UnitTests
+ 
+disabled_rules:
+  - todo
+  - type_name # tests will have have the format <SUT>_Tests
+  - xctfail_message
+  - implicitly_unwrapped_optional
+  - force_unwrapping
+  - force_cast
+  - force_try
+  - function_parameter_count

--- a/UnitTests/PayPalNativePaymentsTests/MockNativeCheckoutProvider.swift
+++ b/UnitTests/PayPalNativePaymentsTests/MockNativeCheckoutProvider.swift
@@ -15,7 +15,6 @@ class MockNativeCheckoutProvider: NativeCheckoutStartable {
     var onError: CheckoutConfig.ErrorCallback?
 
     // todo: implemenet cases for other callbacks
-    // swiftlint:disable function_parameter_count
     func start(
         presentingViewController: UIViewController?,
         createOrder: CheckoutConfig.CreateOrderCallback?,
@@ -28,7 +27,6 @@ class MockNativeCheckoutProvider: NativeCheckoutStartable {
         self.onCancel = onCancel
         self.onError = onError
     }
-    // swiftlint:enable function_parameter_count
 
     func triggerCancel() {
         onCancel?()

--- a/UnitTests/PayPalWebPaymentsTests/PayPalWebCheckoutClient_Tests.swift
+++ b/UnitTests/PayPalWebPaymentsTests/PayPalWebCheckoutClient_Tests.swift
@@ -6,12 +6,10 @@ import AuthenticationServices
 
 class PayPalClient_Tests: XCTestCase {
     
-    // swiftlint:disable implicitly_unwrapped_optional
     var config: CoreConfig!
     var mockWebAuthenticationSession: MockWebAuthenticationSession!
     var payPalClient: PayPalWebCheckoutClient!
     var mockAPIClient: MockAPIClient!
-    // swiftlint:enable implicitly_unwrapped_optional
     
     override func setUp() {
         super.setUp()
@@ -110,7 +108,6 @@ class PayPalClient_Tests: XCTestCase {
     }
 
     func testpayPalCheckoutReturnURL_returnsCorrectURL() {
-        // swiftlint:disable:next force_unwrapping
         let url = URL(string: "https://sandbox.paypal.com/checkoutnow?token=1234")!
         let checkoutURL = payPalClient.payPalCheckoutReturnURL(payPalCheckoutURL: url)
 

--- a/UnitTests/PaymentsCoreTests/APIClient_Tests.swift
+++ b/UnitTests/PaymentsCoreTests/APIClient_Tests.swift
@@ -2,7 +2,6 @@ import XCTest
 @testable import CorePayments
 @testable import TestShared
 
-// swiftlint:disable force_unwrapping implicitly_unwrapped_optional
 class APIClient_Tests: XCTestCase {
 
     // MARK: - Helper Properties
@@ -48,4 +47,3 @@ class APIClient_Tests: XCTestCase {
         XCTAssertEqual(response, "sample_id")
     }
 }
-// swiftlint:enable force_unwrapping implicitly_unwrapped_optional

--- a/UnitTests/PaymentsCoreTests/AnalyticsEventRequest_Tests.swift
+++ b/UnitTests/PaymentsCoreTests/AnalyticsEventRequest_Tests.swift
@@ -1,7 +1,6 @@
 import XCTest
 @testable import CorePayments
 
-// swiftlint:disable force_unwrapping implicitly_unwrapped_optional force_try force_cast
 class AnalyticsEventRequest_Tests: XCTestCase {
     
     var fakeAnalyticsEventData: AnalyticsEventData!
@@ -68,4 +67,3 @@ extension String {
         self.range(of: regex, options: .regularExpression) != nil
     }
 }
-// swiftlint:enable force_unwrapping implicitly_unwrapped_optional force_try force_cast

--- a/UnitTests/PaymentsCoreTests/AnalyticsService_Tests.swift
+++ b/UnitTests/PaymentsCoreTests/AnalyticsService_Tests.swift
@@ -2,7 +2,6 @@ import XCTest
 @testable import CorePayments
 @testable import TestShared
 
-// swiftlint:disable force_unwrapping implicitly_unwrapped_optional force_cast
 class AnalyticsService_Tests: XCTestCase {
 
     // MARK: - Helper properties
@@ -132,4 +131,3 @@ class AnalyticsService_Tests: XCTestCase {
         XCTAssertTrue(analyticsService1 === analyticsService2)
     }
 }
-// swiftlint:enable force_unwrapping implicitly_unwrapped_optional force_cast

--- a/UnitTests/PaymentsCoreTests/EligibilityAPI_Tests.swift
+++ b/UnitTests/PaymentsCoreTests/EligibilityAPI_Tests.swift
@@ -7,13 +7,11 @@ class EligibilityAPI_Tests: XCTestCase {
     let mockClientID = "mockClientId"
     let mockAccessToken = "mockAccessToken"
     let mockURLSession = MockURLSession()
-    // swiftlint:disable implicitly_unwrapped_optional
     var coreConfig: CoreConfig!
     var graphQLClient: GraphQLClient!
     var eligibilityAPI: EligibilityAPI!
     var apiClient: MockAPIClient!
 
-    // swiftlint:enable implicitly_unwrapped_optional
     override func setUp() {
         super.setUp()
         coreConfig = CoreConfig(accessToken: mockAccessToken, environment: .sandbox)
@@ -44,7 +42,6 @@ class EligibilityAPI_Tests: XCTestCase {
     }
     func testCheckEligibilityErrorResponse() async throws {
         mockURLSession.cannedURLResponse = HTTPURLResponse(
-            // swiftlint:disable:next force_unwrapping
             url: URL(string: "www.fake.com")!,
             statusCode: 200,
             httpVersion: "1",

--- a/UnitTests/PaymentsCoreTests/GraphQLClient_Tests.swift
+++ b/UnitTests/PaymentsCoreTests/GraphQLClient_Tests.swift
@@ -6,16 +6,15 @@ class GraphQLClient_Tests: XCTestCase {
 
     let mockClientID = "mockClientId"
     let mockAccessToken = "mockAccessToken"
+    
     // MARK: - Helper Properties
-    // swiftlint:disable implicitly_unwrapped_optional
-    // swiftlint:disable:next force_unwrapping
+    
     let successURLResponse = HTTPURLResponse(url: URL(string: "www.test.com")!, statusCode: 200, httpVersion: "https", headerFields: [:])
     let fakeRequest = FakeRequest()
     var config: CoreConfig!
     var mockURLSession: MockURLSession!
     var graphQLClient: GraphQLClient!
     var graphQLQuery: GraphQLQuery!
-    // swiftlint:enable implicitly_unwrapped_optional
 
     // MARK: - Test lifecycle
 
@@ -46,7 +45,6 @@ class GraphQLClient_Tests: XCTestCase {
 
 
         mockURLSession.cannedURLResponse = HTTPURLResponse(
-            // swiftlint:disable:next force_unwrapping
             url: URL(string: "www.fake.com")!,
             statusCode: 200,
             httpVersion: "1",
@@ -68,7 +66,6 @@ class GraphQLClient_Tests: XCTestCase {
 
 
         mockURLSession.cannedURLResponse = HTTPURLResponse(
-            // swiftlint:disable:next force_unwrapping
             url: URL(string: "www.fake.com")!,
             statusCode: 200,
             httpVersion: "1",

--- a/UnitTests/PaymentsCoreTests/HTTP_Tests.swift
+++ b/UnitTests/PaymentsCoreTests/HTTP_Tests.swift
@@ -2,7 +2,6 @@ import XCTest
 @testable import CorePayments
 @testable import TestShared
 
-// swiftlint:disable force_unwrapping implicitly_unwrapped_optional
 class HTTP_Tests: XCTestCase {
     
     // MARK: - Helper Properties
@@ -182,4 +181,3 @@ class HTTP_Tests: XCTestCase {
         XCTAssertEqual(decodedCacheData.fakeParam, "cached_value2")
     }
 }
-// swiftlint:enable force_unwrapping implicitly_unwrapped_optional

--- a/UnitTests/TestShared/MockAPIClient.swift
+++ b/UnitTests/TestShared/MockAPIClient.swift
@@ -19,7 +19,6 @@ class MockAPIClient: APIClient {
         if let cannedFetchError {
             throw cannedFetchError
         }
-        // swiftlint:disable:next force_unwrapping
         let cannedData = cannedJSONResponse!.data(using: String.Encoding.utf8)!
         return try APIClientDecoder().decode(T.self, from: cannedData)
     }

--- a/fastlane/Fastfile
+++ b/fastlane/Fastfile
@@ -35,7 +35,6 @@ platform :ios do
   lane :lint do
     swiftlint(
       mode: :lint,
-      config_file: ".swiftlint.yml",
       raise_if_swiftlint_error: true,
       strict: true
     )


### PR DESCRIPTION
### Reason for changes

We disable some specific lint rules for unit tests
Ticket: [DTNOR-628](https://paypal.atlassian.net/browse/DTNOR-628)

### Summary of changes

- Add .swfitliny.yaml to UnitTest folder to disable rules under that specific path
- Add rules to ignore
- Remove "config_file" from Fastlane, so that it picks up both swiftlint.ymls

### Checklist

- [ ] Added a changelog entry

### Authors
> List GitHub usernames for everyone who contributed to this pull request.
@jcnoriega 
- 