### PR TITLE
make sure only cache valid data in HTTP performRequest

### DIFF
--- a/Sources/CardPayments/CardClient.swift
+++ b/Sources/CardPayments/CardClient.swift
@@ -60,7 +60,7 @@ public class CardClient: NSObject {
             } catch let error as CoreSDKError {
                 analyticsService?.sendEvent("card-payments:3ds:confirm-payment-source:failed")
                 notifyFailure(with: error)
-            } catch {            
+            } catch {
             }
         }
     }

--- a/Sources/CardPayments/CardClient.swift
+++ b/Sources/CardPayments/CardClient.swift
@@ -61,6 +61,7 @@ public class CardClient: NSObject {
                 analyticsService?.sendEvent("card-payments:3ds:confirm-payment-source:failed")
                 notifyFailure(with: error)
             } catch {
+                // TODO: notifyFailure and analytics here?
             }
         }
     }

--- a/Sources/CardPayments/CardClient.swift
+++ b/Sources/CardPayments/CardClient.swift
@@ -60,7 +60,7 @@ public class CardClient: NSObject {
             } catch let error as CoreSDKError {
                 analyticsService?.sendEvent("card-payments:3ds:confirm-payment-source:failed")
                 notifyFailure(with: error)
-            } catch {                
+            } catch {            
             }
         }
     }

--- a/Sources/CardPayments/CardClient.swift
+++ b/Sources/CardPayments/CardClient.swift
@@ -60,8 +60,7 @@ public class CardClient: NSObject {
             } catch let error as CoreSDKError {
                 analyticsService?.sendEvent("card-payments:3ds:confirm-payment-source:failed")
                 notifyFailure(with: error)
-            } catch {
-                // TODO: notifyFailure and analytics here?
+            } catch {                
             }
         }
     }

--- a/Sources/CorePayments/Networking/HTTP.swift
+++ b/Sources/CorePayments/Networking/HTTP.swift
@@ -36,11 +36,12 @@ class HTTP {
         
         switch response.statusCode {
         case 200..<300:
-            let decodedData = try decoder.decode(T.self, from: data)
             if cachingEnabled {
                 let cachedURLResponse = CachedURLResponse(response: response, data: data)
                 urlCache.storeCachedResponse(cachedURLResponse, for: urlRequest)
             }
+            
+            let decodedData = try decoder.decode(T.self, from: data)
             return (decodedData)
         default:
             let errorData = try decoder.decode(from: data)

--- a/Sources/CorePayments/Networking/HTTP.swift
+++ b/Sources/CorePayments/Networking/HTTP.swift
@@ -24,9 +24,8 @@ class HTTP {
         }
         
         if cachingEnabled, let response = urlCache.cachedResponse(for: urlRequest) {
-            if let decodedData = try? decoder.decode(T.self, from: response.data) {
-                return decodedData
-            }
+            let decodedData = try decoder.decode(T.self, from: response.data)
+            return decodedData
         }
         
         let (data, response) = try await urlSession.performRequest(with: urlRequest)

--- a/Sources/CorePayments/Networking/HTTP.swift
+++ b/Sources/CorePayments/Networking/HTTP.swift
@@ -35,12 +35,11 @@ class HTTP {
         
         switch response.statusCode {
         case 200..<300:
+            let decodedData = try decoder.decode(T.self, from: data)
             if cachingEnabled {
                 let cachedURLResponse = CachedURLResponse(response: response, data: data)
                 urlCache.storeCachedResponse(cachedURLResponse, for: urlRequest)
             }
-            
-            let decodedData = try decoder.decode(T.self, from: data)
             return (decodedData)
         default:
             let errorData = try decoder.decode(from: data)

--- a/UnitTests/PaymentsCoreTests/HTTP_Tests.swift
+++ b/UnitTests/PaymentsCoreTests/HTTP_Tests.swift
@@ -192,4 +192,16 @@ class HTTP_Tests: XCTestCase {
             XCTAssertNil(dataInCache)
         }
     }
+    
+    func testPerformRequestWithCaching_whenDecodingFailure_doesNotCacheHTTPResponse() async throws {
+        mockURLSession.cannedJSONData = #"{ "fake_param": "missingParenthesisBadResponse""#
+        mockURLSession.cannedURLResponse = HTTPURLResponse(url: URL(string: "www.test.com")!, statusCode: 200, httpVersion: "https", headerFields: [:])!
+        
+        do {
+            _ = try await sut.performRequest(fakeRequest, withCaching: true)
+        } catch {
+            let dataInCache = mockURLCache.cannedCache[fakeURLRequest]?.data
+            XCTAssertNil(dataInCache)
+        }
+    }
 }

--- a/UnitTests/PaymentsCoreTests/HTTP_Tests.swift
+++ b/UnitTests/PaymentsCoreTests/HTTP_Tests.swift
@@ -180,4 +180,16 @@ class HTTP_Tests: XCTestCase {
         
         XCTAssertEqual(decodedCacheData.fakeParam, "cached_value2")
     }
+    
+    func testPerformRequestWithCaching_whenBadStatusCode_doesNotCacheHTTPResponse() async throws {
+        mockURLSession.cannedJSONData = #"{ "fake_param": "response" }"#
+        mockURLSession.cannedURLResponse = HTTPURLResponse(url: URL(string: "www.test.com")!, statusCode: 400, httpVersion: "https", headerFields: [:])!
+        
+        do {
+            _ = try await sut.performRequest(fakeRequest, withCaching: true)
+        } catch {
+            let dataInCache = mockURLCache.cannedCache[fakeURLRequest]?.data
+            XCTAssertNil(dataInCache)
+        }
+    }
 }


### PR DESCRIPTION
### Reason for changes

-We have an issue on both GH and Slack that claim when running on device, the SDKs’s clientID fetch before the NXO flow fails and returns the error: Error fetching clientID. Upon deleting app and reinstalling, there were no more issues.
We suspect that an error response got cached. 

### Summary of changes

- check for valid data when storing and retrieving from cache

### Checklist

~- [ ] Added a changelog entry~

### Authors
@KunJeongPark  @scannillo 

- 