### PR TITLE
change on-disk to in-memory cache HTTP performRequest

### DIFF
--- a/Sources/CorePayments/Networking/HTTP.swift
+++ b/Sources/CorePayments/Networking/HTTP.swift
@@ -10,7 +10,7 @@ class HTTP {
 
     init(
         urlSession: URLSessionProtocol = URLSession.shared,
-        urlCache: URLCacheable = URLCache.shared,
+        urlCache: URLCacheable = URLCache(memoryCapacity: 4 * 1024 * 1024, diskCapacity: 0),
         coreConfig: CoreConfig
     ) {
         self.urlSession = urlSession


### PR DESCRIPTION
### Reason for changes

-clientID should not persist on disk in between app sessions.

### Summary of changes

- changed from on-disk to in-memory caching of data in HTTP performRequest

### Checklist

~- [ ] Added a changelog entry~

### Authors
@KunJeongPark @jcnoriega 