### PR TITLE
Update PayPalCheckout version to 1.1.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 # PayPal iOS SDK Release Notes
 
 ## unreleased
+* PayPalNativePayments
+  * Bump `PayPalCheckout` to `1.1.0`
 * CardPayments
   * Add `vault` method 
   * Add `CardVaultRequest` and `CardVaultResult` types for interacting with `vault` method

--- a/Demo/Demo.xcodeproj/project.pbxproj
+++ b/Demo/Demo.xcodeproj/project.pbxproj
@@ -795,7 +795,7 @@
 			repositoryURL = "https://github.com/paypal/paypalcheckout-ios";
 			requirement = {
 				kind = exactVersion;
-				version = 1.0.0;
+				version = 1.1.0;
 			};
 		};
 		BE1766D526FA7AC3007EF438 /* XCRemoteSwiftPackageReference "InAppSettingsKit" */ = {

--- a/Package.resolved
+++ b/Package.resolved
@@ -5,8 +5,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/paypal/paypalcheckout-ios",
       "state" : {
-        "revision" : "773568fbbffd54f900d6d78be7793ae1871d3b35",
-        "version" : "1.0.0"
+        "revision" : "7c6750e1316c6a3d656e90497271de68c63219f1",
+        "version" : "1.1.0"
       }
     }
   ],

--- a/Package.swift
+++ b/Package.swift
@@ -35,7 +35,7 @@ let package = Package(
     ],
     dependencies: [
         // Dependencies declare other packages that this package depends on.
-        .package(name: "PayPalCheckout", url: "https://github.com/paypal/paypalcheckout-ios", .exact("1.0.0"))
+        .package(name: "PayPalCheckout", url: "https://github.com/paypal/paypalcheckout-ios", .exact("1.1.0"))
     ],
     targets: [
         // Targets are the basic building blocks of a package. A target can define a module or a test suite.

--- a/PayPal.podspec
+++ b/PayPal.podspec
@@ -19,7 +19,7 @@ Pod::Spec.new do |s|
   s.subspec "PayPalNativePayments" do |s|
    s.source_files  = "Sources/PayPalNativePayments/**/*.swift"
    s.dependency "PayPal/CorePayments"
-   s.dependency "PayPalCheckout", "1.0.0"
+   s.dependency "PayPalCheckout", "1.1.0"
   end
 
   s.subspec "PaymentButtons" do |s|

--- a/PayPal.xcodeproj/project.pbxproj
+++ b/PayPal.xcodeproj/project.pbxproj
@@ -3377,7 +3377,7 @@
 			repositoryURL = "https://github.com/paypal/paypalcheckout-ios";
 			requirement = {
 				kind = exactVersion;
-				version = 1.0.0;
+				version = 1.1.0;
 			};
 		};
 /* End XCRemoteSwiftPackageReference section */

--- a/PayPal.xcworkspace/xcshareddata/swiftpm/Package.resolved
+++ b/PayPal.xcworkspace/xcshareddata/swiftpm/Package.resolved
@@ -14,8 +14,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/paypal/paypalcheckout-ios",
       "state" : {
-        "revision" : "773568fbbffd54f900d6d78be7793ae1871d3b35",
-        "version" : "1.0.0"
+        "revision" : "7c6750e1316c6a3d656e90497271de68c63219f1",
+        "version" : "1.1.0"
       }
     }
   ],


### PR DESCRIPTION
### Reason for changes

Pulling in newest MXO release

### Summary of changes

- updating the `PayPalCheckout` version to the recent `1.1.0` release, looked to https://github.com/paypal/paypal-ios/pull/169 for reference

### Checklist

- [X] Added a changelog entry

### Authors
> List GitHub usernames for everyone who contributed to this pull request.

- @Charles-Berghausen