### PR TITLE
Add Option to Select Merchant Integration Credential in Demo App

### DIFF
--- a/Demo/Demo.xcodeproj/project.pbxproj
+++ b/Demo/Demo.xcodeproj/project.pbxproj
@@ -9,6 +9,7 @@
 /* Begin PBXBuildFile section */
 		3B80D50E2A291C0800D2EAC4 /* ClientIDRequest.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3B80D50D2A291C0800D2EAC4 /* ClientIDRequest.swift */; };
 		3B80D5102A291CB100D2EAC4 /* ClientIDResponse.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3B80D50F2A291CB100D2EAC4 /* ClientIDResponse.swift */; };
+		3BB7A9772A5CA6FD00C05140 /* MerchantIntegration.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3BB7A9762A5CA6FD00C05140 /* MerchantIntegration.swift */; };
 		5301468C28918B4D00184F22 /* ApprovalResult.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5301468B28918B4D00184F22 /* ApprovalResult.swift */; };
 		536A5CA82898AA2A005C053D /* SwiftUINativeCheckoutDemo.swift in Sources */ = {isa = PBXBuildFile; fileRef = 536A5CA72898AA2A005C053D /* SwiftUINativeCheckoutDemo.swift */; };
 		53B9E8EA28C93B4400719239 /* OrderRequestHelpers.swift in Sources */ = {isa = PBXBuildFile; fileRef = 53B9E8E928C93B4400719239 /* OrderRequestHelpers.swift */; };
@@ -98,6 +99,7 @@
 /* Begin PBXFileReference section */
 		3B80D50D2A291C0800D2EAC4 /* ClientIDRequest.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ClientIDRequest.swift; sourceTree = "<group>"; };
 		3B80D50F2A291CB100D2EAC4 /* ClientIDResponse.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ClientIDResponse.swift; sourceTree = "<group>"; };
+		3BB7A9762A5CA6FD00C05140 /* MerchantIntegration.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MerchantIntegration.swift; sourceTree = "<group>"; };
 		5301468B28918B4D00184F22 /* ApprovalResult.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ApprovalResult.swift; sourceTree = "<group>"; };
 		536A5CA22898A48C005C053D /* PayPalNativeCheckout.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; path = PayPalNativeCheckout.framework; sourceTree = BUILT_PRODUCTS_DIR; };
 		536A5CA72898AA2A005C053D /* SwiftUINativeCheckoutDemo.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SwiftUINativeCheckoutDemo.swift; sourceTree = "<group>"; };
@@ -297,6 +299,7 @@
 			children = (
 				80F33CE726F8DE29006811B1 /* DemoMerchantAPI.swift */,
 				BE1766B226F911A2007EF438 /* URLResponseError.swift */,
+				3BB7A9762A5CA6FD00C05140 /* MerchantIntegration.swift */,
 			);
 			path = Networking;
 			sourceTree = "<group>";
@@ -493,6 +496,7 @@
 				80F33CEF26F8E7CC006811B1 /* CreateOrderParams.swift in Sources */,
 				BECD84A227036DDB007CCAE4 /* Intent.swift in Sources */,
 				BED041AF270CA0FB00C80954 /* CustomButton.swift in Sources */,
+				3BB7A9772A5CA6FD00C05140 /* MerchantIntegration.swift in Sources */,
 				BE1766B326F911A2007EF438 /* URLResponseError.swift in Sources */,
 				CBC16DD929ED90B600307117 /* UpdateOrderParams.swift in Sources */,
 				BE9F36D82745490400AFC7DA /* FloatingLabelTextField.swift in Sources */,

--- a/Demo/Demo/FeatureViewControllers/FeatureBaseViewController.swift
+++ b/Demo/Demo/FeatureViewControllers/FeatureBaseViewController.swift
@@ -94,7 +94,9 @@ class FeatureBaseViewController: UIViewController {
 
     @objc func createOrderTapped() {
         Task {
-            await baseViewModel.createOrder(amount: amountTextField.text)
+            await baseViewModel.createOrder(
+                amount: amountTextField.text, selectedMerchantIntegration: baseViewModel.selectedMerchantIntegration
+            )
         }
     }
 }

--- a/Demo/Demo/Models/CreateOrderParams.swift
+++ b/Demo/Demo/Models/CreateOrderParams.swift
@@ -7,6 +7,7 @@ struct CreateOrderParams: Codable {
 struct PurchaseUnit: Codable {
 
     let amount: Amount
+    // TODO: payee information for connected_partner
 }
 
 struct Amount: Codable {

--- a/Demo/Demo/Networking/DemoMerchantAPI.swift
+++ b/Demo/Demo/Networking/DemoMerchantAPI.swift
@@ -8,8 +8,7 @@ final class DemoMerchantAPI {
     // MARK: Public properties
 
     static let sharedService = DemoMerchantAPI()
-    var clientID: String?
-    
+
     // To hardcode an order ID and client ID for this demo app, set the below values
     enum InjectedValues {
         static let orderID: String? = nil
@@ -20,8 +19,8 @@ final class DemoMerchantAPI {
 
     // MARK: Public Methods
     
-    func caputureOrder(orderID: String) async throws -> Order {
-        guard let url = buildBaseURL(with: "/orders/\(orderID)/capture") else {
+    func captureOrder(orderID: String, selectedMerchantIntegration: MerchantIntegration) async throws -> Order {
+        guard let url = buildBaseURL(with: "/orders/\(orderID)/capture", selectedMerchantIntegration: selectedMerchantIntegration) else {
             throw URLResponseError.invalidURL
         }
         
@@ -30,8 +29,8 @@ final class DemoMerchantAPI {
         return try parse(from: data)
     }
     
-    func authorizeOrder(orderID: String) async throws -> Order {
-        guard let url = buildBaseURL(with: "/orders/\(orderID)/authorize") else {
+    func authorizeOrder(orderID: String, selectedMerchantIntegration: MerchantIntegration) async throws -> Order {
+        guard let url = buildBaseURL(with: "/orders/\(orderID)/authorize", selectedMerchantIntegration: selectedMerchantIntegration) else {
             throw URLResponseError.invalidURL
         }
         
@@ -44,12 +43,11 @@ final class DemoMerchantAPI {
     /// - Parameter orderParams: the parameters to create the order with
     /// - Returns: an order
     /// - Throws: an error explaining why create order failed
-    func createOrder(orderParams: CreateOrderParams) async throws -> Order {
+    func createOrder(orderParams: CreateOrderParams, selectedMerchantIntegration: MerchantIntegration) async throws -> Order {
         if let injectedOrderID = InjectedValues.orderID {
             return Order(id: injectedOrderID, status: "CREATED")
         }
-        
-        guard let url = buildBaseURL(with: "/orders") else {
+        guard let url = buildBaseURL(with: "/orders", selectedMerchantIntegration: selectedMerchantIntegration) else {
             throw URLResponseError.invalidURL
         }
 
@@ -62,11 +60,12 @@ final class DemoMerchantAPI {
     /// - Parameter orderRequest: the order request to create an order
     /// - Returns: an order
     /// - Throws: an error explaining why create order failed
-    func createOrder(orderRequest: PayPalCheckout.OrderRequest) async throws -> Order {
+    func createOrder(orderRequest: PayPalCheckout.OrderRequest, selectedMerchantIntegration: MerchantIntegration) async throws -> Order {
         if let injectedOrderID = InjectedValues.orderID {
             return Order(id: injectedOrderID, status: "CREATED")
         }
-        guard let url = buildBaseURL(with: "/orders") else {
+
+        guard let url = buildBaseURL(with: "/orders", selectedMerchantIntegration: selectedMerchantIntegration) else {
             throw URLResponseError.invalidURL
         }
 
@@ -75,27 +74,14 @@ final class DemoMerchantAPI {
         return try parse(from: data)
     }
 
-    /// This function replicates a way a merchant may go about authorizing/capturing an order on their server and is not part of the SDK flow.
-    /// - Parameters:
-    ///   - processOrderParams: the parameters to process the order with
-    /// - Returns: an order
-    /// - Throws: an error explaining why process order failed
-    func processOrder(processOrderParams: ProcessOrderParams) async throws -> Order {
-        guard let url = buildBaseURL(with: "/\(processOrderParams.intent)-order") else {
-            throw URLResponseError.invalidURL
-        }
-
-        let urlRequest = buildURLRequest(method: "POST", url: url, body: processOrderParams)
-        let data = try await data(for: urlRequest)
-        return try parse(from: data)
-    }
-    
     /// This function replicates a way a merchant may go about patching an order on their server and is not part of the SDK flow.
     /// - Parameters:
     ///   - updateOrderParams: the parameters to update the order with
     /// - Throws: an error explaining why patching the order failed
-    func updateOrder(_ updateOrderParams: UpdateOrderParams) async throws {
-        guard let url = buildBaseURL(with: "/orders/" + updateOrderParams.orderID) else {
+    func updateOrder(_ updateOrderParams: UpdateOrderParams, selectedMerchantIntegration: MerchantIntegration) async throws {
+        guard let url = buildBaseURL(
+            with: "/orders/" + updateOrderParams.orderID, selectedMerchantIntegration: selectedMerchantIntegration
+        ) else {
             throw URLResponseError.invalidURL
         }
         let urlRequest = buildURLRequest(method: "PATCH", url: url, body: updateOrderParams.updateOperations)
@@ -107,16 +93,13 @@ final class DemoMerchantAPI {
     ///   - environment: the current environment
     /// - Returns: a String representing an clientID
     /// - Throws: an error explaining why fetch clientID failed
-    public func getClientID(environment: Demo.Environment) async -> String? {
+    public func getClientID(environment: Demo.Environment, selectedMerchantIntegration: MerchantIntegration) async -> String? {
         if let injectedClientID = InjectedValues.clientID {
             return injectedClientID
         }
         
-        guard let clientID else {
-            clientID = await fetchClientID(environment: environment)
+        let clientID = await fetchClientID(environment: environment, selectedMerchantIntegration: selectedMerchantIntegration)
             return clientID
-        }
-        return clientID
     }
 
     // MARK: Private methods
@@ -154,18 +137,20 @@ final class DemoMerchantAPI {
         }
     }
 
-    private func buildBaseURL(with endpoint: String) -> URL? {
-        URL(string: DemoSettings.environment.baseURL + endpoint)
+    private func buildBaseURL(with endpoint: String, selectedMerchantIntegration: MerchantIntegration = .unspecified) -> URL? {
+        return URL(string: DemoSettings.environment.baseURL + selectedMerchantIntegration.path + endpoint)
     }
 
     private func buildPayPalURL(with endpoint: String) -> URL? {
         URL(string: "https://api.sandbox.paypal.com" + endpoint)
     }
 
-    private func fetchClientID(environment: Demo.Environment) async -> String? {
+    private func fetchClientID(environment: Demo.Environment, selectedMerchantIntegration: MerchantIntegration) async -> String? {
         do {
             let clientIDRequest = ClientIDRequest()
-            let request = try createUrlRequest(clientIDRequest: clientIDRequest, environment: environment)
+            let request = try createUrlRequest(
+                clientIDRequest: clientIDRequest, environment: environment, selectedMerchantIntegration: selectedMerchantIntegration
+            )
             let (data, response) = try await URLSession.shared.performRequest(with: request)
             guard let response = response as? HTTPURLResponse else {
                 throw URLResponseError.serverError
@@ -182,8 +167,12 @@ final class DemoMerchantAPI {
         }
     }
     
-    private func createUrlRequest(clientIDRequest: ClientIDRequest, environment: Demo.Environment) throws -> URLRequest {
+    private func createUrlRequest(
+        clientIDRequest: ClientIDRequest, environment: Demo.Environment, selectedMerchantIntegration: MerchantIntegration
+    ) throws -> URLRequest {
         var completeUrl = environment.baseURL
+       
+        completeUrl += selectedMerchantIntegration.path
         completeUrl.append(contentsOf: clientIDRequest.path)
         guard let url = URL(string: completeUrl) else {
             throw URLResponseError.invalidURL

--- a/Demo/Demo/Networking/MerchantIntegration.swift
+++ b/Demo/Demo/Networking/MerchantIntegration.swift
@@ -1,0 +1,21 @@
+import Foundation
+
+enum MerchantIntegration {
+    case direct
+    case connectedPath
+    case managedPath
+    case unspecified
+    
+    var path: String {
+        switch self {
+        case .direct:
+            return "/direct"
+        case .connectedPath:
+            return "/connected_path"
+        case .managedPath:
+            return "/managed_path"
+        default:
+            return ""
+        }
+    }
+}

--- a/Demo/Demo/ViewModels/BaseViewModel.swift
+++ b/Demo/Demo/ViewModels/BaseViewModel.swift
@@ -8,27 +8,6 @@ import PayPalCheckout
 
 /// This class is used to share the orderID across shared views, update the text of `bottomStatusLabel` in our `FeatureBaseViewController`
 /// as well as share the logic of `processOrder` across our duplicate (SwiftUI and UIKit) card views.
-///
-/// // temp place instead of new file
-enum MerchantIntegration {
-    case direct
-    case connectedPath
-    case managedPath
-    case unspecified
-    
-    var path: String {
-        switch self {
-        case .direct:
-            return "/direct"
-        case .connectedPath:
-            return "/connected_path"
-        case .managedPath:
-            return "/managed_path"
-        default:
-            return ""
-        }
-    }
-}
 
 class BaseViewModel: ObservableObject, PayPalWebCheckoutDelegate, CardDelegate {
 
@@ -38,7 +17,7 @@ class BaseViewModel: ObservableObject, PayPalWebCheckoutDelegate, CardDelegate {
 
     /// order ID shared across views
     @Published var orderID: String?
-    @Published var selectedMerchantIntegration: MerchantIntegration = .connectedPath
+    @Published var selectedMerchantIntegration: MerchantIntegration = .unspecified
 
     // MARK: - Init
 

--- a/Demo/Demo/ViewModels/BaseViewModel.swift
+++ b/Demo/Demo/ViewModels/BaseViewModel.swift
@@ -8,7 +8,6 @@ import PayPalCheckout
 
 /// This class is used to share the orderID across shared views, update the text of `bottomStatusLabel` in our `FeatureBaseViewController`
 /// as well as share the logic of `processOrder` across our duplicate (SwiftUI and UIKit) card views.
-
 class BaseViewModel: ObservableObject, PayPalWebCheckoutDelegate, CardDelegate {
 
     /// Weak reference to associated view
@@ -45,7 +44,7 @@ class BaseViewModel: ObservableObject, PayPalWebCheckoutDelegate, CardDelegate {
         guard let amount = amount else { return nil }
 
         let amountRequest = Amount(currencyCode: "USD", value: amount)
-        // might need to pass in payee as payee object or as auth header
+        // TODO: might need to pass in payee as payee object or as auth header
         let orderRequestParams = CreateOrderParams(
             intent: DemoSettings.intent.rawValue.uppercased(),
             purchaseUnits: [PurchaseUnit(amount: amountRequest)]

--- a/Demo/Demo/ViewModels/BaseViewModel.swift
+++ b/Demo/Demo/ViewModels/BaseViewModel.swift
@@ -8,6 +8,28 @@ import PayPalCheckout
 
 /// This class is used to share the orderID across shared views, update the text of `bottomStatusLabel` in our `FeatureBaseViewController`
 /// as well as share the logic of `processOrder` across our duplicate (SwiftUI and UIKit) card views.
+///
+/// // temp place instead of new file
+enum MerchantIntegration {
+    case direct
+    case connectedPath
+    case managedPath
+    case unspecified
+    
+    var path: String {
+        switch self {
+        case .direct:
+            return "/direct"
+        case .connectedPath:
+            return "/connected_path"
+        case .managedPath:
+            return "/managed_path"
+        default:
+            return ""
+        }
+    }
+}
+
 class BaseViewModel: ObservableObject, PayPalWebCheckoutDelegate, CardDelegate {
 
     /// Weak reference to associated view
@@ -16,6 +38,7 @@ class BaseViewModel: ObservableObject, PayPalWebCheckoutDelegate, CardDelegate {
 
     /// order ID shared across views
     @Published var orderID: String?
+    @Published var selectedMerchantIntegration: MerchantIntegration = .connectedPath
 
     // MARK: - Init
 
@@ -37,18 +60,22 @@ class BaseViewModel: ObservableObject, PayPalWebCheckoutDelegate, CardDelegate {
         }
     }
 
-    func createOrder(amount: String?) async -> String? {
+    func createOrder(amount: String?, selectedMerchantIntegration: MerchantIntegration) async -> String? {
+        // might need to pass in payee as payee object or as auth header
         updateTitle("Creating order...")
         guard let amount = amount else { return nil }
 
         let amountRequest = Amount(currencyCode: "USD", value: amount)
+        // might need to pass in payee as payee object or as auth header
         let orderRequestParams = CreateOrderParams(
             intent: DemoSettings.intent.rawValue.uppercased(),
             purchaseUnits: [PurchaseUnit(amount: amountRequest)]
         )
 
         do {
-            let order = try await DemoMerchantAPI.sharedService.createOrder(orderParams: orderRequestParams)
+            let order = try await DemoMerchantAPI.sharedService.createOrder(
+                orderParams: orderRequestParams, selectedMerchantIntegration: selectedMerchantIntegration
+            )
             updateTitle("Order ID: \(order.id)")
             updateOrderID(with: order.id)
             print("✅ fetched orderID: \(order.id) with status: \(order.status)")
@@ -57,30 +84,6 @@ class BaseViewModel: ObservableObject, PayPalWebCheckoutDelegate, CardDelegate {
             print("❌ failed to fetch orderID: \(error)")
         }
         return orderID
-    }
-
-    func processOrder(orderID: String) async {
-        switch DemoSettings.intent {
-        case .authorize:
-            updateTitle("Authorizing order...")
-        case .capture:
-            updateTitle("Capturing order...")
-        }
-
-        let processOrderParams = ProcessOrderParams(
-            orderId: orderID,
-            intent: DemoSettings.intent.rawValue,
-            countryCode: "US"
-        )
-
-        do {
-            let order = try await DemoMerchantAPI.sharedService.processOrder(processOrderParams: processOrderParams)
-            updateTitle("\(DemoSettings.intent.rawValue.capitalized) success: \(order.status)")
-            print("✅ processed orderID: \(order.id) with status: \(order.status)")
-        } catch {
-            updateTitle("\(DemoSettings.intent.rawValue.capitalized) fail: \(error.localizedDescription)")
-            print("❌ failed to process orderID: \(error)")
-        }
     }
 
     // MARK: Card Module Integration
@@ -190,7 +193,9 @@ class BaseViewModel: ObservableObject, PayPalWebCheckoutDelegate, CardDelegate {
     
     private func captureOrderOnMerchantServer(result: CardResult) {
         Task {
-            let captureResult = try? await DemoMerchantAPI.sharedService.caputureOrder(orderID: result.orderID)
+            let captureResult = try? await DemoMerchantAPI.sharedService.captureOrder(
+                orderID: result.orderID, selectedMerchantIntegration: selectedMerchantIntegration
+            )
             let status = captureResult?.status ?? ""
             updateTitle("Order ID:\(result.orderID) status: \(status)")
         }
@@ -198,7 +203,9 @@ class BaseViewModel: ObservableObject, PayPalWebCheckoutDelegate, CardDelegate {
     
     private func authorizeOrderOnMerchantServer(result: CardResult) {
         Task {
-            let authorizeResult = try? await DemoMerchantAPI.sharedService.authorizeOrder(orderID: result.orderID)
+            let authorizeResult = try? await DemoMerchantAPI.sharedService.authorizeOrder(
+                orderID: result.orderID, selectedMerchantIntegration: selectedMerchantIntegration
+            )
             let status = authorizeResult?.status ?? ""
             updateTitle("Order ID:\(result.orderID) status: \(status)")
         }
@@ -225,7 +232,9 @@ class BaseViewModel: ObservableObject, PayPalWebCheckoutDelegate, CardDelegate {
     }
 
     func getClientID() async -> String? {
-        await DemoMerchantAPI.sharedService.getClientID(environment: DemoSettings.environment)
+        await DemoMerchantAPI.sharedService.getClientID(
+            environment: DemoSettings.environment, selectedMerchantIntegration: selectedMerchantIntegration
+        )
     }
     
     func getCoreConfig() async -> CoreConfig? {


### PR DESCRIPTION
### Summary of changes
- Add enum for Merchant Integration types
- Add `selectedMerchantIntegration` property in `BaseViewModel` and `PayPalViewModel`
- Add parameters to `DemoMerchantAPI` functions to add `selectedMerchantIntegration` into url path for request to merchant server
- Remove `processOrder` functions not used anywhere
- Remove persisting `clientID` in `baseViewModel` since user can select different credentials in single run of the app

### Checklist

~- [ ] Added a changelog entry~

### Authors
- @KunJeongPark @sshropshire 