### PR TITLE
catch encoding error and general errors in cardClient

### DIFF
--- a/PayPal.xcodeproj/project.pbxproj
+++ b/PayPal.xcodeproj/project.pbxproj
@@ -14,6 +14,7 @@
 		067C92E527270FDE009E3054 /* PayPalEnvironment_Tests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 067C92E427270FDE009E3054 /* PayPalEnvironment_Tests.swift */; };
 		06CE009926F3D1660000CC46 /* CoreConfig.swift in Sources */ = {isa = PBXBuildFile; fileRef = 06CE009826F3D1660000CC46 /* CoreConfig.swift */; };
 		06CE009B26F3D5A40000CC46 /* CardClient.swift in Sources */ = {isa = PBXBuildFile; fileRef = 06CE009A26F3D5A40000CC46 /* CardClient.swift */; };
+		3B80D50C2A27979000D2EAC4 /* FailingJSONEncoder.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3B80D50B2A27979000D2EAC4 /* FailingJSONEncoder.swift */; };
 		3D1763A22720722A00652E1C /* CardResult.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3D1763A12720722A00652E1C /* CardResult.swift */; };
 		3DC42BA927187E8300B71645 /* ErrorResponse.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3DC42BA827187E8300B71645 /* ErrorResponse.swift */; };
 		537804FD28760BE2006442BD /* EligibilityAPI_Tests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 537804FC28760BE2006442BD /* EligibilityAPI_Tests.swift */; };
@@ -216,6 +217,7 @@
 		06CE009A26F3D5A40000CC46 /* CardClient.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CardClient.swift; sourceTree = "<group>"; };
 		06CE009F26F3DF100000CC46 /* ConfirmPaymentSourceRequest.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ConfirmPaymentSourceRequest.swift; sourceTree = "<group>"; };
 		06CE00A226F3E32A0000CC46 /* ConfirmPaymentSourceResponse.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ConfirmPaymentSourceResponse.swift; sourceTree = "<group>"; };
+		3B80D50B2A27979000D2EAC4 /* FailingJSONEncoder.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FailingJSONEncoder.swift; sourceTree = "<group>"; };
 		3D1763A12720722A00652E1C /* CardResult.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CardResult.swift; sourceTree = "<group>"; };
 		3D25238127344F330099E4EB /* NativeCheckoutStartable.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; name = NativeCheckoutStartable.swift; path = Sources/PayPalNativePayments/NativeCheckoutStartable.swift; sourceTree = SOURCE_ROOT; };
 		3D25238B273979170099E4EB /* MockNativeCheckoutProvider.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MockNativeCheckoutProvider.swift; sourceTree = "<group>"; };
@@ -600,6 +602,7 @@
 		80E743F9270E40CE00BACECA /* TestShared */ = {
 			isa = PBXGroup;
 			children = (
+				3B80D50B2A27979000D2EAC4 /* FailingJSONEncoder.swift */,
 				80E743FF270E40F300BACECA /* FakeRequests.swift */,
 				BCE8A7F427EA544000AC301B /* MockViewController.swift */,
 				BCE8A7F627EA54A000AC301B /* MockWebAuthenticationSession.swift */,
@@ -1422,6 +1425,7 @@
 				CB4BE28A28512A9800EA2DD1 /* MockQuededURLSession.swift in Sources */,
 				80E74400270E40F300BACECA /* FakeRequests.swift in Sources */,
 				E64763712899B60C00074113 /* MockAPIClient.swift in Sources */,
+				3B80D50C2A27979000D2EAC4 /* FailingJSONEncoder.swift in Sources */,
 				CBC16DDE29EE2F0600307117 /* PayPalNativePaysheetActions.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;

--- a/Sources/CardPayments/APIRequests/ConfirmPaymentSourceRequest.swift
+++ b/Sources/CardPayments/APIRequests/ConfirmPaymentSourceRequest.swift
@@ -49,6 +49,7 @@ struct ConfirmPaymentSourceRequest: APIRequest {
         // TODO - The complexity in this `init` signals to reconsider our use/design of the `APIRequest` protocol.
         // Existing pattern doesn't provide clear, testable interface for encoding JSON POST bodies.
     }
+    
     // MARK: - APIRequest
     
     typealias ResponseType = ConfirmPaymentSourceResponse

--- a/Sources/CardPayments/APIRequests/ConfirmPaymentSourceRequest.swift
+++ b/Sources/CardPayments/APIRequests/ConfirmPaymentSourceRequest.swift
@@ -48,7 +48,7 @@ struct ConfirmPaymentSourceRequest: APIRequest {
         // Existing pattern doesn't provide clear, testable interface for encoding JSON POST bodies.
     }
     
-    /// :nodoc: for testing purpose
+    /// For testing purpose
     init(
         accessToken: String,
         cardRequest: CardRequest,

--- a/Sources/CardPayments/APIRequests/ConfirmPaymentSourceRequest.swift
+++ b/Sources/CardPayments/APIRequests/ConfirmPaymentSourceRequest.swift
@@ -18,7 +18,6 @@ struct ConfirmPaymentSourceRequest: APIRequest {
         accessToken: String,
         cardRequest: CardRequest
     ) throws {
-       
         self.jsonEncoder = JSONEncoder()
         var confirmPaymentSource = ConfirmPaymentSource()
         var card = cardRequest.card

--- a/Sources/CardPayments/APIRequests/ConfirmPaymentSourceRequest.swift
+++ b/Sources/CardPayments/APIRequests/ConfirmPaymentSourceRequest.swift
@@ -9,52 +9,20 @@ struct ConfirmPaymentSourceRequest: APIRequest {
     private let orderID: String
     private let pathFormat: String = "/v2/checkout/orders/%@/confirm-payment-source"
     private let accessToken: String
-    var jsonEncoder: JSONEncoder?
+    var jsonEncoder: JSONEncoder
     
     /// Creates a request to attach a payment source to a specific order.
     /// In order to use this initializer, the `paymentSource` parameter has to
     /// contain the entire dictionary as it exists underneath the `payment_source` key.
-    init(
-        accessToken: String,
-        cardRequest: CardRequest
-    ) throws {
-        self.jsonEncoder = JSONEncoder()
-        var confirmPaymentSource = ConfirmPaymentSource()
-        var card = cardRequest.card
-        let verification = Verification(method: cardRequest.sca.rawValue)
-        card.attributes = Attributes(verification: verification)
-            
-        confirmPaymentSource.applicationContext = ApplicationContext(
-            returnUrl: PayPalCoreConstants.callbackURLScheme + "://card/success",
-            cancelUrl: PayPalCoreConstants.callbackURLScheme + "://card/cancel"
-        )
-        
-        confirmPaymentSource.paymentSource = PaymentSource(card: card)
-        
-        self.orderID = cardRequest.orderID
-        self.accessToken = accessToken
-        
-        path = String(format: pathFormat, orderID)
-        
-        jsonEncoder?.keyEncodingStrategy = .convertToSnakeCase
-        do {
-            body = try jsonEncoder?.encode(confirmPaymentSource)
-        } catch {
-            throw CardClientError.encodingError
-        }
-        
-        // TODO - The complexity in this `init` signals to reconsider our use/design of the `APIRequest` protocol.
-        // Existing pattern doesn't provide clear, testable interface for encoding JSON POST bodies.
-    }
     
     /// For testing purpose
     init(
         accessToken: String,
         cardRequest: CardRequest,
-        encoder: JSONEncoder?
+        encoder: JSONEncoder = JSONEncoder()
     ) throws {
         // encode with custom encoder that throws error if passed in
-        self.jsonEncoder = encoder ?? JSONEncoder()
+        self.jsonEncoder = encoder
         var confirmPaymentSource = ConfirmPaymentSource()
         var card = cardRequest.card
         let verification = Verification(method: cardRequest.sca.rawValue)
@@ -72,9 +40,9 @@ struct ConfirmPaymentSourceRequest: APIRequest {
         
         path = String(format: pathFormat, orderID)
         
-        jsonEncoder?.keyEncodingStrategy = .convertToSnakeCase
+        jsonEncoder.keyEncodingStrategy = .convertToSnakeCase
         do {
-            body = try jsonEncoder?.encode(confirmPaymentSource)
+            body = try jsonEncoder.encode(confirmPaymentSource)
         } catch {
             throw CardClientError.encodingError
         }

--- a/Sources/CardPayments/APIRequests/ConfirmPaymentSourceRequest.swift
+++ b/Sources/CardPayments/APIRequests/ConfirmPaymentSourceRequest.swift
@@ -36,7 +36,11 @@ struct ConfirmPaymentSourceRequest: APIRequest {
         path = String(format: pathFormat, orderID)
         
         jsonEncoder.keyEncodingStrategy = .convertToSnakeCase
-        body = try jsonEncoder.encode(confirmPaymentSource)
+        do {
+            body = try jsonEncoder.encode(confirmPaymentSource)
+        } catch {
+            throw CardClientError.encodingError
+        }
         
         // TODO - The complexity in this `init` signals to reconsider our use/design of the `APIRequest` protocol.
         // Existing pattern doesn't provide clear, testable interface for encoding JSON POST bodies.

--- a/Sources/CardPayments/APIRequests/ConfirmPaymentSourceRequest.swift
+++ b/Sources/CardPayments/APIRequests/ConfirmPaymentSourceRequest.swift
@@ -9,15 +9,21 @@ struct ConfirmPaymentSourceRequest: APIRequest {
     private let orderID: String
     private let pathFormat: String = "/v2/checkout/orders/%@/confirm-payment-source"
     private let accessToken: String
-    private let jsonEncoder = JSONEncoder()
+    var jsonEncoder: JSONEncoder?
     
     /// Creates a request to attach a payment source to a specific order.
     /// In order to use this initializer, the `paymentSource` parameter has to
     /// contain the entire dictionary as it exists underneath the `payment_source` key.
     init(
         accessToken: String,
-        cardRequest: CardRequest
+        cardRequest: CardRequest,
+        encoder: JSONEncoder? = nil
     ) throws {
+        if encoder != nil {
+            self.jsonEncoder = encoder
+        } else {
+            self.jsonEncoder = JSONEncoder()
+        }
         var confirmPaymentSource = ConfirmPaymentSource()
         var card = cardRequest.card
         let verification = Verification(method: cardRequest.sca.rawValue)
@@ -35,9 +41,9 @@ struct ConfirmPaymentSourceRequest: APIRequest {
         
         path = String(format: pathFormat, orderID)
         
-        jsonEncoder.keyEncodingStrategy = .convertToSnakeCase
+        jsonEncoder?.keyEncodingStrategy = .convertToSnakeCase
         do {
-            body = try jsonEncoder.encode(confirmPaymentSource)
+            body = try jsonEncoder?.encode(confirmPaymentSource)
         } catch {
             throw CardClientError.encodingError
         }

--- a/Sources/CardPayments/APIRequests/ConfirmPaymentSourceRequest.swift
+++ b/Sources/CardPayments/APIRequests/ConfirmPaymentSourceRequest.swift
@@ -18,9 +18,8 @@ struct ConfirmPaymentSourceRequest: APIRequest {
     init(
         accessToken: String,
         cardRequest: CardRequest,
-        encoder: JSONEncoder = JSONEncoder()
+        encoder: JSONEncoder = JSONEncoder() // exposed for test injection
     ) throws {
-        // encode with custom encoder that throws error if passed in
         self.jsonEncoder = encoder
         var confirmPaymentSource = ConfirmPaymentSource()
         var card = cardRequest.card

--- a/Sources/CardPayments/APIRequests/ConfirmPaymentSourceRequest.swift
+++ b/Sources/CardPayments/APIRequests/ConfirmPaymentSourceRequest.swift
@@ -15,7 +15,6 @@ struct ConfirmPaymentSourceRequest: APIRequest {
     /// In order to use this initializer, the `paymentSource` parameter has to
     /// contain the entire dictionary as it exists underneath the `payment_source` key.
     
-    /// For testing purpose
     init(
         accessToken: String,
         cardRequest: CardRequest,

--- a/Sources/CardPayments/CardClient.swift
+++ b/Sources/CardPayments/CardClient.swift
@@ -61,6 +61,8 @@ public class CardClient: NSObject {
                 analyticsService?.sendEvent("card-payments:3ds:confirm-payment-source:failed")
                 notifyFailure(with: error)
             } catch {
+                analyticsService?.sendEvent("card-payments:3ds:confirm-payment-source:failed")
+                notifyFailure(with: CardClientError.unknownError)
             }
         }
     }

--- a/Sources/CardPayments/CardClientError.swift
+++ b/Sources/CardPayments/CardClientError.swift
@@ -21,6 +21,12 @@ enum CardClientError {
         case threeDSecureURLError
     }
 
+    static let unknownError = CoreSDKError(
+        code: Code.encodingError.rawValue,
+        domain: domain,
+        errorDescription: "An unknown error has occured. Contact developer.paypal.com/support."
+    )
+    
     static let encodingError = CoreSDKError(
         code: Code.encodingError.rawValue,
         domain: domain,

--- a/Sources/CardPayments/CardClientError.swift
+++ b/Sources/CardPayments/CardClientError.swift
@@ -22,7 +22,7 @@ enum CardClientError {
     }
 
     static let unknownError = CoreSDKError(
-        code: Code.encodingError.rawValue,
+        code: Code.unknown.rawValue,
         domain: domain,
         errorDescription: "An unknown error has occured. Contact developer.paypal.com/support."
     )

--- a/UnitTests/CardPaymentsTests/ConfirmPaymentSourceRequest_Tests.swift
+++ b/UnitTests/CardPaymentsTests/ConfirmPaymentSourceRequest_Tests.swift
@@ -74,10 +74,14 @@ class ConfirmPaymentSourceRequest_Tests: XCTestCase {
         XCTAssertEqual(confirmPaymentSourceRequest.headers, expectedHeaders)
     }
 
+    enum TestError: Error {
+        case encodeError
+    }
+    
     class FailingJSONEncoder: JSONEncoder {
         
         override func encode<T>(_ value: T) throws -> Data where T: Encodable {
-            throw CardClientError.encodingError
+            throw TestError.encodeError
         }
     }
 

--- a/UnitTests/CardPaymentsTests/ConfirmPaymentSourceRequest_Tests.swift
+++ b/UnitTests/CardPaymentsTests/ConfirmPaymentSourceRequest_Tests.swift
@@ -86,14 +86,14 @@ class ConfirmPaymentSourceRequest_Tests: XCTestCase {
     }
 
     func testEncodingFailure_throws_EncodingError() throws {
-        let mockOrderId = "mockOrderId"
+        let mockOrderID = "mockOrderID"
         let card = Card(
             number: "4032036247327321",
             expirationMonth: "11",
             expirationYear: "2024",
             securityCode: "222"
         )
-        let cardRequest = CardRequest(orderID: mockOrderId, card: card)
+        let cardRequest = CardRequest(orderID: mockOrderID, card: card)
         
         let failingEncoder = FailingJSONEncoder()
         

--- a/UnitTests/CardPaymentsTests/ConfirmPaymentSourceRequest_Tests.swift
+++ b/UnitTests/CardPaymentsTests/ConfirmPaymentSourceRequest_Tests.swift
@@ -89,9 +89,9 @@ class ConfirmPaymentSourceRequest_Tests: XCTestCase {
         
         XCTAssertThrowsError(
             try ConfirmPaymentSourceRequest(
-            accessToken: "fake token",
-            cardRequest: cardRequest,
-            encoder: failingEncoder)
+                accessToken: "fake token",
+                cardRequest: cardRequest,
+                encoder: failingEncoder)
         ) { error in
             guard let coreSDKError = error as? CoreSDKError else {
                 XCTFail("Thrown error should be a CoreSDKError")

--- a/UnitTests/CardPaymentsTests/ConfirmPaymentSourceRequest_Tests.swift
+++ b/UnitTests/CardPaymentsTests/ConfirmPaymentSourceRequest_Tests.swift
@@ -74,10 +74,6 @@ class ConfirmPaymentSourceRequest_Tests: XCTestCase {
         XCTAssertEqual(confirmPaymentSourceRequest.headers, expectedHeaders)
     }
 
-    enum TestError: Error {
-        case encodingError
-    }
-
     class FailingJSONEncoder: JSONEncoder {
         
         override func encode<T>(_ value: T) throws -> Data where T: Encodable {

--- a/UnitTests/CardPaymentsTests/ConfirmPaymentSourceRequest_Tests.swift
+++ b/UnitTests/CardPaymentsTests/ConfirmPaymentSourceRequest_Tests.swift
@@ -2,6 +2,7 @@ import Foundation
 import XCTest
 @testable import CorePayments
 @testable import CardPayments
+@testable import TestShared
 
 class ConfirmPaymentSourceRequest_Tests: XCTestCase {
 
@@ -74,17 +75,6 @@ class ConfirmPaymentSourceRequest_Tests: XCTestCase {
         XCTAssertEqual(confirmPaymentSourceRequest.headers, expectedHeaders)
     }
 
-    enum TestError: Error {
-        case encodeError
-    }
-    
-    class FailingJSONEncoder: JSONEncoder {
-        
-        override func encode<T>(_ value: T) throws -> Data where T: Encodable {
-            throw TestError.encodeError
-        }
-    }
-
     func testEncodingFailure_throws_EncodingError() throws {
         let mockOrderID = "mockOrderID"
         let card = Card(
@@ -97,10 +87,12 @@ class ConfirmPaymentSourceRequest_Tests: XCTestCase {
         
         let failingEncoder = FailingJSONEncoder()
         
-        XCTAssertThrowsError(try ConfirmPaymentSourceRequest(
+        XCTAssertThrowsError(
+            try ConfirmPaymentSourceRequest(
             accessToken: "fake token",
             cardRequest: cardRequest,
-            encoder: failingEncoder)) { error in
+            encoder: failingEncoder)
+        ) { error in
             guard let coreSDKError = error as? CoreSDKError else {
                 XCTFail("Thrown error should be a CoreSDKError")
                 return

--- a/UnitTests/TestShared/FailingJSONEncoder.swift
+++ b/UnitTests/TestShared/FailingJSONEncoder.swift
@@ -1,0 +1,12 @@
+import Foundation
+
+enum TestError: Error {
+    case encodeError
+}
+
+class FailingJSONEncoder: JSONEncoder {
+    
+    override func encode<T>(_ value: T) throws -> Data where T: Encodable {
+        throw TestError.encodeError
+    }
+}


### PR DESCRIPTION
### Reason for changes
-CardClient had general catch block with no return to merchant app
-Errors propagated from numerous sources and expecting CoreSDKError type in card delegate function is risky
 without general case handling


### Summary of changes

- Added catching encoding error in ConfirmPaymentRequest
- Added unknownError property in CardClientError
- Send CardClientError.unknownError in general catch block in CardClient's approveOrder function

### Checklist

~- [ ] Added a changelog entry~

### Authors
> @KunJeongPark 