### PR TITLE
Remove unneeded APIRequest conformance from Demo

### DIFF
--- a/Demo/Demo/Models/ClientIDRequest.swift
+++ b/Demo/Demo/Models/ClientIDRequest.swift
@@ -1,7 +1,7 @@
 import Foundation
 import CorePayments
 
-struct ClientIDRequest: APIRequest {
+struct ClientIDRequest {
 
     typealias ResponseType = ClientIDResponse
 


### PR DESCRIPTION
### Reason for changes

Make it clear that the Demo does not rely on the SDK's internal `APIRequest` protocol. 

_We're also planning to remove this protocol entirely (👀  #177)_

### Summary of changes

- Remove unneeded conformance to `APIRequest` on `ClientIDRequest` in demo app

### Checklist

- ~Added a changelog entry~

### Authors
@scannillo 
