### PR TITLE
UI for Vault with Purchase

### DIFF
--- a/Demo/Demo/SwiftUIComponents/SwiftUICardDemo.swift
+++ b/Demo/Demo/SwiftUIComponents/SwiftUICardDemo.swift
@@ -35,12 +35,12 @@ struct SwiftUICardDemo: View {
                         cvvText = cardFormatter.formatFieldWith(newValue, field: .cvv)
                     }
                 HStack {
-                    Toggle("Should Vault", isOn: $shouldVaultSelected)
+                    Toggle("Should Vault with Purchase", isOn: $shouldVaultSelected)
+                    // TODO: turn on if vault with purchase on sample server is implemented
+                        .disabled(true)
                     Spacer()
                 }
-                if shouldVaultSelected {
-                    FloatingLabelTextField(placeholder: "Vault Customer ID (Optional)", text: $vaultCustomerID)
-                }
+                FloatingLabelTextField(placeholder: "Vault Customer ID (Optional)", text: $vaultCustomerID)
                 Button("\(DemoSettings.intent.rawValue.capitalized) Order") {
                     guard let card = baseViewModel.createCard(
                         cardNumber: cardNumberText,


### PR DESCRIPTION
### Summary of changes

- Disabled toggle button UI for Vault with Purchase for now.
- It was created for now reverted client side Vault with Purchase
- Exposed optional Customer ID for testing Vault without Purchase which is being implemented. 
- Plan is to turn this toggle button on when that implementation of passing in vault options for create order 
   is done for server side, sample merchant server.
   We have work to do to provide correct parameters, headers for different integrations for create order, setup token.
- We are waiting on current issues on that implementation to be resolved. 
- Final UI will be more complex with selections for different integration patterns including C4, vault without purchase flow vs checkout flow with/without vault option.
<p float="left">
<image src = "https://github.com/paypal/paypal-ios/assets/9273272/d24b991b-db1c-4052-9791-6a1fe64154dd" width = "500" />
</p>


### Checklist

~- [ ] Added a changelog entry~

### Authors
- @KunJeongPark 