### PR TITLE
Return Deep Link URL from 3DS Verification

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 # PayPal iOS SDK Release Notes
 
 ## unreleased
+* CardPayments
+  * Add `deepLinkURL` property to `CardResult`
 * Breaking Changes
   * CardPayments
     * Remove `status` property from `CardResult`

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,8 +2,6 @@
 # PayPal iOS SDK Release Notes
 
 ## unreleased
-* CardPayments
-  * Add `deepLinkURL` property to `CardResult`
 * Breaking Changes
   * CardPayments
     * Remove `status` property from `CardResult`

--- a/Sources/CardPayments/CardClient.swift
+++ b/Sources/CardPayments/CardClient.swift
@@ -50,9 +50,7 @@ public class CardClient: NSObject {
                 } else {
                     analyticsService?.sendEvent("card-payments:3ds:confirm-payment-source:succeeded")
                     
-                    let cardResult = CardResult(
-                        orderID: result.id
-                    )
+                    let cardResult = CardResult(orderID: result.id, deepLinkURL: nil)
                     notifySuccess(for: cardResult)
                 }
             } catch let error as CoreSDKError {
@@ -86,7 +84,7 @@ public class CardClient: NSObject {
                     self?.analyticsService?.sendEvent("card-payments:3ds:challenge-presentation:failed")
                 }
             },
-            sessionDidComplete: { _, error in
+            sessionDidComplete: { url, error in
                 self.delegate?.cardThreeDSecureDidFinish(self)
                 if let error = error {
                     switch error {
@@ -99,9 +97,7 @@ public class CardClient: NSObject {
                     }
                 }
                 
-                let cardResult = CardResult(
-                    orderID: orderId
-                )
+                let cardResult = CardResult(orderID: orderId, deepLinkURL: url)
                 self.notifySuccess(for: cardResult)
             }
         )

--- a/Sources/CardPayments/Models/CardResult.swift
+++ b/Sources/CardPayments/Models/CardResult.swift
@@ -9,6 +9,8 @@ public struct CardResult {
     /// The order ID associated with the transaction
     public let orderID: String
 
-    ///  The deep link url returned from 3DS authentication
+    //// :nodoc: This is the deep link url returned from 3DS authentication
+    ///
+    // TODO: parse contents of this URL once we are clear on values returned from 3ds
     public let deepLinkURL: URL?
 }

--- a/Sources/CardPayments/Models/CardResult.swift
+++ b/Sources/CardPayments/Models/CardResult.swift
@@ -8,4 +8,7 @@ public struct CardResult {
 
     /// The order ID associated with the transaction
     public let orderID: String
+
+    ///  The deep link url returned from 3DS authentication
+    public let deepLinkURL: URL?
 }

--- a/Sources/CardPayments/Models/CardResult.swift
+++ b/Sources/CardPayments/Models/CardResult.swift
@@ -10,7 +10,6 @@ public struct CardResult {
     public let orderID: String
 
     //// :nodoc: This is the deep link url returned from 3DS authentication
-    ///
     // TODO: parse contents of this URL once we are clear on values returned from 3ds
     public let deepLinkURL: URL?
 }


### PR DESCRIPTION
### Summary of changes

- Added url from 3DS authentication to CardResult returned to the merchant in notifySuccess

### Checklist

- [x] Added a changelog entry

### Authors
> List GitHub usernames for everyone who contributed to this pull request.

- @KunJeongPark @sshropshire 