### PR TITLE
[Docs] PayPal Buttons: Fix Typos

### DIFF
--- a/Demo/Demo/SwiftUIComponents/SwiftUIPaymentButtonDemo.swift
+++ b/Demo/Demo/SwiftUIComponents/SwiftUIPaymentButtonDemo.swift
@@ -96,6 +96,7 @@ struct SwiftUIPaymentButtonDemo: View {
                         label: selectedLabel
                     )
                     .id(buttonId)
+                    .frame(maxWidth: .infinity)
 
                 case .payLater:
                     PayPalPayLaterButton.Representable(
@@ -113,8 +114,11 @@ struct SwiftUIPaymentButtonDemo: View {
                     )
                     .id(buttonId)
                 }
-            }.padding()
+            }
+            .padding()
+            .frame(maxWidth: .infinity)
         }
+        .frame(maxWidth: .infinity)
     }
 
     private func getColorFunding(with funding: PaymentButtonFundingSource) -> [String] {

--- a/docs/PaymentButtons/README.md
+++ b/docs/PaymentButtons/README.md
@@ -36,6 +36,8 @@ Each button as a `UKit` and `SwiftUI` implementation as follows:
 #### UKit
 
 ```swift
+import PaymentButtons
+
 class MyViewController: ViewController {
 
     lazy var payPalButton: PayPalButton = {
@@ -44,7 +46,7 @@ class MyViewController: ViewController {
         return payPalButton
     }()
     
-    @objc func paymentButtonTapped() {
+    @objc func payPalButtonTapped() {
         // Insert your code here
     }
     
@@ -58,6 +60,8 @@ class MyViewController: ViewController {
 #### SwiftUI
 
 ```swift
+import PaymentButtons
+
 struct MyApp: View {
     @ViewBuilder
     var body: some View {

--- a/docs/PaymentButtons/README.md
+++ b/docs/PaymentButtons/README.md
@@ -59,7 +59,6 @@ class MyViewController: ViewController {
         NSLayoutConstraint.activate([
             view.leadingAnchor.constraint(equalTo: safeArea.leadingAnchor, constant: 20)
             view.trailingAnchor.constraint(equalTo: safeArea.trailingAnchor, constant: -20)
-            view.centerXAnchor.constraint(equalTo: safeArea.centerXAnchor)
             view.centerYAnchor.constraint(equalTo: safeArea.centerYAnchor)
         ])
     }

--- a/docs/PaymentButtons/README.md
+++ b/docs/PaymentButtons/README.md
@@ -53,6 +53,15 @@ class MyViewController: ViewController {
     override func viewDidLoad() {
         super.viewDidLoad()
         view.addSubview(payPalButton)
+
+        // example constraints to absolutely center the button with a 20 pt. horizontal margin
+        let safeArea = view.safeAreaLayoutGuide
+        NSLayoutConstraing.activate([
+            view.leadingAnchor.constraint(equalTo: safeArea.leadingAnchor, constant: 20)
+            view.trailingAnchor.constraint(equalTo: safeArea.trailingAnchor, constant: -20)
+            view.centerXAnchor.constraint(equalTo: safeArea.centerXAnchor)
+            view.centerYAnchor.constraint(equalTo: safeArea.centerYAnchor)
+        ])
     }
 }
 ```

--- a/docs/PaymentButtons/README.md
+++ b/docs/PaymentButtons/README.md
@@ -56,7 +56,7 @@ class MyViewController: ViewController {
 
         // example constraints to absolutely center the button with a 20 pt. horizontal margin
         let safeArea = view.safeAreaLayoutGuide
-        NSLayoutConstraing.activate([
+        NSLayoutConstraint.activate([
             view.leadingAnchor.constraint(equalTo: safeArea.leadingAnchor, constant: 20)
             view.trailingAnchor.constraint(equalTo: safeArea.trailingAnchor, constant: -20)
             view.centerXAnchor.constraint(equalTo: safeArea.centerXAnchor)


### PR DESCRIPTION
### Reason for changes

Docs code for `PaymentButtons` does not compile when copy pasted into an Xcode project.

### Summary of changes

- Add missing `import` statements for `PaymentButtons` onboarding
- Fix typo in PayPal button target selector name 

### Checklist

~- [ ] Added a changelog entry~

### Authors
> List GitHub usernames for everyone who contributed to this pull request.

- @sshropshire