### PR TITLE
Update docs - Add `PATCH` orders API link

### DIFF
--- a/docs/PayPalNativePayments/README.md
+++ b/docs/PayPalNativePayments/README.md
@@ -120,6 +120,8 @@ For a working example please refer to [PayPalViewModel](../../Demo/Demo/ViewMode
 
 You can optionally conform to `PayPalNativeShippingDelegate` to receive notifications when the user updates their shipping address or shipping method details.
 
+Implementing this optional delegate will require your server implementation support the [PayPal Orders API - Update order](https://developer.paypal.com/docs/api/orders/v2/#orders_patch) or `PATCH` functionality.
+
 ```swift
 extension MyViewModel: PayPalNativeShippingDelegate {
 

--- a/docs/PayPalNativePayments/README.md
+++ b/docs/PayPalNativePayments/README.md
@@ -120,7 +120,7 @@ For a working example please refer to [PayPalViewModel](../../Demo/Demo/ViewMode
 
 You can optionally conform to `PayPalNativeShippingDelegate` to receive notifications when the user updates their shipping address or shipping method details.
 
-Implementing this optional delegate will require your server implementation support the [PayPal Orders API - Update order](https://developer.paypal.com/docs/api/orders/v2/#orders_patch) or `PATCH` functionality.
+Implementing this optional delegate will require your server implementation support the [PayPal Orders API - Update order](https://developer.paypal.com/docs/api/orders/v2/#orders_patch) (or `PATCH`) functionality.
 
 ```swift
 extension MyViewModel: PayPalNativeShippingDelegate {


### PR DESCRIPTION
### Reason for changes

- Missing server-side instructions for `PATCH` required to implement the NXO shipping callbacks

### Summary of changes

- Add `PATCH` orders API documentation link to PayPalNativePayments docs


### Checklist

- [ ] Added a changelog entry

### Authors
@scannillo 
- 