### PR TITLE
Rename Repository URL and Necessary Changes

### DIFF
--- a/MOBILE_CHECKOUT_MIGRATION_GUIDE.md
+++ b/MOBILE_CHECKOUT_MIGRATION_GUIDE.md
@@ -1,6 +1,6 @@
 # PayPal Mobile Checkout SDK: Migration Guide
 
-This guide outlines how to update your integration from using the soon-to-be-deprecated [PayPal Mobile Checkout SDK](https://developer.paypal.com/limited-release/paypal-mobile-checkout/) to the new PayPal Mobile [iOS SDK](https://github.com/paypal/iOS-SDK).
+This guide outlines how to update your integration from using the soon-to-be-deprecated [PayPal Mobile Checkout SDK](https://developer.paypal.com/limited-release/paypal-mobile-checkout/) to the new PayPal Mobile [iOS SDK](https://github.com/paypal/paypal-ios).
 
 ## Pre-Requisites
 In order to use this migration guide, you must:
@@ -17,7 +17,7 @@ In order to use this migration guide, you must:
 
 1. Add the new SDK to your app
   * Swift Package Manger
-      * In Xcode, add the PayPal SDK as a [package dependency](https://developer.apple.com/documentation/swift_packages/adding_package_dependencies_to_your_app) to your Xcode project. Enter https://github.com/paypal/iOS-SDK.git as the package URL. 
+      * In Xcode, add the PayPal SDK as a [package dependency](https://developer.apple.com/documentation/swift_packages/adding_package_dependencies_to_your_app) to your Xcode project. Enter https://github.com/paypal/paypal-ios.git as the package URL. 
       * Tick the `PayPalNativePayments`, `PaymentButtons`, and `CorePayments` boxes to add the libraries to your app.
 
   * CocoaPods

--- a/PayPal.podspec
+++ b/PayPal.podspec
@@ -5,7 +5,7 @@ Pod::Spec.new do |s|
   s.homepage         = "https://developer.paypal.com/home"
   s.license          = "MIT"
   s.author           = { "PayPal" => "sdks@paypal.com" }
-  s.source           = { :git => "https://github.com/paypal/iOS-SDK.git", :tag => s.version.to_s }
+  s.source           = { :git => "https://github.com/paypal/paypal-ios.git", :tag => s.version.to_s }
   s.swift_version    = "5.7"
 
   s.platform         = :ios, "14.0"

--- a/SampleApps/SPMTest/SPMTest.xcodeproj/project.pbxproj
+++ b/SampleApps/SPMTest/SPMTest.xcodeproj/project.pbxproj
@@ -7,16 +7,16 @@
 	objects = {
 
 /* Begin PBXBuildFile section */
+		3B23E8E42A7030E90075E792 /* CardPayments in Frameworks */ = {isa = PBXBuildFile; productRef = 3B23E8E32A7030E90075E792 /* CardPayments */; };
+		3B23E8E62A7030E90075E792 /* CorePayments in Frameworks */ = {isa = PBXBuildFile; productRef = 3B23E8E52A7030E90075E792 /* CorePayments */; };
+		3B23E8E82A7030E90075E792 /* FraudProtection in Frameworks */ = {isa = PBXBuildFile; productRef = 3B23E8E72A7030E90075E792 /* FraudProtection */; };
+		3B23E8EA2A7030E90075E792 /* PayPalNativePayments in Frameworks */ = {isa = PBXBuildFile; productRef = 3B23E8E92A7030E90075E792 /* PayPalNativePayments */; };
+		3B23E8EC2A7030E90075E792 /* PayPalWebPayments in Frameworks */ = {isa = PBXBuildFile; productRef = 3B23E8EB2A7030E90075E792 /* PayPalWebPayments */; };
+		3B23E8EE2A7030E90075E792 /* PaymentButtons in Frameworks */ = {isa = PBXBuildFile; productRef = 3B23E8ED2A7030E90075E792 /* PaymentButtons */; };
 		80C6FD6726BD8AFF00B73E76 /* SPMTestApp.swift in Sources */ = {isa = PBXBuildFile; fileRef = 80C6FD6626BD8AFF00B73E76 /* SPMTestApp.swift */; };
 		80C6FD6926BD8AFF00B73E76 /* ContentView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 80C6FD6826BD8AFF00B73E76 /* ContentView.swift */; };
 		80C6FD6B26BD8B0000B73E76 /* Assets.xcassets in Resources */ = {isa = PBXBuildFile; fileRef = 80C6FD6A26BD8B0000B73E76 /* Assets.xcassets */; };
 		80C6FD6E26BD8B0000B73E76 /* Preview Assets.xcassets in Resources */ = {isa = PBXBuildFile; fileRef = 80C6FD6D26BD8B0000B73E76 /* Preview Assets.xcassets */; };
-		CB1AC3BE2982BE250081AED6 /* CardPayments in Frameworks */ = {isa = PBXBuildFile; productRef = CB1AC3BD2982BE250081AED6 /* CardPayments */; };
-		CBDEEA182989782D00A460A6 /* FraudProtection in Frameworks */ = {isa = PBXBuildFile; productRef = CBDEEA172989782D00A460A6 /* FraudProtection */; };
-		CBDEEA1A2989782D00A460A6 /* PaymentButtons in Frameworks */ = {isa = PBXBuildFile; productRef = CBDEEA192989782D00A460A6 /* PaymentButtons */; };
-		CBDEEA1E2989782D00A460A6 /* PayPalNativePayments in Frameworks */ = {isa = PBXBuildFile; productRef = CBDEEA1D2989782D00A460A6 /* PayPalNativePayments */; };
-		CBDEEA202989782D00A460A6 /* PayPalWebPayments in Frameworks */ = {isa = PBXBuildFile; productRef = CBDEEA1F2989782D00A460A6 /* PayPalWebPayments */; };
-		CBDEEA25298AE91400A460A6 /* CorePayments in Frameworks */ = {isa = PBXBuildFile; productRef = CBDEEA24298AE91400A460A6 /* CorePayments */; };
 /* End PBXBuildFile section */
 
 /* Begin PBXFileReference section */
@@ -32,12 +32,12 @@
 			isa = PBXFrameworksBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
-				CBDEEA182989782D00A460A6 /* FraudProtection in Frameworks */,
-				CBDEEA202989782D00A460A6 /* PayPalWebPayments in Frameworks */,
-				CBDEEA25298AE91400A460A6 /* CorePayments in Frameworks */,
-				CBDEEA1A2989782D00A460A6 /* PaymentButtons in Frameworks */,
-				CBDEEA1E2989782D00A460A6 /* PayPalNativePayments in Frameworks */,
-				CB1AC3BE2982BE250081AED6 /* CardPayments in Frameworks */,
+				3B23E8E62A7030E90075E792 /* CorePayments in Frameworks */,
+				3B23E8EE2A7030E90075E792 /* PaymentButtons in Frameworks */,
+				3B23E8E42A7030E90075E792 /* CardPayments in Frameworks */,
+				3B23E8EC2A7030E90075E792 /* PayPalWebPayments in Frameworks */,
+				3B23E8E82A7030E90075E792 /* FraudProtection in Frameworks */,
+				3B23E8EA2A7030E90075E792 /* PayPalNativePayments in Frameworks */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -104,12 +104,12 @@
 			);
 			name = SPMTest;
 			packageProductDependencies = (
-				CB1AC3BD2982BE250081AED6 /* CardPayments */,
-				CBDEEA172989782D00A460A6 /* FraudProtection */,
-				CBDEEA192989782D00A460A6 /* PaymentButtons */,
-				CBDEEA1D2989782D00A460A6 /* PayPalNativePayments */,
-				CBDEEA1F2989782D00A460A6 /* PayPalWebPayments */,
-				CBDEEA24298AE91400A460A6 /* CorePayments */,
+				3B23E8E32A7030E90075E792 /* CardPayments */,
+				3B23E8E52A7030E90075E792 /* CorePayments */,
+				3B23E8E72A7030E90075E792 /* FraudProtection */,
+				3B23E8E92A7030E90075E792 /* PayPalNativePayments */,
+				3B23E8EB2A7030E90075E792 /* PayPalWebPayments */,
+				3B23E8ED2A7030E90075E792 /* PaymentButtons */,
 			);
 			productName = SPMTest;
 			productReference = 80C6FD6326BD8AFF00B73E76 /* SPMTest.app */;
@@ -140,7 +140,7 @@
 			);
 			mainGroup = 80C6FD5A26BD8AFF00B73E76;
 			packageReferences = (
-				BC8A980427EB6AB700F6A4F2 /* XCRemoteSwiftPackageReference "iOS-SDK" */,
+				3B23E8E22A7030E90075E792 /* XCRemoteSwiftPackageReference "paypal-ios" */,
 			);
 			productRefGroup = 80C6FD6426BD8AFF00B73E76 /* Products */;
 			projectDirPath = "";
@@ -376,9 +376,9 @@
 /* End XCConfigurationList section */
 
 /* Begin XCRemoteSwiftPackageReference section */
-		BC8A980427EB6AB700F6A4F2 /* XCRemoteSwiftPackageReference "iOS-SDK" */ = {
+		3B23E8E22A7030E90075E792 /* XCRemoteSwiftPackageReference "paypal-ios" */ = {
 			isa = XCRemoteSwiftPackageReference;
-			repositoryURL = "https://github.com/paypal/iOS-SDK.git";
+			repositoryURL = "https://github.com/paypal/paypal-ios";
 			requirement = {
 				branch = main;
 				kind = branch;
@@ -387,35 +387,35 @@
 /* End XCRemoteSwiftPackageReference section */
 
 /* Begin XCSwiftPackageProductDependency section */
-		CB1AC3BD2982BE250081AED6 /* CardPayments */ = {
+		3B23E8E32A7030E90075E792 /* CardPayments */ = {
 			isa = XCSwiftPackageProductDependency;
-			package = BC8A980427EB6AB700F6A4F2 /* XCRemoteSwiftPackageReference "iOS-SDK" */;
+			package = 3B23E8E22A7030E90075E792 /* XCRemoteSwiftPackageReference "paypal-ios" */;
 			productName = CardPayments;
 		};
-		CBDEEA172989782D00A460A6 /* FraudProtection */ = {
+		3B23E8E52A7030E90075E792 /* CorePayments */ = {
 			isa = XCSwiftPackageProductDependency;
-			package = BC8A980427EB6AB700F6A4F2 /* XCRemoteSwiftPackageReference "iOS-SDK" */;
+			package = 3B23E8E22A7030E90075E792 /* XCRemoteSwiftPackageReference "paypal-ios" */;
+			productName = CorePayments;
+		};
+		3B23E8E72A7030E90075E792 /* FraudProtection */ = {
+			isa = XCSwiftPackageProductDependency;
+			package = 3B23E8E22A7030E90075E792 /* XCRemoteSwiftPackageReference "paypal-ios" */;
 			productName = FraudProtection;
 		};
-		CBDEEA192989782D00A460A6 /* PaymentButtons */ = {
+		3B23E8E92A7030E90075E792 /* PayPalNativePayments */ = {
 			isa = XCSwiftPackageProductDependency;
-			package = BC8A980427EB6AB700F6A4F2 /* XCRemoteSwiftPackageReference "iOS-SDK" */;
-			productName = PaymentButtons;
-		};
-		CBDEEA1D2989782D00A460A6 /* PayPalNativePayments */ = {
-			isa = XCSwiftPackageProductDependency;
-			package = BC8A980427EB6AB700F6A4F2 /* XCRemoteSwiftPackageReference "iOS-SDK" */;
+			package = 3B23E8E22A7030E90075E792 /* XCRemoteSwiftPackageReference "paypal-ios" */;
 			productName = PayPalNativePayments;
 		};
-		CBDEEA1F2989782D00A460A6 /* PayPalWebPayments */ = {
+		3B23E8EB2A7030E90075E792 /* PayPalWebPayments */ = {
 			isa = XCSwiftPackageProductDependency;
-			package = BC8A980427EB6AB700F6A4F2 /* XCRemoteSwiftPackageReference "iOS-SDK" */;
+			package = 3B23E8E22A7030E90075E792 /* XCRemoteSwiftPackageReference "paypal-ios" */;
 			productName = PayPalWebPayments;
 		};
-		CBDEEA24298AE91400A460A6 /* CorePayments */ = {
+		3B23E8ED2A7030E90075E792 /* PaymentButtons */ = {
 			isa = XCSwiftPackageProductDependency;
-			package = BC8A980427EB6AB700F6A4F2 /* XCRemoteSwiftPackageReference "iOS-SDK" */;
-			productName = CorePayments;
+			package = 3B23E8E22A7030E90075E792 /* XCRemoteSwiftPackageReference "paypal-ios" */;
+			productName = PaymentButtons;
 		};
 /* End XCSwiftPackageProductDependency section */
 	};

--- a/SampleApps/SPMTest/SPMTest.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
+++ b/SampleApps/SPMTest/SPMTest.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
@@ -1,12 +1,12 @@
 {
   "pins" : [
     {
-      "identity" : "ios-sdk",
+      "identity" : "paypal-ios",
       "kind" : "remoteSourceControl",
-      "location" : "https://github.com/paypal/iOS-SDK.git",
+      "location" : "https://github.com/paypal/paypal-ios",
       "state" : {
         "branch" : "main",
-        "revision" : "37162c457947f6a9014fd6bf2e78a1cb93251f4b"
+        "revision" : "80bf151ba2a5d74b08cef1c55a596e9e7ecfe497"
       }
     },
     {
@@ -14,8 +14,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/paypal/paypalcheckout-ios",
       "state" : {
-        "revision" : "0d50b2c2a16437de057ce4f6f3612561a3d9a263",
-        "version" : "0.109.0"
+        "revision" : "773568fbbffd54f900d6d78be7793ae1871d3b35",
+        "version" : "1.0.0"
       }
     }
   ],

--- a/Sources/CardPayments/CardClient.swift
+++ b/Sources/CardPayments/CardClient.swift
@@ -16,7 +16,6 @@ public class CardClient: NSObject {
     /// Initialize a CardClient to process card payment
     /// - Parameter config: The CoreConfig object
     public init(config: CoreConfig) {
-        print("test")
         self.config = config
         self.apiClient = APIClient(coreConfig: config)
         self.webAuthenticationSession = WebAuthenticationSession()

--- a/Sources/CardPayments/CardClient.swift
+++ b/Sources/CardPayments/CardClient.swift
@@ -16,6 +16,7 @@ public class CardClient: NSObject {
     /// Initialize a CardClient to process card payment
     /// - Parameter config: The CoreConfig object
     public init(config: CoreConfig) {
+        print("test")
         self.config = config
         self.apiClient = APIClient(coreConfig: config)
         self.webAuthenticationSession = WebAuthenticationSession()

--- a/docs/CardPayments/README.md
+++ b/docs/CardPayments/README.md
@@ -21,7 +21,7 @@ You will need a server integration to create an order and capture the funds usin
 
 #### Swift Package Manager
 
-In Xcode, add the PayPal SDK as a [package dependency](https://developer.apple.com/documentation/swift_packages/adding_package_dependencies_to_your_app) to your Xcode project. Enter https://github.com/paypal/iOS-SDK as the package URL. Tick the `CardPayments` checkbox to add the Card Payments library to your app.
+In Xcode, add the PayPal SDK as a [package dependency](https://developer.apple.com/documentation/swift_packages/adding_package_dependencies_to_your_app) to your Xcode project. Enter https://github.com/paypal/paypal-ios as the package URL. Tick the `CardPayments` checkbox to add the Card Payments library to your app.
 
 #### CocoaPods
 

--- a/docs/PayPalNativePayments/README.md
+++ b/docs/PayPalNativePayments/README.md
@@ -22,7 +22,7 @@ You will need a server integration to create an order to capture funds using the
 
 #### Swift Package Manager
 
-In Xcode, add the PayPal SDK as a [package dependency](https://developer.apple.com/documentation/swift_packages/adding_package_dependencies_to_your_app) to your Xcode project. Enter https://github.com/paypal/iOS-SDK as the package URL. Tick the `PayPalNativePayments` checkbox to add the PayPal Native Payments library to your app.
+In Xcode, add the PayPal SDK as a [package dependency](https://developer.apple.com/documentation/swift_packages/adding_package_dependencies_to_your_app) to your Xcode project. Enter https://github.com/paypal/paypal-ios as the package URL. Tick the `PayPalNativePayments` checkbox to add the PayPal Native Payments library to your app.
 
 #### CocoaPods
 

--- a/docs/PayPalWebPayments/README.md
+++ b/docs/PayPalWebPayments/README.md
@@ -21,7 +21,7 @@ You will need a server integration to create an order to capture funds using the
 
 #### Swift Package Manager
 
-In Xcode, add the PayPal SDK as a [package dependency](https://developer.apple.com/documentation/swift_packages/adding_package_dependencies_to_your_app) to your Xcode project. Enter https://github.com/paypal/iOS-SDK as the package URL. Tick the `PayPalWebPayments` checkbox to add the PayPal Web Payments library to your app.
+In Xcode, add the PayPal SDK as a [package dependency](https://developer.apple.com/documentation/swift_packages/adding_package_dependencies_to_your_app) to your Xcode project. Enter https://github.com/paypal/paypal-ios as the package URL. Tick the `PayPalWebPayments` checkbox to add the PayPal Web Payments library to your app.
 
 #### CocoaPods
 

--- a/docs/PaymentButtons/README.md
+++ b/docs/PaymentButtons/README.md
@@ -8,7 +8,7 @@
 
 #### Swift Package Manager
 
-In Xcode, follow the guide to [add package dependencies to your app](https://developer.apple.com/documentation/swift_packages/adding_package_dependencies_to_your_app) and enter https://github.com/paypal/iOS-SDK as the repository URL. Tick the `PaymentButtons` checkbox to add the Payment Buttons library to your app.
+In Xcode, follow the guide to [add package dependencies to your app](https://developer.apple.com/documentation/swift_packages/adding_package_dependencies_to_your_app) and enter https://github.com/paypal/paypal-ios as the repository URL. Tick the `PaymentButtons` checkbox to add the Payment Buttons library to your app.
 
 #### CocoaPods
 


### PR DESCRIPTION
### Reason for changes

We need to avoid GitHub url name collisions in SPM. Previously our repo was hosted at `www.github.com/paypal/ios-sdk`. This caused collisions & compilation errors when used alongside other SPM packages hosted at `www.github.com/<some-company>/ios-sdk`.

### Summary of changes

- Rename url in SPM test project dependency
- Update repo URL links in docs & Podspec

### Checklist

~- [ ] Added a changelog entry~

### Authors
> List GitHub usernames for everyone who contributed to this pull request.

- @KunJeongPark @scannillo 