### PR TITLE
Remove `prefersEphemeralBrowser` setting from ASWebSession

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,8 @@
 ## unreleased
 * PayPalNativePayments
   * Bump `PayPalCheckout` to `1.0.0`
+* PaymentsCore
+  * Allow `ASWebAuthenticationSession` used for PayPal Web & 3DS flows to share cookies with Safari (fixes #179)
   
 ## 0.0.9 (2023-06-23)
 * Breaking Changes

--- a/Sources/CorePayments/WebAuthenticationSession.swift
+++ b/Sources/CorePayments/WebAuthenticationSession.swift
@@ -15,7 +15,6 @@ public class WebAuthenticationSession: NSObject {
             completionHandler: sessionDidComplete
         )
 
-        authenticationSession.prefersEphemeralWebBrowserSession = true
         authenticationSession.presentationContextProvider = context
 
         DispatchQueue.main.async {


### PR DESCRIPTION
### Reason for changes

- Addresses #179 

### Summary of changes

- Use Apple's default setting for [`prefersEphemeralBrowserSession`](https://developer.apple.com/documentation/authenticationservices/aswebauthenticationsession/3237231-prefersephemeralwebbrowsersessio)
- This allows users login to be recognized between sessions, if enabled on the site

### Checklist

- [X] Added a changelog entry

### Authors
@scannillo 