### PR TITLE
Remove Reference to AccessToken in Integration Guides

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,10 +31,7 @@ This SDK supports:
 
 ## Client ID
 
-The PayPal SDK uses client ID for authentication.
-
-> The following example can be adapted to any server-side language/framework of your choice. We use command-line curl requests to demonstrate the overall composition of the Access Token HTTP request.
-
+The PayPal SDK uses a client ID for authentication.
 
 ## Modules
 

--- a/README.md
+++ b/README.md
@@ -50,7 +50,7 @@ To accept a certain payment method in your app, you only need to include that pa
 ## Sample Code
 
 ```swift
-// STEP 0: Fetch an CLIENT_ID and ORDER_ID from your server.
+// STEP 0: Enter a CLIENT_ID and fetch ORDER_ID from your server.
 
 // STEP 1: Create a CoreConfiguration object
 paymentConfig = CoreConfig(clientID: CLIENT_ID, environment: .sandbox)

--- a/README.md
+++ b/README.md
@@ -29,48 +29,12 @@ This SDK supports:
 * UIKit
 * SwiftUI
 
-## Access Token
+## ClientID
 
-The PayPal SDK uses access tokens for authentication.
+The PayPal SDK uses clientID for authentication.
 
 > The following example can be adapted to any server-side language/framework of your choice. We use command-line curl requests to demonstrate the overall composition of the Access Token HTTP request.
 
-To create an access token:
-
-1. Follow the steps in [Get Started](https://developer.paypal.com/api/rest/#link-getstarted) to obtain a client ID and secret from the PayPal Developer site.
-1. Make an HTTP request with Basic Authentication using client ID and secret to fetch an access token:
-
-**Request**
-```bash
-# for LIVE environment
-curl -X POST https://api.paypal.com/v1/oauth2/token \
--u $CLIENT_ID:$CLIENT_SECRET \
--H 'Content-Type: application/x-www-form-urlencoded' \
--d 'grant_type=client_credentials&response_type=token&return_authn_schemes=true'
-
-# for SANDBOX environment
-curl -X POST https://api.sandbox.paypal.com/v1/oauth2/token \
--u $CLIENT_ID:$CLIENT_SECRET \
--H 'Content-Type: application/x-www-form-urlencoded' \
--d 'grant_type=client_credentials&response_type=token&return_authn_schemes=true'
-```
-
-:warning:&nbsp;Make sure the environment variables for `CLIENT_ID` and `CLIENT_SECRET` are set.
-
-**Response**
-
-```json
-{
-  "scope": "...",
-  "access_token": "<ACCESS_TOKEN>",
-  "token_type": "Bearer",
-  "app_id": "...",
-  "expires_in": 32400,
-  "nonce": "..."
-}
-```
-
-Use the value for `access_token` in the response to create an instance of `CoreConfig` to use with any of the SDK's feature clients.
 
 ## Modules
 
@@ -86,10 +50,10 @@ To accept a certain payment method in your app, you only need to include that pa
 ## Sample Code
 
 ```swift
-// STEP 0: Fetch an ACCESS_TOKEN and ORDER_ID from your server.
+// STEP 0: Fetch an CLIENT_ID and ORDER_ID from your server.
 
-// STEP 1: Create a PaymentConfiguration object
-paymentConfig = PaymentConfig(token: ACCESS_TOKEN)
+// STEP 1: Create a CoreConfiguration object
+paymentConfig = CoreConfig(clientID: CLIENT_ID, environment: .sandbox)
 
 // STEP 2: Create payment method client objects
 cardClient = CardClient(config: paymentConfig)

--- a/README.md
+++ b/README.md
@@ -44,35 +44,6 @@ Each feature module has its own onboarding guide:
 
 To accept a certain payment method in your app, you only need to include that payment-specific submodule.
 
-## Sample Code
-
-```swift
-// STEP 0: Enter a CLIENT_ID and fetch ORDER_ID from your server.
-
-// STEP 1: Create a CoreConfiguration object
-paymentConfig = CoreConfig(clientID: CLIENT_ID, environment: .sandbox)
-
-// STEP 2: Create payment method client objects
-cardClient = CardClient(config: paymentConfig)
-
-// STEP 3: Collect relevant payment method details
-card = Card(number: 4111111111111111, cvv: 123, ...)
-
-// STEP 4: Call checkout method
-cardClient?.checkoutWithCard(orderID: ORDER_ID, card: card) { result in
-    switch result {
-    case .success(let orderId):
-      // Send orderID to your server to process the payment
-    case .error(let error):
-      // handle checkout error
-    }
-}
-
-// STEP 5: Send orderID to your server to capture/authorize
-
-```
-
-
 ## Testing
 
 This project uses the `XCTest` framework provided by Xcode. Every code path should be unit tested. Unit tests should make up most of the test coverage, with integration, and then UI tests following.

--- a/README.md
+++ b/README.md
@@ -29,9 +29,9 @@ This SDK supports:
 * UIKit
 * SwiftUI
 
-## ClientID
+## Client ID
 
-The PayPal SDK uses clientID for authentication.
+The PayPal SDK uses client ID for authentication.
 
 > The following example can be adapted to any server-side language/framework of your choice. We use command-line curl requests to demonstrate the overall composition of the Access Token HTTP request.
 

--- a/docs/CardPayments/README.md
+++ b/docs/CardPayments/README.md
@@ -33,10 +33,10 @@ pod 'PayPal/CardPayments'
 
 ### 2. Initiate the CardPayments SDK
 
-Create a `CoreConfig` using an [access token](../../README.md#access-token):
+Create a `CoreConfig` using an [client id](https://developer.paypal.com/api/rest/):
 
 ```swift
-let config = CoreConfig(accessToken: "<ACCESS_TOKEN>", environment: .sandbox)
+let config = CoreConfig(clientID: "<CLIENT_ID>", environment: .sandbox)
 ```
 
 Create a `CardClient` to approve an order with a Card payment method:

--- a/docs/CardPayments/README.md
+++ b/docs/CardPayments/README.md
@@ -11,7 +11,7 @@ Follow these steps to add Card payments:
 ## Setup a PayPal Developer Account
 
 You will need to set up authorization to use the PayPal Payments SDK. 
-Follow the steps in [Get Started](https://developer.paypal.com/api/rest/#link-getstarted) to create a client ID and generate an access token. 
+Follow the steps in [Get Started](https://developer.paypal.com/api/rest/#link-getstarted) to create a client ID.
 
 You will need a server integration to create an order and capture the funds using [PayPal Orders v2 API](https://developer.paypal.com/docs/api/orders/v2). 
 

--- a/docs/PayPalNativePayments/README.md
+++ b/docs/PayPalNativePayments/README.md
@@ -34,10 +34,10 @@ pod 'PayPal/PayPalNativePayments'
 
 ### 2. Initiate the Payments SDK
 
-Create a `CoreConfig` using an [access token](../../README.md#access-token):
+Create a `CoreConfig` using an [client id](https://developer.paypal.com/api/rest/):
 
 ```swift
-let config = CoreConfig(accessToken: "<ACCESS_TOKEN>", environment: .sandbox)
+let config = CoreConfig(clientID: "<CLIENT_ID>", environment: .sandbox)
 ```
 
 Create a `PayPalNativeCheckoutClient` to approve an order with a PayPal payment method:

--- a/docs/PayPalWebPayments/README.md
+++ b/docs/PayPalWebPayments/README.md
@@ -33,10 +33,10 @@ pod 'PayPal/PayPalWebPayments'
 
 ### 2. Initiate the Payments SDK
 
-Create a `CoreConfig` using an [access token](../../README.md#access-token):
+Create a `CoreConfig` using an [client id](https://developer.paypal.com/api/rest/):
 
 ```swift
-let config = CoreConfig(accessToken: "<ACCESS_TOKEN>", environment: .sandbox)
+let config = CoreConfig(clientID: "<CLIENT_ID>", environment: .sandbox)
 ```
 
 Create a `PayPalWebCheckoutClient` to approve an order with a PayPal payment method:


### PR DESCRIPTION
### Summary of changes

- Change instruction for instantiating CoreConfig to use clientID instead of accessToken in README and /docs

### Checklist

~- [ ] Added a changelog entry~

### Authors
> List GitHub usernames for everyone who contributed to this pull request.

- @KunJeongPark 