### PR TITLE
Clarify docs that `PayPalNativeShippingDelegate` is sometimes required

### DIFF
--- a/Sources/PayPalNativePayments/PayPalNativeCheckoutDelegate.swift
+++ b/Sources/PayPalNativePayments/PayPalNativeCheckoutDelegate.swift
@@ -28,7 +28,7 @@ public protocol PayPalNativeCheckoutDelegate: AnyObject {
     func paypalWillStart(_ payPalClient: PayPalNativeCheckoutClient)
 }
 
-/// A delegate to receive notifcations if the user changes their shipping information.
+/// A delegate to receive notifications if the user changes their shipping information.
 ///
 /// This is **only required** if the order ID was created with `shipping_preferences = GET_FROM_FILE`. [See Orders V2 documentation](https://developer.paypal.com/docs/api/orders/v2/#definition-order_application_context). If the order ID was created with `shipping_preferences = NO_SHIPPING` or `SET_PROVIDED_ADDRESS`, don't implement this protocol.
 public protocol PayPalNativeShippingDelegate: AnyObject {

--- a/Sources/PayPalNativePayments/PayPalNativeCheckoutDelegate.swift
+++ b/Sources/PayPalNativePayments/PayPalNativeCheckoutDelegate.swift
@@ -28,7 +28,9 @@ public protocol PayPalNativeCheckoutDelegate: AnyObject {
     func paypalWillStart(_ payPalClient: PayPalNativeCheckoutClient)
 }
 
-/// An optional delegate to receive notifcations if the user changes their shipping information.
+/// A delegate to receive notifcations if the user changes their shipping information.
+///
+/// This is **only required** if the order ID was created with `shipping_preferences = GET_FROM_FILE`. [See Orders V2 documentation](https://developer.paypal.com/docs/api/orders/v2/#definition-order_application_context). If the order ID was created with `shipping_preferences = NO_SHIPPING` or `SET_PROVIDED_ADDRESS`, don't implement this protocol.
 public protocol PayPalNativeShippingDelegate: AnyObject {
     
     /// Notify when the users selected shipping address changes. Use `PayPalNativeShippingActions.approve`

--- a/docs/PayPalNativePayments/README.md
+++ b/docs/PayPalNativePayments/README.md
@@ -126,8 +126,8 @@ For a working example please refer to [PayPalViewModel](../../Demo/Demo/ViewMode
 extension MyViewModel: PayPalNativeShippingDelegate {
 
     func setup() {
-        paypalNativeClient.delegate = self         // required
-        paypalNativeClient.shippingDelegate = self // optional
+        paypalNativeClient.delegate = self         // always required
+        paypalNativeClient.shippingDelegate = self // required for `GET_FROM_FILE` orders
     }
 
     func paypal(

--- a/docs/PayPalNativePayments/README.md
+++ b/docs/PayPalNativePayments/README.md
@@ -116,11 +116,11 @@ extension MyViewModel: PayPalNativeCheckoutDelegate {
 
 For a working example please refer to [PayPalViewModel](../../Demo/Demo/ViewModels/PayPalViewModel.swift) in our Demo application
 
-### 5. Optionally inspect shipping details
+### 5. Inspect shipping details
 
-You can optionally conform to `PayPalNativeShippingDelegate` to receive notifications when the user updates their shipping address or shipping method details.
+:warning: Only implement `PayPalNativeShippingDelegate` if your order ID was created with [`shipping_preference`](https://developer.paypal.com/docs/api/orders/v2/#definition-order_application_context) = `GET_FROM_FILE`. If you created your order ID with [`shipping_preference`](https://developer.paypal.com/docs/api/orders/v2/#definition-order_application_context) = `NO_SHIPPING` or `SET_PROVIDED_ADDRESS`, **skip this step**.
 
-Implementing this optional delegate will require your server implementation support the [PayPal Orders API - Update order](https://developer.paypal.com/docs/api/orders/v2/#orders_patch) (or `PATCH`) functionality.
+`PayPalNativeShippingDelegate` notifies your app when the user updates their shipping address or shipping method details. You are required to `PATCH` the order details on your server if the shipping method (or amount) changes. Do this with the [PayPal Orders API - Update order](https://developer.paypal.com/docs/api/orders/v2/#orders_patch) functionality.
 
 ```swift
 extension MyViewModel: PayPalNativeShippingDelegate {


### PR DESCRIPTION
### Reason for changes

- [This GH issue](https://github.com/paypal/iOS-SDK/issues/146#issuecomment-1538689698) raised a question about when a merchant needs to implement the shipping callback. Turns out, it is not entirely optional. There is a case when a merchant must set it to avoid an infinite spinner on their checkout button.
- Special thanks to @laurentbourg for highlighting this area of improvement 👏 

### Summary of changes

- Clarify that merchants using `GET_FROM_FILE` orders must implement `PayPalNativeShippingDelegate`

### Checklist

- ~Added a changelog entry~

### Authors
@scannillo 