### PR TITLE
Send 'production' over 'live' to FPTI

### DIFF
--- a/Sources/CorePayments/Networking/AnalyticsService.swift
+++ b/Sources/CorePayments/Networking/AnalyticsService.swift
@@ -45,7 +45,7 @@ public struct AnalyticsService {
             let clientID = coreConfig.clientID
             
             let eventData = AnalyticsEventData(
-                environment: http.coreConfig.environment.toString,
+                environment: http.coreConfig.environment.analyticsString,
                 eventName: name,
                 clientID: clientID,
                 orderID: orderID

--- a/Sources/CorePayments/Networking/Enums/Environment.swift
+++ b/Sources/CorePayments/Networking/Enums/Environment.swift
@@ -31,5 +31,14 @@ public enum Environment {
             return "live"
         }
     }
+    
+    var analyticsString: String {
+        switch self {
+        case .sandbox:
+            return "sandbox"
+        case .live:
+            return "production"
+        }
+    }
 }
 // swiftlint:enable force_unwrapping

--- a/UnitTests/PaymentsCoreTests/AnalyticsService_Tests.swift
+++ b/UnitTests/PaymentsCoreTests/AnalyticsService_Tests.swift
@@ -44,7 +44,7 @@ class AnalyticsService_Tests: XCTestCase {
             return
         }
         
-        XCTAssertEqual(env, "live")
+        XCTAssertEqual(env, "production")
     }
     
     func testSendEvent_whenSandbox_sendsProperTag() async {


### PR DESCRIPTION
### Reason for changes

- While creating analytics dashboards, we realized that the BT & PPCP SDKs differ in the values we are sending for the `merchant_sdk_env` key to FPTI
    - BT Mobile SDKs are sending: production & sandbox, PPCP mobile SDKs are sending live & sandbox

### Summary of changes

- Send `production` over `live` in FPTI post body

### Checklist

- ~Added a changelog entry~

### Authors
@scannillo 