### PR TITLE
Send `orderID` instead of `sessionID` to FPTI analytics

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@
 * Card
   * Rename `Card.init()` parameter from `cardHolderName` to `cardholderName`
   * Remove unnecessary `Card.expiry` property
+* CorePayments
+  * Send `orderID` instead of `sessionID` for analytics
 
 ## 0.0.7 (2023-03-28)
 * PayPalNativePayments

--- a/Sources/CardPayments/CardClient.swift
+++ b/Sources/CardPayments/CardClient.swift
@@ -11,6 +11,7 @@ public class CardClient: NSObject {
     private let apiClient: APIClient
     private let config: CoreConfig
     private let webAuthenticationSession: WebAuthenticationSession
+    private var analyticsService: AnalyticsService?
 
     /// Initialize a CardClient to process card payment
     /// - Parameter config: The CoreConfig object
@@ -35,25 +36,19 @@ public class CardClient: NSObject {
     /// - Returns: Card result
     /// - Throws: PayPalSDK error if approve order could not complete successfully
     public func approveOrder(request: CardRequest) {
-        apiClient.sendAnalyticsEvent("card-payments:3ds:started")
+        analyticsService = AnalyticsService(coreConfig: config, orderID: request.orderID)
+        analyticsService?.sendEvent("card-payments:3ds:started")
         Task {
-            do {
-                _ = try await apiClient.fetchCachedOrRemoteClientID()
-            } catch {
-                notifyFailure(with: CorePaymentsError.clientIDNotFoundError)
-                return
-            }
-            
             do {
                 let confirmPaymentRequest = try ConfirmPaymentSourceRequest(accessToken: config.accessToken, cardRequest: request)
                 let (result) = try await apiClient.fetch(request: confirmPaymentRequest)
                 
                 if let url: String = result.links?.first(where: { $0.rel == "payer-action" })?.href {
-                    apiClient.sendAnalyticsEvent("card-payments:3ds:confirm-payment-source:challenge-required")
+                    analyticsService?.sendEvent("card-payments:3ds:confirm-payment-source:challenge-required")
                     
                     startThreeDSecureChallenge(url: url, orderId: result.id)
                 } else {
-                    apiClient.sendAnalyticsEvent("card-payments:3ds:confirm-payment-source:succeeded")
+                    analyticsService?.sendEvent("card-payments:3ds:confirm-payment-source:succeeded")
                     
                     let cardResult = CardResult(
                         orderID: result.id,
@@ -63,7 +58,7 @@ public class CardClient: NSObject {
                     notifySuccess(for: cardResult)
                 }
             } catch let error as CoreSDKError {
-                apiClient.sendAnalyticsEvent("card-payments:3ds:confirm-payment-source:failed")
+                analyticsService?.sendEvent("card-payments:3ds:confirm-payment-source:failed")
                 notifyFailure(with: error)
             } catch {
             }
@@ -86,9 +81,9 @@ public class CardClient: NSObject {
             context: self,
             sessionDidDisplay: { [weak self] didDisplay in
                 if didDisplay {
-                    self?.apiClient.sendAnalyticsEvent("card-payments:3ds:challenge-presentation:succeeded")
+                    self?.analyticsService?.sendEvent("card-payments:3ds:challenge-presentation:succeeded")
                 } else {
-                    self?.apiClient.sendAnalyticsEvent("card-payments:3ds:challenge-presentation:failed")
+                    self?.analyticsService?.sendEvent("card-payments:3ds:challenge-presentation:failed")
                 }
             },
             sessionDidComplete: { _, error in
@@ -121,27 +116,27 @@ public class CardClient: NSObject {
                     status: result.status,
                     paymentSource: result.paymentSource
                 )
-                self.apiClient.sendAnalyticsEvent("card-payments:3ds:get-order-info:succeeded")
+                self.analyticsService?.sendEvent("card-payments:3ds:get-order-info:succeeded")
                 notifySuccess(for: cardResult)
             } catch let error as CoreSDKError {
-                self.apiClient.sendAnalyticsEvent("card-payments:3ds:get-order-info:failed")
+                self.analyticsService?.sendEvent("card-payments:3ds:get-order-info:failed")
                 notifyFailure(with: error)
             }
         }
     }
 
     private func notifySuccess(for result: CardResult) {
-        apiClient.sendAnalyticsEvent("card-payments:3ds:succeeded")
+        analyticsService?.sendEvent("card-payments:3ds:succeeded")
         delegate?.card(self, didFinishWithResult: result)
     }
 
     private func notifyFailure(with error: CoreSDKError) {
-        apiClient.sendAnalyticsEvent("card-payments:3ds:failed")
+        analyticsService?.sendEvent("card-payments:3ds:failed")
         delegate?.card(self, didFinishWithError: error)
     }
 
     private func notifyCancellation() {
-        apiClient.sendAnalyticsEvent("card-payments:3ds:challenge:user-canceled")
+        analyticsService?.sendEvent("card-payments:3ds:challenge:user-canceled")
         delegate?.cardDidCancel(self)
     }
 }

--- a/Sources/CorePayments/AnalyticsEventData.swift
+++ b/Sources/CorePayments/AnalyticsEventData.swift
@@ -18,7 +18,7 @@ struct AnalyticsEventData: Encodable {
         case clientOS = "client_os"
         case component = "comp"
         case deviceManufacturer = "device_manufacturer"
-        case environment = "merchant_app_environment"
+        case environment = "merchant_sdk_env"
         case eventName = "event_name"
         case eventSource = "event_source"
         case orderID = "order_id"

--- a/Sources/CorePayments/AnalyticsEventData.swift
+++ b/Sources/CorePayments/AnalyticsEventData.swift
@@ -21,12 +21,12 @@ struct AnalyticsEventData: Encodable {
         case environment = "merchant_app_environment"
         case eventName = "event_name"
         case eventSource = "event_source"
+        case orderID = "order_id"
         case packageManager = "ios_package_manager"
         case isSimulator = "is_simulator"
         case merchantAppVersion = "mapv"
         case deviceModel = "mobile_device_model"
         case platform = "platform"
-        case sessionID = "session_id"
         case timestamp = "t"
         case tenantName = "tenant_name"
     }
@@ -50,6 +50,8 @@ struct AnalyticsEventData: Encodable {
     let eventSource = "mobile-native"
     
     let environment: String
+    
+    let orderID: String
 
     let packageManager: String = {
         #if COCOAPODS
@@ -84,17 +86,15 @@ struct AnalyticsEventData: Encodable {
 
     let platform = "iOS"
 
-    let sessionID: String
-
     let timestamp = String(Date().timeIntervalSince1970 * 1000)
 
     let tenantName = "PayPal"
     
-    init(environment: String, eventName: String, clientID: String, sessionID: String) {
+    init(environment: String, eventName: String, clientID: String, orderID: String) {
         self.environment = environment
         self.eventName = eventName
         self.clientID = clientID
-        self.sessionID = sessionID
+        self.orderID = orderID
     }
     
     func encode(to encoder: Encoder) throws {
@@ -117,7 +117,7 @@ struct AnalyticsEventData: Encodable {
         try eventParameters.encode(merchantAppVersion, forKey: .merchantAppVersion)
         try eventParameters.encode(deviceModel, forKey: .deviceModel)
         try eventParameters.encode(platform, forKey: .platform)
-        try eventParameters.encode(sessionID, forKey: .sessionID)
+        try eventParameters.encode(orderID, forKey: .orderID)
         try eventParameters.encode(timestamp, forKey: .timestamp)
         try eventParameters.encode(tenantName, forKey: .tenantName)
     }

--- a/Sources/CorePayments/Networking/APIClient.swift
+++ b/Sources/CorePayments/Networking/APIClient.swift
@@ -47,14 +47,14 @@ public class APIClient {
     /// Sends analytics event to https://api.paypal.com/v1/tracking/events/ via a background task.
     /// - Parameter name: Event name string used to identify this unique event in FPTI.
     public func sendAnalyticsEvent(_ name: String) {
-        Task(priority: .background) {
-            do {
-                let clientID = try await fetchCachedOrRemoteClientID()
-                let analyticsService = AnalyticsService.sharedInstance(http: http)
-                await analyticsService.sendEvent(name: name, clientID: clientID)
-            } catch {
-                NSLog("[PayPal SDK] Failed to send analytics due to missing clientID: %@", error.localizedDescription.debugDescription)
-            }
-        }
+//        Task(priority: .background) {
+//            do {
+//                let clientID = try await fetchCachedOrRemoteClientID()
+//                let analyticsService = AnalyticsService.sharedInstance(http: http)
+//                await analyticsService.sendEvent(name: name, clientID: clientID)
+//            } catch {
+//                NSLog("[PayPal SDK] Failed to send analytics due to missing clientID: %@", error.localizedDescription.debugDescription)
+//            }
+//        }
     }
 }

--- a/Sources/CorePayments/Networking/APIClient.swift
+++ b/Sources/CorePayments/Networking/APIClient.swift
@@ -41,20 +41,4 @@ public class APIClient {
         let (response) = try await http.performRequest(request, withCaching: true)
         return response.clientID
     }
-    
-    /// :nodoc: This method is exposed for internal PayPal use only. Do not use. It is not covered by Semantic Versioning and may change or be removed at any time.
-    ///
-    /// Sends analytics event to https://api.paypal.com/v1/tracking/events/ via a background task.
-    /// - Parameter name: Event name string used to identify this unique event in FPTI.
-    public func sendAnalyticsEvent(_ name: String) {
-//        Task(priority: .background) {
-//            do {
-//                let clientID = try await fetchCachedOrRemoteClientID()
-//                let analyticsService = AnalyticsService.sharedInstance(http: http)
-//                await analyticsService.sendEvent(name: name, clientID: clientID)
-//            } catch {
-//                NSLog("[PayPal SDK] Failed to send analytics due to missing clientID: %@", error.localizedDescription.debugDescription)
-//            }
-//        }
-    }
 }

--- a/Sources/CorePayments/Networking/AnalyticsService.swift
+++ b/Sources/CorePayments/Networking/AnalyticsService.swift
@@ -1,55 +1,57 @@
 import Foundation
 
 /// Constructs `AnalyticsEventData` models and sends FPTI analytics events.
-class AnalyticsService {
+public class AnalyticsService {
     
     // MARK: - Internal Properties
-
-    private static let instance = AnalyticsService()
     
-    private var sessionID = UUID().uuidString.replacingOccurrences(of: "-", with: "")
-    
-    private var http: HTTP? {
-        // This property observer generates a new `sessionID` if the `accessToken`
-        // injected into the `AnalyticsSingleton` ever changes.
-        willSet {
-            if newValue?.coreConfig.accessToken != http?.coreConfig.accessToken {
-                sessionID = UUID().uuidString.replacingOccurrences(of: "-", with: "")
-            }
-        }
-    }
+    private let coreConfig: CoreConfig
+    private let http: HTTP
+    private let orderID: String
         
     // MARK: - Initializer
     
     /// This initializer is private to enforce the singleton pattern. An instance of `AnalyticsService` cannot be instantiated outside this file.
-    private init() { }
-    
-    // MARK: - Internal Methods
-    
-    /// Used to access the singleton instance of `AnalyticsService`.
-    static func sharedInstance(http: HTTP) -> AnalyticsService {
-        instance.http = http
-        return instance
+    public init(coreConfig: CoreConfig, orderID: String) {
+        self.coreConfig = coreConfig
+        self.http = HTTP(coreConfig: coreConfig)
+        self.orderID = orderID
+        // TODO: - Make init async, or throw if clientID not found
     }
+    
+    // MARK: - Public Methods
         
-    func sendEvent(name: String, clientID: String) async {
-        guard let http else {
-            NSLog("[PayPal SDK]", "Failed to send analytics due to nil HTTP client.")
-            return
+    public func sendEvent(_ name: String) {
+        Task {
+            do {
+                let clientID = try await fetchCachedOrRemoteClientID()
+            } catch {
+                NSLog("[PayPal SDK] Failed to send analytics due to missing clientID: %@", error.localizedDescription.debugDescription)
+            }
         }
+        
+        // TODO: - block sending event until clientID fetched
         
         let eventData = AnalyticsEventData(
             environment: http.coreConfig.environment.toString,
             eventName: name,
-            clientID: clientID,
-            sessionID: sessionID
+            clientID: "clientID",
+            sessionID: orderID
         )
         
-        do {
-            let analyticsEventRequest = try AnalyticsEventRequest(eventData: eventData)
-            let (_) = try await http.performRequest(analyticsEventRequest)
-        } catch {
-            NSLog("[PayPal SDK] Failed to send analytics: %@", error.localizedDescription)
+        Task(priority: .background) {
+            do {
+                let analyticsEventRequest = try AnalyticsEventRequest(eventData: eventData)
+                let (_) = try await http.performRequest(analyticsEventRequest)
+            } catch {
+                NSLog("[PayPal SDK] Failed to send analytics: %@", error.localizedDescription)
+            }
         }
+    }
+    
+    private func fetchCachedOrRemoteClientID() async throws -> String {
+        let request = GetClientIDRequest(accessToken: coreConfig.accessToken)
+        let (response) = try await http.performRequest(request, withCaching: true)
+        return response.clientID
     }
 }

--- a/Sources/CorePayments/Networking/AnalyticsService.swift
+++ b/Sources/CorePayments/Networking/AnalyticsService.swift
@@ -1,7 +1,7 @@
 import Foundation
 
 /// :nodoc: Constructs `AnalyticsEventData` models and sends FPTI analytics events.
-public class AnalyticsService {
+public struct AnalyticsService {
     
     // MARK: - Internal Properties
     

--- a/Sources/CorePayments/Networking/AnalyticsService.swift
+++ b/Sources/CorePayments/Networking/AnalyticsService.swift
@@ -60,7 +60,7 @@ public struct AnalyticsService {
     
     private func fetchCachedOrRemoteClientID() async throws -> String {
         let request = GetClientIDRequest(accessToken: coreConfig.accessToken)
-        let (response) = try await http.performRequest(request, withCaching: true)
+        let response = try await http.performRequest(request, withCaching: true)
         return response.clientID
     }
 }

--- a/Sources/CorePayments/Networking/AnalyticsService.swift
+++ b/Sources/CorePayments/Networking/AnalyticsService.swift
@@ -60,7 +60,7 @@ public class AnalyticsService {
             environment: http.coreConfig.environment.toString,
             eventName: name,
             clientID: clientID,
-            sessionID: orderID
+            orderID: orderID
         )
         
 //        Task(priority: .background) {

--- a/Sources/CorePayments/Networking/AnalyticsService.swift
+++ b/Sources/CorePayments/Networking/AnalyticsService.swift
@@ -1,6 +1,6 @@
 import Foundation
 
-/// Constructs `AnalyticsEventData` models and sends FPTI analytics events.
+/// :nodoc: Constructs `AnalyticsEventData` models and sends FPTI analytics events.
 public class AnalyticsService {
     
     // MARK: - Internal Properties
@@ -61,7 +61,7 @@ public class AnalyticsService {
             let analyticsEventRequest = try AnalyticsEventRequest(eventData: eventData)
             let (_) = try await http.performRequest(analyticsEventRequest)
         } catch {
-            NSLog("[PayPal SDK] Failed to send analytics: %@", error.localizedDescription.debugDescription)
+            NSLog("[PayPal SDK] Failed to send analytics: %@", error.localizedDescription)
         }
     }
     

--- a/Sources/CorePayments/Networking/AnalyticsService.swift
+++ b/Sources/CorePayments/Networking/AnalyticsService.swift
@@ -36,16 +36,26 @@ public class AnalyticsService {
         Task {
             do {
                 let clientID = try await fetchCachedOrRemoteClientID()
-                sendEvent(name, clientID: clientID)
+                await sendEvent(name, clientID: clientID)
             } catch {
                 NSLog("[PayPal SDK] Failed to send analytics due to missing clientID: %@", error.localizedDescription.debugDescription)
             }
         }
     }
     
+    /// Exposed for testing
+    func sendAnalyticsEvent(_ name: String) async {
+        do {
+            let clientID = try await fetchCachedOrRemoteClientID()
+            await sendEvent(name, clientID: clientID)
+        } catch {
+            NSLog("[PayPal SDK] Failed to send analytics due to missing clientID: %@", error.localizedDescription.debugDescription)
+        }
+    }
+    
     // MARK: - Private Methods
     
-    private func sendEvent(_ name: String, clientID: String) {
+    private func sendEvent(_ name: String, clientID: String) async {
         let eventData = AnalyticsEventData(
             environment: http.coreConfig.environment.toString,
             eventName: name,
@@ -53,14 +63,14 @@ public class AnalyticsService {
             sessionID: orderID
         )
         
-        Task(priority: .background) {
+//        Task(priority: .background) {
             do {
                 let analyticsEventRequest = try AnalyticsEventRequest(eventData: eventData)
                 let (_) = try await http.performRequest(analyticsEventRequest)
             } catch {
                 NSLog("[PayPal SDK] Failed to send analytics: %@", error.localizedDescription)
             }
-        }
+//        }
     }
     
     private func fetchCachedOrRemoteClientID() async throws -> String {

--- a/Sources/CorePayments/Networking/AnalyticsService.swift
+++ b/Sources/CorePayments/Networking/AnalyticsService.swift
@@ -38,16 +38,9 @@ public struct AnalyticsService {
         }
     }
     
-    /// :nodoc: Exposed for testing only.
-    ///
-    /// Blocking version of the `sendEvent` function. Allows easy unit testing of asychronous code.
-    func sendEvent(_ name: String) async {
-        await performEventRequest(name)
-    }
+    // MARK: - Internal Methods
     
-    // MARK: - Private Methods
-    
-    private func performEventRequest(_ name: String) async {
+    func performEventRequest(_ name: String) async {
         do {
             let clientID = try await fetchCachedOrRemoteClientID()
             

--- a/Sources/CorePayments/Networking/AnalyticsService.swift
+++ b/Sources/CorePayments/Networking/AnalyticsService.swift
@@ -32,22 +32,22 @@ public class AnalyticsService {
     ///
     /// Sends analytics event to https://api.paypal.com/v1/tracking/events/ via a background task.
     /// - Parameter name: Event name string used to identify this unique event in FPTI.
-    public func sendAnalyticsEvent(_ name: String) {
+    public func sendEvent(_ name: String) {
         Task(priority: .background) {
-            await sendEvent(name)
+            await performEventRequest(name)
         }
     }
     
     /// :nodoc: Exposed for testing only.
     ///
-    /// Blocking version of the `sendAnalyticsEvent` function. Allows easy unit testing of asychronous code.
-    func sendAnalyticsEvent(_ name: String) async {
-        await sendEvent(name)
+    /// Blocking version of the `sendEvent` function. Allows easy unit testing of asychronous code.
+    func sendEvent(_ name: String) async {
+        await performEventRequest(name)
     }
     
     // MARK: - Private Methods
     
-    private func sendEvent(_ name: String) async {
+    private func performEventRequest(_ name: String) async {
         do {
             let clientID = try await fetchCachedOrRemoteClientID()
             

--- a/Sources/PayPalNativePayments/PayPalNativeCheckoutClient.swift
+++ b/Sources/PayPalNativePayments/PayPalNativeCheckoutClient.swift
@@ -55,7 +55,7 @@ public class PayPalNativeCheckoutClient {
             )
             delegate?.paypalWillStart(self)
             
-            analyticsService?.sendAnalyticsEvent("paypal-native-payments:started")
+            analyticsService?.sendEvent("paypal-native-payments:started")
             self.nativeCheckoutProvider.start(
                 presentingViewController: presentingViewController,
                 createOrder: { orderRequestAction in
@@ -99,29 +99,29 @@ public class PayPalNativeCheckoutClient {
     }
     
     private func notifySuccess(for result: PayPalNativeCheckoutResult) {
-        analyticsService?.sendAnalyticsEvent("paypal-native-payments:succeeded")
+        analyticsService?.sendEvent("paypal-native-payments:succeeded")
         delegate?.paypal(self, didFinishWithResult: result)
     }
 
     private func notifyFailure(with errorInfo: PayPalCheckout.ErrorInfo) {
-        analyticsService?.sendAnalyticsEvent("paypal-native-payments:failed")
+        analyticsService?.sendEvent("paypal-native-payments:failed")
         
         let error = PayPalNativePaymentsError.nativeCheckoutSDKError(errorInfo.reason)
         delegate?.paypal(self, didFinishWithError: error)
     }
 
     private func notifyCancellation() {
-        analyticsService?.sendAnalyticsEvent("paypal-native-payments:canceled")
+        analyticsService?.sendEvent("paypal-native-payments:canceled")
         delegate?.paypalDidCancel(self)
     }
     
     private func notifyShippingMethod(shippingMethod: PayPalNativeShippingMethod) {
-        analyticsService?.sendAnalyticsEvent("paypal-native-payments:shipping-method-changed")
+        analyticsService?.sendEvent("paypal-native-payments:shipping-method-changed")
         shippingDelegate?.paypal(self, didShippingMethodChange: shippingMethod)
     }
     
     private func notifyShippingChange(shippingAddress: PayPalNativeShippingAddress) {
-        analyticsService?.sendAnalyticsEvent("paypal-native-payments:shipping-address-changed")
+        analyticsService?.sendEvent("paypal-native-payments:shipping-address-changed")
         shippingDelegate?.paypal(self, didShippingAddressChange: shippingAddress)
     }
 }

--- a/Sources/PayPalWebPayments/PayPalWebCheckoutClient.swift
+++ b/Sources/PayPalWebPayments/PayPalWebCheckoutClient.swift
@@ -33,7 +33,7 @@ public class PayPalWebCheckoutClient: NSObject {
     ///   - request: the PayPalRequest for the transaction
     public func start(request: PayPalWebCheckoutRequest) {
         analyticsService = AnalyticsService(coreConfig: config, orderID: request.orderID)
-        analyticsService?.sendAnalyticsEvent("paypal-web-payments:started")
+        analyticsService?.sendEvent("paypal-web-payments:started")
         
         Task {
             do {
@@ -61,9 +61,9 @@ public class PayPalWebCheckoutClient: NSObject {
             context: self,
             sessionDidDisplay: { [weak self] didDisplay in
                 if didDisplay {
-                    self?.analyticsService?.sendAnalyticsEvent("paypal-web-payments:browser-presentation:succeeded")
+                    self?.analyticsService?.sendEvent("paypal-web-payments:browser-presentation:succeeded")
                 } else {
-                    self?.analyticsService?.sendAnalyticsEvent("paypal-web-payments:browser-presentation:failed")
+                    self?.analyticsService?.sendEvent("paypal-web-payments:browser-presentation:failed")
                 }
             },
             sessionDidComplete: { url, error in
@@ -112,17 +112,17 @@ public class PayPalWebCheckoutClient: NSObject {
 
     private func notifySuccess(for result: PayPalWebCheckoutResult) {
         let payPalResult = PayPalWebCheckoutResult(orderID: result.orderID, payerID: result.payerID)
-        analyticsService?.sendAnalyticsEvent("paypal-web-payments:succeeded")
+        analyticsService?.sendEvent("paypal-web-payments:succeeded")
         delegate?.payPal(self, didFinishWithResult: payPalResult)
     }
 
     private func notifyFailure(with error: CoreSDKError) {
-        analyticsService?.sendAnalyticsEvent("paypal-web-payments:failed")
+        analyticsService?.sendEvent("paypal-web-payments:failed")
         delegate?.payPal(self, didFinishWithError: error)
     }
 
     private func notifyCancellation() {
-        analyticsService?.sendAnalyticsEvent("paypal-web-payments:browser-login:canceled")
+        analyticsService?.sendEvent("paypal-web-payments:browser-login:canceled")
         delegate?.payPalDidCancel(self)
     }
 }

--- a/Sources/PayPalWebPayments/PayPalWebCheckoutClient.swift
+++ b/Sources/PayPalWebPayments/PayPalWebCheckoutClient.swift
@@ -35,15 +35,6 @@ public class PayPalWebCheckoutClient: NSObject {
         analyticsService = AnalyticsService(coreConfig: config, orderID: request.orderID)
         analyticsService?.sendEvent("paypal-web-payments:started")
         
-        Task {
-            do {
-                _ = try await apiClient.fetchCachedOrRemoteClientID()
-            } catch {
-                notifyFailure(with: CorePaymentsError.clientIDNotFoundError)
-                return
-            }
-        }
-        
         let baseURLString = config.environment.payPalBaseURL.absoluteString
         let payPalCheckoutURLString =
             "\(baseURLString)/checkoutnow?token=\(request.orderID)" +

--- a/UnitTests/CardPaymentsTests/CardClient_Tests.swift
+++ b/UnitTests/CardPaymentsTests/CardClient_Tests.swift
@@ -45,28 +45,6 @@ class CardClient_Tests: XCTestCase {
 
     // MARK: - approveOrder() tests
     
-    func testApproveOrder_ifClientIDFetchFails_returnsError() {
-        mockAPIClient.cannedClientIDError = CoreSDKError(code: 0, domain: "", errorDescription: "")
-        
-        let expectation = expectation(description: "approveOrder() completed")
-
-        let mockCardDelegate = MockCardDelegate(success: {_, _ in
-            XCTFail("Invoked success() callback. Should invoke error().")
-        }, error: { _, err in
-            XCTAssertEqual(err.code, 1)
-            XCTAssertEqual(err.domain, "CorePaymentsErrorDomain")
-            XCTAssertEqual(err.errorDescription, "Error fetching clientID. Contact developer.paypal.com/support.")
-            expectation.fulfill()
-        }, threeDSWillLaunch: { _ in
-            XCTFail("Invoked willLaunch() callback. Should invoke error().")
-        })
-
-        cardClient.delegate = mockCardDelegate
-        cardClient.approveOrder(request: cardRequest)
-
-        waitForExpectations(timeout: 10)
-    }
-    
     func testApproveOrder_withInvalid3DSURL_returnsError() {
         mockAPIClient.cannedJSONResponse = CardResponses.confirmPaymentSourceJsonInvalid3DSURL.rawValue
         

--- a/UnitTests/PayPalWebPaymentsTests/PayPalWebCheckoutClient_Tests.swift
+++ b/UnitTests/PayPalWebPaymentsTests/PayPalWebCheckoutClient_Tests.swift
@@ -24,22 +24,6 @@ class PayPalClient_Tests: XCTestCase {
         )
     }
     
-    func testStart_ifClientIDFetchFails_returnsError() {
-        mockAPIClient.cannedClientIDError = CoreSDKError(code: 0, domain: "", errorDescription: "")
-        
-        let request = PayPalWebCheckoutRequest(orderID: "1234")
-        let delegate = MockPayPalWebDelegate()
-        
-        payPalClient.delegate = delegate
-        payPalClient.start(request: request)
-        
-        let error = delegate.capturedError
-        
-        XCTAssertEqual(error?.domain, "CorePaymentsErrorDomain")
-        XCTAssertEqual(error?.code, 1)
-        XCTAssertEqual(error?.localizedDescription, "Error fetching clientID. Contact developer.paypal.com/support.")
-    }
-    
     func testStart_whenNativeSDKOnCancelCalled_returnsCancellationError() {
         let request = PayPalWebCheckoutRequest(orderID: "1234")
         let delegate = MockPayPalWebDelegate()

--- a/UnitTests/PaymentsCoreTests/AnalyticsEventRequest_Tests.swift
+++ b/UnitTests/PaymentsCoreTests/AnalyticsEventRequest_Tests.swift
@@ -15,7 +15,7 @@ class AnalyticsEventRequest_Tests: XCTestCase {
             environment: "fake-env",
             eventName: "fake-name",
             clientID: "fake-client-id",
-            orderID: "fake-session"
+            orderID: "fake-order"
         )
         
         sut = try! AnalyticsEventRequest(eventData: fakeAnalyticsEventData)
@@ -36,7 +36,7 @@ class AnalyticsEventRequest_Tests: XCTestCase {
         XCTAssertTrue((eventParams["client_os"] as! String).matches("iOS \\d+\\.\\d+|iPadOS \\d+\\.\\d+"))
         XCTAssertEqual(eventParams["comp"] as? String, "ppcpmobilesdk")
         XCTAssertEqual(eventParams["device_manufacturer"] as? String, "Apple")
-        XCTAssertEqual(eventParams["merchant_app_environment"] as? String, "fake-env")
+        XCTAssertEqual(eventParams["merchant_sdk_env"] as? String, "fake-env")
         XCTAssertEqual(eventParams["event_name"] as? String, "fake-name")
         XCTAssertEqual(eventParams["event_source"] as? String, "mobile-native")
         XCTAssertTrue((eventParams["ios_package_manager"] as! String).matches("Carthage or Other|CocoaPods|Swift Package Manager"))
@@ -45,7 +45,7 @@ class AnalyticsEventRequest_Tests: XCTestCase {
         XCTAssertTrue((eventParams["mobile_device_model"] as! String).matches("iPhone\\d,\\d|x86_64|arm64"))
         XCTAssertEqual(eventParams["partner_client_id"] as! String, "fake-client-id")
         XCTAssertEqual(eventParams["platform"] as? String, "iOS")
-        XCTAssertEqual(eventParams["session_id"] as? String, "fake-session")
+        XCTAssertEqual(eventParams["order_id"] as? String, "fake-order")
         XCTAssertGreaterThanOrEqual(eventParams["t"] as! String, currentTime)
         XCTAssertLessThanOrEqual(eventParams["t"] as! String, oneSecondLater)
         XCTAssertEqual(eventParams["tenant_name"] as? String, "PayPal")

--- a/UnitTests/PaymentsCoreTests/AnalyticsEventRequest_Tests.swift
+++ b/UnitTests/PaymentsCoreTests/AnalyticsEventRequest_Tests.swift
@@ -16,7 +16,7 @@ class AnalyticsEventRequest_Tests: XCTestCase {
             environment: "fake-env",
             eventName: "fake-name",
             clientID: "fake-client-id",
-            sessionID: "fake-session"
+            orderID: "fake-session"
         )
         
         sut = try! AnalyticsEventRequest(eventData: fakeAnalyticsEventData)

--- a/UnitTests/PaymentsCoreTests/AnalyticsService_Tests.swift
+++ b/UnitTests/PaymentsCoreTests/AnalyticsService_Tests.swift
@@ -30,10 +30,22 @@ class AnalyticsService_Tests: XCTestCase {
 
     // MARK: - sendEvent()
 
-    func testSendEvent_postsAnalyticsEventRequestType() async {
+    func testSendEvent_whenClientID_postsAnalyticsEventRequestType() async {
         await sut.sendAnalyticsEvent("fake-event")
 
         XCTAssert(mockHTTP.lastAPIRequest is AnalyticsEventRequest)
+    }
+    
+    func testSendEvent_whenNoClientID_doesNotPostAnalyticsEventRequestType() async {
+        mockURLSession.cannedJSONData = nil
+        
+        let coreConfig = CoreConfig(accessToken: "fake-token", environment: .live)
+        let mockHTTP = MockHTTP(urlSession: mockURLSession, coreConfig: coreConfig)
+        let sut = AnalyticsService(coreConfig: coreConfig, orderID: "fake-orderID", http: mockHTTP)
+                
+        await sut.sendAnalyticsEvent("fake-event")
+
+        XCTAssert(mockHTTP.lastAPIRequest is GetClientIDRequest)
     }
     
     func testSendEvent_whenLive_sendsProperTag() async {

--- a/UnitTests/PaymentsCoreTests/AnalyticsService_Tests.swift
+++ b/UnitTests/PaymentsCoreTests/AnalyticsService_Tests.swift
@@ -30,7 +30,7 @@ class AnalyticsService_Tests: XCTestCase {
     // MARK: - sendEvent()
 
     func testSendEvent_whenClientID_postsAnalyticsEventRequestType() async {
-        await sut.sendEvent("fake-event")
+        await sut.performEventRequest("fake-event")
 
         XCTAssert(mockHTTP.lastAPIRequest is AnalyticsEventRequest)
     }
@@ -42,7 +42,7 @@ class AnalyticsService_Tests: XCTestCase {
         let mockHTTP = MockHTTP(urlSession: mockURLSession, coreConfig: coreConfig)
         let sut = AnalyticsService(coreConfig: coreConfig, orderID: "fake-orderID", http: mockHTTP)
                 
-        await sut.sendEvent("fake-event")
+        await sut.performEventRequest("fake-event")
 
         XCTAssert(mockHTTP.lastAPIRequest is GetClientIDRequest)
     }
@@ -52,7 +52,7 @@ class AnalyticsService_Tests: XCTestCase {
         let mockHTTP = MockHTTP(urlSession: mockURLSession, coreConfig: coreConfig)
         let sut = AnalyticsService(coreConfig: coreConfig, orderID: "fake-orderID", http: mockHTTP)
         
-        await sut.sendEvent("fake-event")
+        await sut.performEventRequest("fake-event")
         
         guard let env = parsePostParam(from: mockHTTP.lastPOSTParameters, forKey: "merchant_sdk_env") else {
             XCTFail("JSON body missing `merchant_sdk_env` key.")
@@ -63,7 +63,7 @@ class AnalyticsService_Tests: XCTestCase {
     }
     
     func testSendEvent_whenSandbox_sendsProperTag() async {
-        await sut.sendEvent("fake-event")
+        await sut.performEventRequest("fake-event")
         
         guard let env = parsePostParam(from: mockHTTP.lastPOSTParameters, forKey: "merchant_sdk_env") else {
             XCTFail("JSON body missing `merchant_sdk_env` key.")
@@ -74,7 +74,7 @@ class AnalyticsService_Tests: XCTestCase {
     }
     
     func testSendEvent_addsMetadataParams() async {
-        await sut.sendEvent("fake-event")
+        await sut.performEventRequest("fake-event")
         
         guard let eventName = parsePostParam(from: mockHTTP.lastPOSTParameters, forKey: "event_name") else {
             XCTFail("JSON body missing `event_name` key.")

--- a/UnitTests/PaymentsCoreTests/AnalyticsService_Tests.swift
+++ b/UnitTests/PaymentsCoreTests/AnalyticsService_Tests.swift
@@ -54,8 +54,8 @@ class AnalyticsService_Tests: XCTestCase {
         
         await sut.sendEvent("fake-event")
         
-        guard let env = parsePostParam(from: mockHTTP.lastPOSTParameters, forKey: "merchant_app_environment") else {
-            XCTFail("JSON body missing `merchant_app_environment` key.")
+        guard let env = parsePostParam(from: mockHTTP.lastPOSTParameters, forKey: "merchant_sdk_env") else {
+            XCTFail("JSON body missing `merchant_sdk_env` key.")
             return
         }
         
@@ -65,8 +65,8 @@ class AnalyticsService_Tests: XCTestCase {
     func testSendEvent_whenSandbox_sendsProperTag() async {
         await sut.sendEvent("fake-event")
         
-        guard let env = parsePostParam(from: mockHTTP.lastPOSTParameters, forKey: "merchant_app_environment") else {
-            XCTFail("JSON body missing `merchant_app_environment` key.")
+        guard let env = parsePostParam(from: mockHTTP.lastPOSTParameters, forKey: "merchant_sdk_env") else {
+            XCTFail("JSON body missing `merchant_sdk_env` key.")
             return
         }
         

--- a/UnitTests/PaymentsCoreTests/AnalyticsService_Tests.swift
+++ b/UnitTests/PaymentsCoreTests/AnalyticsService_Tests.swift
@@ -75,8 +75,8 @@ class AnalyticsService_Tests: XCTestCase {
             return
         }
         
-        guard let orderID = parsePostParam(from: mockHTTP.lastPOSTParameters, forKey: "session_id") else {
-            XCTFail("JSON body missing `session_id` key.")
+        guard let orderID = parsePostParam(from: mockHTTP.lastPOSTParameters, forKey: "order_id") else {
+            XCTFail("JSON body missing `order_id` key.")
             return
         }
         

--- a/UnitTests/PaymentsCoreTests/AnalyticsService_Tests.swift
+++ b/UnitTests/PaymentsCoreTests/AnalyticsService_Tests.swift
@@ -8,127 +8,131 @@ class AnalyticsService_Tests: XCTestCase {
     // MARK: - Helper properties
 
     var mockURLSession: MockURLSession!
-
+    var sut: AnalyticsService!
+    var mockHTTP: MockHTTP!
+    let coreConfig = CoreConfig(accessToken: "fake-token", environment: .sandbox)
     // MARK: - Test lifecycle
     
     override func setUp() {
         super.setUp()
-
+        
         mockURLSession = MockURLSession()
         mockURLSession.cannedError = nil
         mockURLSession.cannedURLResponse = HTTPURLResponse(url: URL(string: "www.fake-url.com")!, statusCode: 200, httpVersion: "https", headerFields: [:])
         mockURLSession.cannedJSONData = ""
+        
+        mockHTTP = MockHTTP(urlSession: mockURLSession, coreConfig: coreConfig)
+        
+        sut = AnalyticsService(coreConfig: coreConfig, orderID: "fake-orderID", http: mockHTTP)
     }
 
     // MARK: - sendEvent()
 
     func testSendEvent_postsAnalyticsEventRequestType() async {
         let fakeConfig = CoreConfig(accessToken: "fake-token-1", environment: .sandbox)
-        let mockHTTP = MockHTTP(urlSession: mockURLSession, coreConfig: fakeConfig)
 
-        let analyticsService = AnalyticsService.sharedInstance(http: mockHTTP)
-        await analyticsService.sendEvent(name: "fake-event", clientID: "fake-client-id")
+        sut.sendAnalyticsEvent("fake-event")
 
         XCTAssert(mockHTTP.lastAPIRequest is AnalyticsEventRequest)
     }
     
-    func testSendEvent_whenLive_sendsProperTag() async {
-        let fakeConfig = CoreConfig(accessToken: "fake-token-1", environment: .live)
-        let mockHTTP = MockHTTP(urlSession: mockURLSession, coreConfig: fakeConfig)
-
-        let analyticsService = AnalyticsService.sharedInstance(http: mockHTTP)
-        await analyticsService.sendEvent(name: "fake-event", clientID: "fake-client-id")
-        
-        guard let eventParams = (mockHTTP.lastPOSTParameters?["events"] as! [String: [String: Any]])["event_params"] else {
-            XCTFail("JSON body missing `event_params` key.")
-            return
-        }
-        
-        XCTAssertEqual(eventParams["merchant_app_environment"] as? String, "live")
-    }
-    
-    func testSendEvent_whenSandbox_sendsProperTag() async {
-        let fakeConfig = CoreConfig(accessToken: "fake-token-1", environment: .sandbox)
-        let mockHTTP = MockHTTP(urlSession: mockURLSession, coreConfig: fakeConfig)
-
-        let analyticsService = AnalyticsService.sharedInstance(http: mockHTTP)
-        await analyticsService.sendEvent(name: "fake-event", clientID: "fake-client-id")
-        
-        guard let eventParams = (mockHTTP.lastPOSTParameters?["events"] as! [String: [String: Any]])["event_params"] else {
-            XCTFail("JSON body missing `event_params` key.")
-            return
-        }
-        
-        XCTAssertEqual(eventParams["merchant_app_environment"] as? String, "sandbox")
-    }
-    
-    // MARK: - sharedInstance()
-
-    func testSharedInstance_withDifferentAccessToken_postsUniqueSessionID() async {
-        // Construct 1st CoreConfig
-        let config1 = CoreConfig(accessToken: "fake-token-1", environment: .sandbox)
-        let mockHTTP1 = MockHTTP(urlSession: mockURLSession, coreConfig: config1)
-        var analyticsService = AnalyticsService.sharedInstance(http: mockHTTP1)
-        
-        // Send 1st event
-        await analyticsService.sendEvent(name: "fake-event-1", clientID: "fake-client-id")
-        
-        // Capture sessionID
-        let postParams1 = mockHTTP1.lastPOSTParameters as! [String: [String: [String: Any]]]
-        let sessionID1 = postParams1["events"]!["event_params"]!["session_id"]! as! String
-        
-        // Construct 2nd CoreConfig
-        let config2 = CoreConfig(accessToken: "fake-token-2", environment: .sandbox)
-        let mockHTTP2 = MockHTTP(urlSession: mockURLSession, coreConfig: config2)
-        analyticsService = AnalyticsService.sharedInstance(http: mockHTTP2)
-        
-        // Send 2nd event
-        await analyticsService.sendEvent(name: "fake-event-2", clientID: "fake-client-id")
-        
-        // Capture sessionID
-        let postParams2 = mockHTTP2.lastPOSTParameters as! [String: [String: [String: Any]]]
-        let sessionID2 = postParams2["events"]!["event_params"]!["session_id"]! as! String
-
-        XCTAssertNotEqual(sessionID1, sessionID2)
-    }
-    
-    func testSharedInstance_withSameAccessToken_postsSameSessionID() async {
-        // Construct 1st CoreConfig
-        let config1 = CoreConfig(accessToken: "fake-token-1", environment: .sandbox)
-        let mockHTTP1 = MockHTTP(urlSession: mockURLSession, coreConfig: config1)
-        var analyticsService = AnalyticsService.sharedInstance(http: mockHTTP1)
-        
-        // Send 1st event
-        await analyticsService.sendEvent(name: "fake-event-1", clientID: "fake-client-id")
-        
-        // Capture sessionID
-        let postParams1 = mockHTTP1.lastPOSTParameters as! [String: [String: [String: Any]]]
-        let sessionID1 = postParams1["events"]!["event_params"]!["session_id"]! as! String
-        
-        // Construct 2nd CoreConfig
-        let config2 = CoreConfig(accessToken: "fake-token-1", environment: .sandbox)
-        let mockHTTP2 = MockHTTP(urlSession: mockURLSession, coreConfig: config2)
-        analyticsService = AnalyticsService.sharedInstance(http: mockHTTP2)
-        
-        // Send 2nd event
-        await analyticsService.sendEvent(name: "fake-event-2", clientID: "fake-client-id")
-        
-        // Capture sessionID
-        let postParams2 = mockHTTP2.lastPOSTParameters as! [String: [String: [String: Any]]]
-        let sessionID2 = postParams2["events"]!["event_params"]!["session_id"]! as! String
-
-        XCTAssertEqual(sessionID1, sessionID2)
-    }
-        
-    func testSharedInstance_returnsSingletonInstance() {
-        let config1 = CoreConfig(accessToken: "fake-token-1", environment: .sandbox)
-        let mockHTTP1 = MockHTTP(urlSession: mockURLSession, coreConfig: config1)
-        let analyticsService1 = AnalyticsService.sharedInstance(http: mockHTTP1)
-        
-        let config2 = CoreConfig(accessToken: "fake-token-2", environment: .sandbox)
-        let mockHTTP2 = MockHTTP(urlSession: mockURLSession, coreConfig: config2)
-        let analyticsService2 = AnalyticsService.sharedInstance(http: mockHTTP2)
-        
-        XCTAssertTrue(analyticsService1 === analyticsService2)
-    }
+//    func testSendEvent_whenLive_sendsProperTag() async {
+//        let fakeConfig = CoreConfig(accessToken: "fake-token-1", environment: .live)
+//        let mockHTTP = MockHTTP(urlSession: mockURLSession, coreConfig: fakeConfig)
+//
+//        let analyticsService = AnalyticsService.sharedInstance(http: mockHTTP)
+//        await analyticsService.sendEvent(name: "fake-event", clientID: "fake-client-id")
+//        
+//        guard let eventParams = (mockHTTP.lastPOSTParameters?["events"] as! [String: [String: Any]])["event_params"] else {
+//            XCTFail("JSON body missing `event_params` key.")
+//            return
+//        }
+//        
+//        XCTAssertEqual(eventParams["merchant_app_environment"] as? String, "live")
+//    }
+//    
+//    func testSendEvent_whenSandbox_sendsProperTag() async {
+//        let fakeConfig = CoreConfig(accessToken: "fake-token-1", environment: .sandbox)
+//        let mockHTTP = MockHTTP(urlSession: mockURLSession, coreConfig: fakeConfig)
+//
+//        let analyticsService = AnalyticsService.sharedInstance(http: mockHTTP)
+//        await analyticsService.sendEvent(name: "fake-event", clientID: "fake-client-id")
+//        
+//        guard let eventParams = (mockHTTP.lastPOSTParameters?["events"] as! [String: [String: Any]])["event_params"] else {
+//            XCTFail("JSON body missing `event_params` key.")
+//            return
+//        }
+//        
+//        XCTAssertEqual(eventParams["merchant_app_environment"] as? String, "sandbox")
+//    }
+//    
+//    // MARK: - sharedInstance()
+//
+//    func testSharedInstance_withDifferentAccessToken_postsUniqueSessionID() async {
+//        // Construct 1st CoreConfig
+//        let config1 = CoreConfig(accessToken: "fake-token-1", environment: .sandbox)
+//        let mockHTTP1 = MockHTTP(urlSession: mockURLSession, coreConfig: config1)
+//        var analyticsService = AnalyticsService.sharedInstance(http: mockHTTP1)
+//        
+//        // Send 1st event
+//        await analyticsService.sendEvent(name: "fake-event-1", clientID: "fake-client-id")
+//        
+//        // Capture sessionID
+//        let postParams1 = mockHTTP1.lastPOSTParameters as! [String: [String: [String: Any]]]
+//        let sessionID1 = postParams1["events"]!["event_params"]!["session_id"]! as! String
+//        
+//        // Construct 2nd CoreConfig
+//        let config2 = CoreConfig(accessToken: "fake-token-2", environment: .sandbox)
+//        let mockHTTP2 = MockHTTP(urlSession: mockURLSession, coreConfig: config2)
+//        analyticsService = AnalyticsService.sharedInstance(http: mockHTTP2)
+//        
+//        // Send 2nd event
+//        await analyticsService.sendEvent(name: "fake-event-2", clientID: "fake-client-id")
+//        
+//        // Capture sessionID
+//        let postParams2 = mockHTTP2.lastPOSTParameters as! [String: [String: [String: Any]]]
+//        let sessionID2 = postParams2["events"]!["event_params"]!["session_id"]! as! String
+//
+//        XCTAssertNotEqual(sessionID1, sessionID2)
+//    }
+//    
+//    func testSharedInstance_withSameAccessToken_postsSameSessionID() async {
+//        // Construct 1st CoreConfig
+//        let config1 = CoreConfig(accessToken: "fake-token-1", environment: .sandbox)
+//        let mockHTTP1 = MockHTTP(urlSession: mockURLSession, coreConfig: config1)
+//        var analyticsService = AnalyticsService.sharedInstance(http: mockHTTP1)
+//        
+//        // Send 1st event
+//        await analyticsService.sendEvent(name: "fake-event-1", clientID: "fake-client-id")
+//        
+//        // Capture sessionID
+//        let postParams1 = mockHTTP1.lastPOSTParameters as! [String: [String: [String: Any]]]
+//        let sessionID1 = postParams1["events"]!["event_params"]!["session_id"]! as! String
+//        
+//        // Construct 2nd CoreConfig
+//        let config2 = CoreConfig(accessToken: "fake-token-1", environment: .sandbox)
+//        let mockHTTP2 = MockHTTP(urlSession: mockURLSession, coreConfig: config2)
+//        analyticsService = AnalyticsService.sharedInstance(http: mockHTTP2)
+//        
+//        // Send 2nd event
+//        await analyticsService.sendEvent(name: "fake-event-2", clientID: "fake-client-id")
+//        
+//        // Capture sessionID
+//        let postParams2 = mockHTTP2.lastPOSTParameters as! [String: [String: [String: Any]]]
+//        let sessionID2 = postParams2["events"]!["event_params"]!["session_id"]! as! String
+//
+//        XCTAssertEqual(sessionID1, sessionID2)
+//    }
+//        
+//    func testSharedInstance_returnsSingletonInstance() {
+//        let config1 = CoreConfig(accessToken: "fake-token-1", environment: .sandbox)
+//        let mockHTTP1 = MockHTTP(urlSession: mockURLSession, coreConfig: config1)
+//        let analyticsService1 = AnalyticsService.sharedInstance(http: mockHTTP1)
+//        
+//        let config2 = CoreConfig(accessToken: "fake-token-2", environment: .sandbox)
+//        let mockHTTP2 = MockHTTP(urlSession: mockURLSession, coreConfig: config2)
+//        let analyticsService2 = AnalyticsService.sharedInstance(http: mockHTTP2)
+//        
+//        XCTAssertTrue(analyticsService1 === analyticsService2)
+//    }
 }

--- a/UnitTests/PaymentsCoreTests/AnalyticsService_Tests.swift
+++ b/UnitTests/PaymentsCoreTests/AnalyticsService_Tests.swift
@@ -31,7 +31,7 @@ class AnalyticsService_Tests: XCTestCase {
     // MARK: - sendEvent()
 
     func testSendEvent_whenClientID_postsAnalyticsEventRequestType() async {
-        await sut.sendAnalyticsEvent("fake-event")
+        await sut.sendEvent("fake-event")
 
         XCTAssert(mockHTTP.lastAPIRequest is AnalyticsEventRequest)
     }
@@ -43,7 +43,7 @@ class AnalyticsService_Tests: XCTestCase {
         let mockHTTP = MockHTTP(urlSession: mockURLSession, coreConfig: coreConfig)
         let sut = AnalyticsService(coreConfig: coreConfig, orderID: "fake-orderID", http: mockHTTP)
                 
-        await sut.sendAnalyticsEvent("fake-event")
+        await sut.sendEvent("fake-event")
 
         XCTAssert(mockHTTP.lastAPIRequest is GetClientIDRequest)
     }
@@ -53,7 +53,7 @@ class AnalyticsService_Tests: XCTestCase {
         let mockHTTP = MockHTTP(urlSession: mockURLSession, coreConfig: coreConfig)
         let sut = AnalyticsService(coreConfig: coreConfig, orderID: "fake-orderID", http: mockHTTP)
         
-        await sut.sendAnalyticsEvent("fake-event")
+        await sut.sendEvent("fake-event")
         
         guard let env = parsePostParam(from: mockHTTP.lastPOSTParameters, forKey: "merchant_app_environment") else {
             XCTFail("JSON body missing `merchant_app_environment` key.")
@@ -64,7 +64,7 @@ class AnalyticsService_Tests: XCTestCase {
     }
     
     func testSendEvent_whenSandbox_sendsProperTag() async {
-        await sut.sendAnalyticsEvent("fake-event")
+        await sut.sendEvent("fake-event")
         
         guard let env = parsePostParam(from: mockHTTP.lastPOSTParameters, forKey: "merchant_app_environment") else {
             XCTFail("JSON body missing `merchant_app_environment` key.")
@@ -75,7 +75,7 @@ class AnalyticsService_Tests: XCTestCase {
     }
     
     func testSendEvent_addsMetadataParams() async {
-        await sut.sendAnalyticsEvent("fake-event")
+        await sut.sendEvent("fake-event")
         
         guard let eventName = parsePostParam(from: mockHTTP.lastPOSTParameters, forKey: "event_name") else {
             XCTFail("JSON body missing `event_name` key.")

--- a/UnitTests/PaymentsCoreTests/AnalyticsService_Tests.swift
+++ b/UnitTests/PaymentsCoreTests/AnalyticsService_Tests.swift
@@ -10,7 +10,7 @@ class AnalyticsService_Tests: XCTestCase {
     var mockURLSession: MockURLSession!
     var sut: AnalyticsService!
     var mockHTTP: MockHTTP!
-    let coreConfig = CoreConfig(accessToken: "fake-token", environment: .sandbox)
+    var coreConfig = CoreConfig(accessToken: "fake-token", environment: .sandbox)
     // MARK: - Test lifecycle
     
     override func setUp() {
@@ -19,120 +19,77 @@ class AnalyticsService_Tests: XCTestCase {
         mockURLSession = MockURLSession()
         mockURLSession.cannedError = nil
         mockURLSession.cannedURLResponse = HTTPURLResponse(url: URL(string: "www.fake-url.com")!, statusCode: 200, httpVersion: "https", headerFields: [:])
-        mockURLSession.cannedJSONData = ""
+        mockURLSession.cannedJSONData = """
+            { "client_id": "fake-client-id" }
+        """
         
         mockHTTP = MockHTTP(urlSession: mockURLSession, coreConfig: coreConfig)
         
-        sut = AnalyticsService(coreConfig: coreConfig, orderID: "fake-orderID", http: mockHTTP)
+        sut = AnalyticsService(coreConfig: coreConfig, orderID: "fake-order-id", http: mockHTTP)
     }
 
     // MARK: - sendEvent()
 
     func testSendEvent_postsAnalyticsEventRequestType() async {
-        let fakeConfig = CoreConfig(accessToken: "fake-token-1", environment: .sandbox)
-
-        sut.sendAnalyticsEvent("fake-event")
+        await sut.sendAnalyticsEvent("fake-event")
 
         XCTAssert(mockHTTP.lastAPIRequest is AnalyticsEventRequest)
     }
     
-//    func testSendEvent_whenLive_sendsProperTag() async {
-//        let fakeConfig = CoreConfig(accessToken: "fake-token-1", environment: .live)
-//        let mockHTTP = MockHTTP(urlSession: mockURLSession, coreConfig: fakeConfig)
-//
-//        let analyticsService = AnalyticsService.sharedInstance(http: mockHTTP)
-//        await analyticsService.sendEvent(name: "fake-event", clientID: "fake-client-id")
-//        
-//        guard let eventParams = (mockHTTP.lastPOSTParameters?["events"] as! [String: [String: Any]])["event_params"] else {
-//            XCTFail("JSON body missing `event_params` key.")
-//            return
-//        }
-//        
-//        XCTAssertEqual(eventParams["merchant_app_environment"] as? String, "live")
-//    }
-//    
-//    func testSendEvent_whenSandbox_sendsProperTag() async {
-//        let fakeConfig = CoreConfig(accessToken: "fake-token-1", environment: .sandbox)
-//        let mockHTTP = MockHTTP(urlSession: mockURLSession, coreConfig: fakeConfig)
-//
-//        let analyticsService = AnalyticsService.sharedInstance(http: mockHTTP)
-//        await analyticsService.sendEvent(name: "fake-event", clientID: "fake-client-id")
-//        
-//        guard let eventParams = (mockHTTP.lastPOSTParameters?["events"] as! [String: [String: Any]])["event_params"] else {
-//            XCTFail("JSON body missing `event_params` key.")
-//            return
-//        }
-//        
-//        XCTAssertEqual(eventParams["merchant_app_environment"] as? String, "sandbox")
-//    }
-//    
-//    // MARK: - sharedInstance()
-//
-//    func testSharedInstance_withDifferentAccessToken_postsUniqueSessionID() async {
-//        // Construct 1st CoreConfig
-//        let config1 = CoreConfig(accessToken: "fake-token-1", environment: .sandbox)
-//        let mockHTTP1 = MockHTTP(urlSession: mockURLSession, coreConfig: config1)
-//        var analyticsService = AnalyticsService.sharedInstance(http: mockHTTP1)
-//        
-//        // Send 1st event
-//        await analyticsService.sendEvent(name: "fake-event-1", clientID: "fake-client-id")
-//        
-//        // Capture sessionID
-//        let postParams1 = mockHTTP1.lastPOSTParameters as! [String: [String: [String: Any]]]
-//        let sessionID1 = postParams1["events"]!["event_params"]!["session_id"]! as! String
-//        
-//        // Construct 2nd CoreConfig
-//        let config2 = CoreConfig(accessToken: "fake-token-2", environment: .sandbox)
-//        let mockHTTP2 = MockHTTP(urlSession: mockURLSession, coreConfig: config2)
-//        analyticsService = AnalyticsService.sharedInstance(http: mockHTTP2)
-//        
-//        // Send 2nd event
-//        await analyticsService.sendEvent(name: "fake-event-2", clientID: "fake-client-id")
-//        
-//        // Capture sessionID
-//        let postParams2 = mockHTTP2.lastPOSTParameters as! [String: [String: [String: Any]]]
-//        let sessionID2 = postParams2["events"]!["event_params"]!["session_id"]! as! String
-//
-//        XCTAssertNotEqual(sessionID1, sessionID2)
-//    }
-//    
-//    func testSharedInstance_withSameAccessToken_postsSameSessionID() async {
-//        // Construct 1st CoreConfig
-//        let config1 = CoreConfig(accessToken: "fake-token-1", environment: .sandbox)
-//        let mockHTTP1 = MockHTTP(urlSession: mockURLSession, coreConfig: config1)
-//        var analyticsService = AnalyticsService.sharedInstance(http: mockHTTP1)
-//        
-//        // Send 1st event
-//        await analyticsService.sendEvent(name: "fake-event-1", clientID: "fake-client-id")
-//        
-//        // Capture sessionID
-//        let postParams1 = mockHTTP1.lastPOSTParameters as! [String: [String: [String: Any]]]
-//        let sessionID1 = postParams1["events"]!["event_params"]!["session_id"]! as! String
-//        
-//        // Construct 2nd CoreConfig
-//        let config2 = CoreConfig(accessToken: "fake-token-1", environment: .sandbox)
-//        let mockHTTP2 = MockHTTP(urlSession: mockURLSession, coreConfig: config2)
-//        analyticsService = AnalyticsService.sharedInstance(http: mockHTTP2)
-//        
-//        // Send 2nd event
-//        await analyticsService.sendEvent(name: "fake-event-2", clientID: "fake-client-id")
-//        
-//        // Capture sessionID
-//        let postParams2 = mockHTTP2.lastPOSTParameters as! [String: [String: [String: Any]]]
-//        let sessionID2 = postParams2["events"]!["event_params"]!["session_id"]! as! String
-//
-//        XCTAssertEqual(sessionID1, sessionID2)
-//    }
-//        
-//    func testSharedInstance_returnsSingletonInstance() {
-//        let config1 = CoreConfig(accessToken: "fake-token-1", environment: .sandbox)
-//        let mockHTTP1 = MockHTTP(urlSession: mockURLSession, coreConfig: config1)
-//        let analyticsService1 = AnalyticsService.sharedInstance(http: mockHTTP1)
-//        
-//        let config2 = CoreConfig(accessToken: "fake-token-2", environment: .sandbox)
-//        let mockHTTP2 = MockHTTP(urlSession: mockURLSession, coreConfig: config2)
-//        let analyticsService2 = AnalyticsService.sharedInstance(http: mockHTTP2)
-//        
-//        XCTAssertTrue(analyticsService1 === analyticsService2)
-//    }
+    func testSendEvent_whenLive_sendsProperTag() async {
+        let coreConfig = CoreConfig(accessToken: "fake-token", environment: .live)
+        let mockHTTP = MockHTTP(urlSession: mockURLSession, coreConfig: coreConfig)
+        let sut = AnalyticsService(coreConfig: coreConfig, orderID: "fake-orderID", http: mockHTTP)
+        
+        await sut.sendAnalyticsEvent("fake-event")
+        
+        guard let env = parsePostParam(from: mockHTTP.lastPOSTParameters, forKey: "merchant_app_environment") else {
+            XCTFail("JSON body missing `merchant_app_environment` key.")
+            return
+        }
+        
+        XCTAssertEqual(env, "live")
+    }
+    
+    func testSendEvent_whenSandbox_sendsProperTag() async {
+        await sut.sendAnalyticsEvent("fake-event")
+        
+        guard let env = parsePostParam(from: mockHTTP.lastPOSTParameters, forKey: "merchant_app_environment") else {
+            XCTFail("JSON body missing `merchant_app_environment` key.")
+            return
+        }
+        
+        XCTAssertEqual(env, "sandbox")
+    }
+    
+    func testSendEvent_addsMetadataParams() async {
+        await sut.sendAnalyticsEvent("fake-event")
+        
+        guard let eventName = parsePostParam(from: mockHTTP.lastPOSTParameters, forKey: "event_name") else {
+            XCTFail("JSON body missing `event_name` key.")
+            return
+        }
+        
+        guard let clientID = parsePostParam(from: mockHTTP.lastPOSTParameters, forKey: "partner_client_id") else {
+            XCTFail("JSON body missing `partner_client_id` key.")
+            return
+        }
+        
+        guard let orderID = parsePostParam(from: mockHTTP.lastPOSTParameters, forKey: "session_id") else {
+            XCTFail("JSON body missing `session_id` key.")
+            return
+        }
+        
+        XCTAssertEqual(eventName, "fake-event")
+        XCTAssertEqual(clientID, "fake-client-id")
+        XCTAssertEqual(orderID, "fake-order-id")
+    }
+    
+    // MARK: - Helpers
+    
+    private func parsePostParam(from postParameters: [String: Any]?, forKey key: String) -> String? {
+        let topLevelEvent = postParameters?["events"] as? [String: Any]
+        let eventParams = topLevelEvent?["event_params"] as? [String: Any]
+        return eventParams?[key] as? String
+    }
 }

--- a/UnitTests/TestShared/MockAPIClient.swift
+++ b/UnitTests/TestShared/MockAPIClient.swift
@@ -30,8 +30,4 @@ class MockAPIClient: APIClient {
         }
         return cannedClientID
     }
-    
-    override func sendAnalyticsEvent(_ name: String) {
-        postedAnalyticsEvents.append(name)
-    }
 }


### PR DESCRIPTION
### Reason for changes

- The analytics team suggests we track and use the `orderID` to link events together, instead of a `sessionID`

### Summary of changes

- Change `AnalyticsService` from singleton to basic struct
- Remove analytics capabilities from `APIClient`
- Each feature client now has it's own `AnalyticsService` instance
    - Move `clientID` fetch requirement to `AnalyticsService` layer
- Send `orderID` instead of `sessionID` in `AnalyticsEventData`
- Rename `merchant_app_environment` to `merchant_sdk_env` to match Arachne --> FPTI tag naming convention

### Checklist

- [x] Added a changelog entry

### Authors
@scannillo 