### PR TITLE
Rename APIClient to NetworkingClient

### DIFF
--- a/PayPal.xcodeproj/project.pbxproj
+++ b/PayPal.xcodeproj/project.pbxproj
@@ -3,7 +3,7 @@
 	archiveVersion = 1;
 	classes = {
 	};
-	objectVersion = 52;
+	objectVersion = 54;
 	objects = {
 
 /* Begin PBXBuildFile section */
@@ -31,7 +31,7 @@
 		802C4A762945676E00896A5D /* AnalyticsService_Tests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 802C4A752945676E00896A5D /* AnalyticsService_Tests.swift */; };
 		802EFBDB2A96B47A00AB709D /* TrackingEventsAPI_Tests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 802EFBD92A968BCD00AB709D /* TrackingEventsAPI_Tests.swift */; };
 		8034A9E726B875C90055AF13 /* CorePayments.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 80B9F85126B8750000D67843 /* CorePayments.framework */; };
-		8036C1E4270F9BE700C0F091 /* APIClient_Tests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8036C1E0270F9BE700C0F091 /* APIClient_Tests.swift */; };
+		8036C1E4270F9BE700C0F091 /* NetworkingClient_Tests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8036C1E0270F9BE700C0F091 /* NetworkingClient_Tests.swift */; };
 		8036C1E5270F9BE700C0F091 /* Environment_Tests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8036C1E1270F9BE700C0F091 /* Environment_Tests.swift */; };
 		803C31B1270E41690067D36E /* TestShared.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 80E743F8270E40CE00BACECA /* TestShared.framework */; };
 		803C31B4270E430E0067D36E /* TestShared.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 80E743F8270E40CE00BACECA /* TestShared.framework */; };
@@ -120,10 +120,10 @@
 		BE4F785827EB656400FF4C0E /* PayPalWebCheckoutResult.swift in Sources */ = {isa = PBXBuildFile; fileRef = BE4F784727EB629100FF4C0E /* PayPalWebCheckoutResult.swift */; };
 		BE71161C27234B8A00165069 /* PayPalNativePaymentsError.swift in Sources */ = {isa = PBXBuildFile; fileRef = BE71161B27234B8A00165069 /* PayPalNativePaymentsError.swift */; };
 		BE711621272358E200165069 /* Environment+Extension.swift in Sources */ = {isa = PBXBuildFile; fileRef = BE711620272358E200165069 /* Environment+Extension.swift */; };
-		BEA100E726EF9EDA0036A6A5 /* APIClient.swift in Sources */ = {isa = PBXBuildFile; fileRef = BEA100E626EF9EDA0036A6A5 /* APIClient.swift */; };
+		BEA100E726EF9EDA0036A6A5 /* NetworkingClient.swift in Sources */ = {isa = PBXBuildFile; fileRef = BEA100E626EF9EDA0036A6A5 /* NetworkingClient.swift */; };
 		BEA100EC26EFA7790036A6A5 /* HTTPMethod.swift in Sources */ = {isa = PBXBuildFile; fileRef = BEA100EB26EFA7790036A6A5 /* HTTPMethod.swift */; };
 		BEA100EE26EFA7990036A6A5 /* HTTPHeader.swift in Sources */ = {isa = PBXBuildFile; fileRef = BEA100ED26EFA7990036A6A5 /* HTTPHeader.swift */; };
-		BEA100F026EFA7C20036A6A5 /* APIClientError.swift in Sources */ = {isa = PBXBuildFile; fileRef = BEA100EF26EFA7C20036A6A5 /* APIClientError.swift */; };
+		BEA100F026EFA7C20036A6A5 /* NetworkingClientError.swift in Sources */ = {isa = PBXBuildFile; fileRef = BEA100EF26EFA7C20036A6A5 /* NetworkingClientError.swift */; };
 		BEA100F226EFA7DE0036A6A5 /* Environment.swift in Sources */ = {isa = PBXBuildFile; fileRef = BEA100F126EFA7DE0036A6A5 /* Environment.swift */; };
 		CB16E6D8285B7A2B00FD6F52 /* FakeConfirmPaymentResponse.swift in Sources */ = {isa = PBXBuildFile; fileRef = CB16E6D7285B7A2B00FD6F52 /* FakeConfirmPaymentResponse.swift */; };
 		CB16E6DA285B7B7300FD6F52 /* MockCardDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = CB16E6D9285B7B7300FD6F52 /* MockCardDelegate.swift */; };
@@ -151,7 +151,7 @@
 		CBC16DF629EECCB900307117 /* NativeCheckoutProvider_Tests.swift in Sources */ = {isa = PBXBuildFile; fileRef = CBC16DF529EECCB900307117 /* NativeCheckoutProvider_Tests.swift */; };
 		CBD6004728D0C24A00C3EFF6 /* MockPayPalDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = CBD6004628D0C24900C3EFF6 /* MockPayPalDelegate.swift */; };
 		E6022E802857C6BE008B0E27 /* GraphQLHTTPResponse.swift in Sources */ = {isa = PBXBuildFile; fileRef = E64623222836A69E008AC8E1 /* GraphQLHTTPResponse.swift */; };
-		E64763712899B60C00074113 /* MockAPIClient.swift in Sources */ = {isa = PBXBuildFile; fileRef = E64763702899B60C00074113 /* MockAPIClient.swift */; };
+		E64763712899B60C00074113 /* MockNetworkingClient.swift in Sources */ = {isa = PBXBuildFile; fileRef = E64763702899B60C00074113 /* MockNetworkingClient.swift */; };
 /* End PBXBuildFile section */
 
 /* Begin PBXContainerItemProxy section */
@@ -229,7 +229,7 @@
 		802EFBD72A9685DF00AB709D /* MockTrackingEventsAPI.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MockTrackingEventsAPI.swift; sourceTree = "<group>"; };
 		802EFBD92A968BCD00AB709D /* TrackingEventsAPI_Tests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TrackingEventsAPI_Tests.swift; sourceTree = "<group>"; };
 		8034A9E326B875C90055AF13 /* CorePaymentsTests.xctest */ = {isa = PBXFileReference; explicitFileType = wrapper.cfbundle; includeInIndex = 0; path = CorePaymentsTests.xctest; sourceTree = BUILT_PRODUCTS_DIR; };
-		8036C1E0270F9BE700C0F091 /* APIClient_Tests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; name = APIClient_Tests.swift; path = UnitTests/PaymentsCoreTests/APIClient_Tests.swift; sourceTree = SOURCE_ROOT; };
+		8036C1E0270F9BE700C0F091 /* NetworkingClient_Tests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; name = NetworkingClient_Tests.swift; path = UnitTests/PaymentsCoreTests/NetworkingClient_Tests.swift; sourceTree = SOURCE_ROOT; };
 		8036C1E1270F9BE700C0F091 /* Environment_Tests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; name = Environment_Tests.swift; path = UnitTests/PaymentsCoreTests/Environment_Tests.swift; sourceTree = SOURCE_ROOT; };
 		8036F87F2A30E492005B6186 /* HTTPResponse_Tests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = HTTPResponse_Tests.swift; sourceTree = "<group>"; };
 		803C31B8270E4C560067D36E /* MockURLSession.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MockURLSession.swift; sourceTree = "<group>"; };
@@ -313,10 +313,10 @@
 		BE9F36DE274859A000AFC7DA /* PaymentButtonColor.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PaymentButtonColor.swift; sourceTree = "<group>"; };
 		BE9F36E0274859C200AFC7DA /* PaymentButtonImage.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PaymentButtonImage.swift; sourceTree = "<group>"; };
 		BE9F36E3275520E700AFC7DA /* PayPalCreditButton_Tests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PayPalCreditButton_Tests.swift; sourceTree = "<group>"; };
-		BEA100E626EF9EDA0036A6A5 /* APIClient.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = APIClient.swift; sourceTree = "<group>"; };
+		BEA100E626EF9EDA0036A6A5 /* NetworkingClient.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = NetworkingClient.swift; sourceTree = "<group>"; };
 		BEA100EB26EFA7790036A6A5 /* HTTPMethod.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = HTTPMethod.swift; sourceTree = "<group>"; };
 		BEA100ED26EFA7990036A6A5 /* HTTPHeader.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = HTTPHeader.swift; sourceTree = "<group>"; };
-		BEA100EF26EFA7C20036A6A5 /* APIClientError.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = APIClientError.swift; sourceTree = "<group>"; };
+		BEA100EF26EFA7C20036A6A5 /* NetworkingClientError.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NetworkingClientError.swift; sourceTree = "<group>"; };
 		BEA100F126EFA7DE0036A6A5 /* Environment.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Environment.swift; sourceTree = "<group>"; };
 		BEDB7FE32788AB8E00CEA554 /* Coordinator.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Coordinator.swift; sourceTree = "<group>"; };
 		BEF3FF1627AC5DF3006B4B69 /* Coordinator_Tests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Coordinator_Tests.swift; sourceTree = "<group>"; };
@@ -342,7 +342,7 @@
 		CBC16DF529EECCB900307117 /* NativeCheckoutProvider_Tests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NativeCheckoutProvider_Tests.swift; sourceTree = "<group>"; };
 		CBD6004628D0C24900C3EFF6 /* MockPayPalDelegate.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MockPayPalDelegate.swift; sourceTree = "<group>"; };
 		E64623222836A69E008AC8E1 /* GraphQLHTTPResponse.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = GraphQLHTTPResponse.swift; sourceTree = "<group>"; };
-		E64763702899B60C00074113 /* MockAPIClient.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MockAPIClient.swift; sourceTree = "<group>"; };
+		E64763702899B60C00074113 /* MockNetworkingClient.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MockNetworkingClient.swift; sourceTree = "<group>"; };
 		OBJ_16 /* README.md */ = {isa = PBXFileReference; lastKnownFileType = net.daringfireball.markdown; path = README.md; sourceTree = "<group>"; };
 		OBJ_6 /* Package.swift */ = {isa = PBXFileReference; explicitFileType = sourcecode.swift; path = Package.swift; sourceTree = "<group>"; };
 		"PayPal::PayPalTests::Product" /* PayPalNativeCheckoutTests.xctest */ = {isa = PBXFileReference; explicitFileType = wrapper.cfbundle; path = PayPalNativeCheckoutTests.xctest; sourceTree = BUILT_PRODUCTS_DIR; };
@@ -500,9 +500,8 @@
 			isa = PBXGroup;
 			children = (
 				808EEA80291321FE001B6765 /* AnalyticsEventData_Tests.swift */,
-				8036C1E0270F9BE700C0F091 /* APIClient_Tests.swift */,
 				802C4A752945676E00896A5D /* AnalyticsService_Tests.swift */,
-				8036C1E0270F9BE700C0F091 /* APIClient_Tests.swift */,
+				8036C1E0270F9BE700C0F091 /* NetworkingClient_Tests.swift */,
 				8036C1E1270F9BE700C0F091 /* Environment_Tests.swift */,
 				80FC261C29847AC7008EC841 /* HTTP_Tests.swift */,
 				8036F87F2A30E492005B6186 /* HTTPResponse_Tests.swift */,
@@ -593,7 +592,7 @@
 			children = (
 				3B80D50B2A27979000D2EAC4 /* FailingJSONEncoder.swift */,
 				80E743FF270E40F300BACECA /* FakeRequests.swift */,
-				E64763702899B60C00074113 /* MockAPIClient.swift */,
+				E64763702899B60C00074113 /* MockNetworkingClient.swift */,
 				802C4A732945670400896A5D /* MockHTTP.swift */,
 				CB4BE28928512A9800EA2DD1 /* MockQuededURLSession.swift */,
 				803C31B8270E4C560067D36E /* MockURLSession.swift */,
@@ -726,7 +725,7 @@
 			isa = PBXGroup;
 			children = (
 				E646231928369B71008AC8E1 /* GraphQL */,
-				BEA100E626EF9EDA0036A6A5 /* APIClient.swift */,
+				BEA100E626EF9EDA0036A6A5 /* NetworkingClient.swift */,
 				804E628529380B04004B9FEF /* AnalyticsService.swift */,
 				80E2FDBF2A8353550045593D /* TrackingEventsAPI.swift */,
 				804E62812937EBCE004B9FEF /* HTTP.swift */,
@@ -734,7 +733,7 @@
 				80E643822A1EBBD2008FD705 /* HTTPResponse.swift */,
 				80E2FDC22A8354AD0045593D /* RESTRequest.swift */,
 				807BF58E2A2A5D19002F32B3 /* HTTPResponseParser.swift */,
-				BEA100EF26EFA7C20036A6A5 /* APIClientError.swift */,
+				BEA100EF26EFA7C20036A6A5 /* NetworkingClientError.swift */,
 				BC04836E27B2FB3600FA7B46 /* URLSessionProtocol.swift */,
 				BC04837327B2FC7300FA7B46 /* URLSession+URLSessionProtocol.swift */,
 				BEA100EA26EFA7670036A6A5 /* Enums */,
@@ -1288,7 +1287,7 @@
 				802EFBDB2A96B47A00AB709D /* TrackingEventsAPI_Tests.swift in Sources */,
 				802C4A762945676E00896A5D /* AnalyticsService_Tests.swift in Sources */,
 				807BF5912A2A5D48002F32B3 /* HTTPResponseParser_Tests.swift in Sources */,
-				8036C1E4270F9BE700C0F091 /* APIClient_Tests.swift in Sources */,
+				8036C1E4270F9BE700C0F091 /* NetworkingClient_Tests.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -1309,7 +1308,7 @@
 				CB4BE27E2847EA7D00EA2DD1 /* WebAuthenticationSession.swift in Sources */,
 				80E2FDC12A83535A0045593D /* TrackingEventsAPI.swift in Sources */,
 				BEA100F226EFA7DE0036A6A5 /* Environment.swift in Sources */,
-				BEA100F026EFA7C20036A6A5 /* APIClientError.swift in Sources */,
+				BEA100F026EFA7C20036A6A5 /* NetworkingClientError.swift in Sources */,
 				804E628629380B04004B9FEF /* AnalyticsService.swift in Sources */,
 				BC04837427B2FC7300FA7B46 /* URLSession+URLSessionProtocol.swift in Sources */,
 				80E2FDC32A8354AD0045593D /* RESTRequest.swift in Sources */,
@@ -1318,7 +1317,7 @@
 				804E62822937EBCE004B9FEF /* HTTP.swift in Sources */,
 				BC04836F27B2FB3600FA7B46 /* URLSessionProtocol.swift in Sources */,
 				065A4DBC26FCD8090007014A /* CoreSDKError.swift in Sources */,
-				BEA100E726EF9EDA0036A6A5 /* APIClient.swift in Sources */,
+				BEA100E726EF9EDA0036A6A5 /* NetworkingClient.swift in Sources */,
 				807BF58F2A2A5D19002F32B3 /* HTTPResponseParser.swift in Sources */,
 				807D56AE2A869064009E591D /* GraphQLRequest.swift in Sources */,
 			);
@@ -1352,7 +1351,7 @@
 				CB4BE28B2851423900EA2DD1 /* MockWebAuthenticationSession.swift in Sources */,
 				CB4BE28A28512A9800EA2DD1 /* MockQuededURLSession.swift in Sources */,
 				80E74400270E40F300BACECA /* FakeRequests.swift in Sources */,
-				E64763712899B60C00074113 /* MockAPIClient.swift in Sources */,
+				E64763712899B60C00074113 /* MockNetworkingClient.swift in Sources */,
 				3B80D50C2A27979000D2EAC4 /* FailingJSONEncoder.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
@@ -1365,7 +1364,6 @@
 				80E2FDBE2A83528B0045593D /* CheckoutOrdersAPI.swift in Sources */,
 				3B79E4F72A8503CA00C01D06 /* UpdateVaultVariables.swift in Sources */,
 				8048D28C270B9DE00072214A /* ConfirmPaymentSourceResponse.swift in Sources */,
-				3B109B3D2A85D1CA00D8135F /* MockGraphQLClient.swift in Sources */,
 				3D1763A22720722A00652E1C /* CardResult.swift in Sources */,
 				BC0A82A5270B9533006E9A21 /* ConfirmPaymentSourceRequest.swift in Sources */,
 				CB4BE2802847F01000EA2DD1 /* CardDelegate.swift in Sources */,

--- a/Sources/CardPayments/APIRequests/CheckoutOrdersAPI.swift
+++ b/Sources/CardPayments/APIRequests/CheckoutOrdersAPI.swift
@@ -11,19 +11,19 @@ class CheckoutOrdersAPI {
     // MARK: - Private Propertires
     
     private let coreConfig: CoreConfig
-    private let apiClient: APIClient
+    private let networkingClient: NetworkingClient
     
     // MARK: - Initializer
     
     init(coreConfig: CoreConfig) {
         self.coreConfig = coreConfig
-        self.apiClient = APIClient(coreConfig: coreConfig)
+        self.networkingClient = NetworkingClient(coreConfig: coreConfig)
     }
     
-    /// Exposed for injecting MockAPIClient in tests
-    init(coreConfig: CoreConfig, apiClient: APIClient) {
+    /// Exposed for injecting MockNetworkingClient in tests
+    init(coreConfig: CoreConfig, networkingClient: NetworkingClient) {
         self.coreConfig = coreConfig
-        self.apiClient = apiClient
+        self.networkingClient = networkingClient
     }
     
     // MARK: - Internal Methods
@@ -38,7 +38,7 @@ class CheckoutOrdersAPI {
             postParameters: confirmData
         )
         
-        let httpResponse = try await apiClient.fetch(request: restRequest)
+        let httpResponse = try await networkingClient.fetch(request: restRequest)
         return try HTTPResponseParser().parseREST(httpResponse, as: ConfirmPaymentSourceResponse.self)
     }
 }

--- a/Sources/CardPayments/APIRequests/VaultPaymentTokensAPI.swift
+++ b/Sources/CardPayments/APIRequests/VaultPaymentTokensAPI.swift
@@ -9,19 +9,19 @@ class VaultPaymentTokensAPI {
     // MARK: - Private Propertires
     
     private let coreConfig: CoreConfig
-    private let apiClient: APIClient
+    private let networkingClient: NetworkingClient
     
     // MARK: - Initializer
     
     init(coreConfig: CoreConfig) {
         self.coreConfig = coreConfig
-        self.apiClient = APIClient(coreConfig: coreConfig)
+        self.networkingClient = NetworkingClient(coreConfig: coreConfig)
     }
     
-    /// Exposed for injecting MockAPIClient in tests
-    init(coreConfig: CoreConfig, apiClient: APIClient) {
+    /// Exposed for injecting MockNetworkingClient in tests
+    init(coreConfig: CoreConfig, networkingClient: NetworkingClient) {
         self.coreConfig = coreConfig
-        self.apiClient = apiClient
+        self.networkingClient = networkingClient
     }
     
     // MARK: - Internal Methods
@@ -57,7 +57,7 @@ class VaultPaymentTokensAPI {
             queryNameForURL: "UpdateVaultSetupToken"
         )
 
-        let httpResponse = try await apiClient.fetch(request: graphQLRequest)
+        let httpResponse = try await networkingClient.fetch(request: graphQLRequest)
         
         return try HTTPResponseParser().parseGraphQL(httpResponse, as: UpdateSetupTokenResponse.self)
     }

--- a/Sources/CorePayments/Networking/HTTP.swift
+++ b/Sources/CorePayments/Networking/HTTP.swift
@@ -25,7 +25,7 @@ class HTTP {
         
         let (data, response) = try await urlSession.performRequest(with: urlRequest)
         guard let response = response as? HTTPURLResponse else {
-            throw APIClientError.invalidURLResponseError
+            throw NetworkingClientError.invalidURLResponseError
         }
         
         return HTTPResponse(status: response.statusCode, body: data)

--- a/Sources/CorePayments/Networking/HTTPResponseParser.swift
+++ b/Sources/CorePayments/Networking/HTTPResponseParser.swift
@@ -16,7 +16,7 @@ public class HTTPResponseParser {
 
     public func parseREST<T: Decodable>(_ httpResponse: HTTPResponse, as type: T.Type) throws -> T {
         guard let data = httpResponse.body else {
-            throw APIClientError.noResponseDataError
+            throw NetworkingClientError.noResponseDataError
         }
         
         if httpResponse.isSuccessful {
@@ -28,7 +28,7 @@ public class HTTPResponseParser {
     
     public func parseGraphQL<T: Decodable>(_ httpResponse: HTTPResponse, as type: T.Type) throws -> T {
         guard let data = httpResponse.body else {
-            throw APIClientError.noResponseDataError
+            throw NetworkingClientError.noResponseDataError
         }
         
         if httpResponse.isSuccessful {
@@ -44,14 +44,14 @@ public class HTTPResponseParser {
         do {
             if isGraphQL {
                 guard let data = try decoder.decode(GraphQLHTTPResponse<T>.self, from: data).data else {
-                    throw APIClientError.noGraphQLDataKey
+                    throw NetworkingClientError.noGraphQLDataKey
                 }
                 return data
             } else {
                 return try decoder.decode(T.self, from: data)
             }
         } catch {
-            throw APIClientError.jsonDecodingError(error.localizedDescription)
+            throw NetworkingClientError.jsonDecodingError(error.localizedDescription)
         }
     }
     
@@ -59,13 +59,13 @@ public class HTTPResponseParser {
         do {
             if isGraphQL {
                 let errorData = try decoder.decode(GraphQLErrorResponse.self, from: data)
-                throw APIClientError.serverResponseError(errorData.error)
+                throw NetworkingClientError.serverResponseError(errorData.error)
             } else {
                 let errorData = try decoder.decode(ErrorResponse.self, from: data)
-                throw APIClientError.serverResponseError(errorData.readableDescription)
+                throw NetworkingClientError.serverResponseError(errorData.readableDescription)
             }
         } catch {
-            throw APIClientError.jsonDecodingError(error.localizedDescription)
+            throw NetworkingClientError.jsonDecodingError(error.localizedDescription)
         }
     }
 }

--- a/Sources/CorePayments/Networking/NetworkingClient.swift
+++ b/Sources/CorePayments/Networking/NetworkingClient.swift
@@ -1,11 +1,10 @@
 import Foundation
 
-// TODO: - Rename to `NetworkingClient`. Now that we have `<PPaaS>API.swift` classes, ths responsibility of this class really is to coordinate networking. It transforms REST & GraphQL into HTTP requests.
 /// This method is exposed for internal PayPal use only. Do not use. It is not covered by Semantic Versioning and may change or be removed at any time.
 ///
-/// `APIClient` is the entry point for each payment method feature to perform API requests. It also offers convenience methods for API requests used across multiple payment methods / modules.
+/// `NetworkingClient` transforms REST & GraphQL requests into the proper HTTP format and executes network requests.
 @_documentation(visibility: private)
-public class APIClient {
+public class NetworkingClient {
         
     // MARK: - Internal Properties
     

--- a/Sources/CorePayments/Networking/NetworkingClientError.swift
+++ b/Sources/CorePayments/Networking/NetworkingClientError.swift
@@ -1,7 +1,8 @@
 import Foundation
 
-enum APIClientError {
+enum NetworkingClientError {
 
+    // NEXT_MAJOR_VERSION: - Change to "NetworkingClientErrorDomain"
     static let domain = "APIClientErrorDomain"
 
     enum Code: Int {

--- a/Sources/CorePayments/Networking/TrackingEventsAPI.swift
+++ b/Sources/CorePayments/Networking/TrackingEventsAPI.swift
@@ -8,20 +8,20 @@ class TrackingEventsAPI {
     // MARK: - Internal Properties
 
     var coreConfig: CoreConfig // exposed for testing
-    private var apiClient: APIClient
+    private var networkingClient: NetworkingClient
 
     // MARK: - Initializer
     
     init(coreConfig merchantConfig: CoreConfig) {
         // api.sandbox.paypal.com does not currently send FPTI events to BigQuery/Looker
         self.coreConfig = CoreConfig(clientID: merchantConfig.clientID, environment: .live)
-        self.apiClient = APIClient(coreConfig: coreConfig)
+        self.networkingClient = NetworkingClient(coreConfig: coreConfig)
     }
     
-    /// Exposed for injecting MockAPIClient in tests
-    init(coreConfig: CoreConfig, apiClient: APIClient) {
+    /// Exposed for injecting MockNetworkingClient in tests
+    init(coreConfig: CoreConfig, networkingClient: NetworkingClient) {
         self.coreConfig = coreConfig
-        self.apiClient = apiClient
+        self.networkingClient = networkingClient
     }
     
     // MARK: - Internal Functions
@@ -34,6 +34,6 @@ class TrackingEventsAPI {
             postParameters: analyticsEventData
         )
         
-        return try await apiClient.fetch(request: restRequest)
+        return try await networkingClient.fetch(request: restRequest)
     }
 }

--- a/Sources/PayPalNativePayments/PayPalNativeCheckoutClient.swift
+++ b/Sources/PayPalNativePayments/PayPalNativeCheckoutClient.swift
@@ -11,7 +11,7 @@ public class PayPalNativeCheckoutClient {
     public weak var delegate: PayPalNativeCheckoutDelegate?
     public weak var shippingDelegate: PayPalNativeShippingDelegate?
     private let nativeCheckoutProvider: NativeCheckoutStartable
-    private let apiClient: APIClient
+    private let networkingClient: NetworkingClient
     private let config: CoreConfig
     private var analyticsService: AnalyticsService?
 
@@ -22,14 +22,14 @@ public class PayPalNativeCheckoutClient {
         self.init(
             config: config,
             nativeCheckoutProvider: NativeCheckoutProvider(),
-            apiClient: APIClient(coreConfig: config)
+            networkingClient: NetworkingClient(coreConfig: config)
         )
     }
 
-    init(config: CoreConfig, nativeCheckoutProvider: NativeCheckoutStartable, apiClient: APIClient) {
+    init(config: CoreConfig, nativeCheckoutProvider: NativeCheckoutStartable, networkingClient: NetworkingClient) {
         self.config = config
         self.nativeCheckoutProvider = nativeCheckoutProvider
-        self.apiClient = apiClient
+        self.networkingClient = networkingClient
     }
 
     /// Present PayPal Paysheet and start a PayPal transaction

--- a/Sources/PayPalWebPayments/PayPalWebCheckoutClient.swift
+++ b/Sources/PayPalWebPayments/PayPalWebCheckoutClient.swift
@@ -9,7 +9,7 @@ public class PayPalWebCheckoutClient: NSObject {
     public weak var delegate: PayPalWebCheckoutDelegate?
     let config: CoreConfig
     private let webAuthenticationSession: WebAuthenticationSession
-    private let apiClient: APIClient
+    private let networkingClient: NetworkingClient
     private var analyticsService: AnalyticsService?
 
     /// Initialize a PayPalNativeCheckoutClient to process PayPal transaction
@@ -18,14 +18,14 @@ public class PayPalWebCheckoutClient: NSObject {
     public init(config: CoreConfig) {
         self.config = config
         self.webAuthenticationSession = WebAuthenticationSession()
-        self.apiClient = APIClient(coreConfig: config)
+        self.networkingClient = NetworkingClient(coreConfig: config)
     }
     
     /// For internal use for testing/mocking purpose
-    init(config: CoreConfig, apiClient: APIClient, webAuthenticationSession: WebAuthenticationSession) {
+    init(config: CoreConfig, networkingClient: NetworkingClient, webAuthenticationSession: WebAuthenticationSession) {
         self.config = config
         self.webAuthenticationSession = webAuthenticationSession
-        self.apiClient = apiClient
+        self.networkingClient = networkingClient
     }
 
     /// Launch the PayPal web flow

--- a/UnitTests/CardPaymentsTests/CardClient_Tests.swift
+++ b/UnitTests/CardPaymentsTests/CardClient_Tests.swift
@@ -19,7 +19,7 @@ class CardClient_Tests: XCTestCase {
     var cardRequest: CardRequest!
 
     let mockWebAuthSession = MockWebAuthenticationSession()
-    var mockAPIClient: MockAPIClient!
+    var mockNetworkingClient: MockNetworkingClient!
     var mockCardVaultDelegate: MockCardVaultDelegate!
     var mockCheckoutOrdersAPI: MockCheckoutOrdersAPI!
     var mockVaultAPI: MockVaultPaymentTokensAPI!
@@ -30,11 +30,11 @@ class CardClient_Tests: XCTestCase {
 
     override func setUp() {
         super.setUp()
-        mockAPIClient = MockAPIClient(coreConfig: config)
+        mockNetworkingClient = MockNetworkingClient(coreConfig: config)
         cardRequest = CardRequest(orderID: "testOrderId", card: card)
         
-        mockCheckoutOrdersAPI = MockCheckoutOrdersAPI(coreConfig: config, apiClient: mockAPIClient)
-        mockVaultAPI = MockVaultPaymentTokensAPI(coreConfig: config, apiClient: mockAPIClient)
+        mockCheckoutOrdersAPI = MockCheckoutOrdersAPI(coreConfig: config, networkingClient: mockNetworkingClient)
+        mockVaultAPI = MockVaultPaymentTokensAPI(coreConfig: config, networkingClient: mockNetworkingClient)
         
         sut = CardClient(
             config: config,

--- a/UnitTests/CardPaymentsTests/CheckoutOrdersAPI_Tests.swift
+++ b/UnitTests/CardPaymentsTests/CheckoutOrdersAPI_Tests.swift
@@ -28,7 +28,7 @@ class CheckoutOrdersAPI_Tests: XCTestCase {
         
         let mockHTTP = MockHTTP(coreConfig: coreConfig)
         mockNetworkingClient = MockNetworkingClient(http: mockHTTP)
-        sut = CheckoutOrdersAPI(coreConfig: coreConfig, mockNetworkingClient: mockNetworkingClient)
+        sut = CheckoutOrdersAPI(coreConfig: coreConfig, networkingClient: mockNetworkingClient)
     }
     
     // MARK: - confirmPaymentSource()

--- a/UnitTests/CardPaymentsTests/ConfirmPaymentSourceRequest_Tests.swift
+++ b/UnitTests/CardPaymentsTests/ConfirmPaymentSourceRequest_Tests.swift
@@ -6,7 +6,7 @@ import XCTest
 
 class ConfirmPaymentSourceRequest_Tests: XCTestCase {
     
-    // TODO: - Move to SDK wrapper on JSONEncoder for use in tests & APIClient
+    // TODO: - Move to SDK wrapper on JSONEncoder for use in tests & NetworkingClient
     let encoder = JSONEncoder()
     
     override func setUp() {

--- a/UnitTests/PayPalNativePaymentsTests/PayPalClient_Tests.swift
+++ b/UnitTests/PayPalNativePaymentsTests/PayPalClient_Tests.swift
@@ -7,7 +7,7 @@ import PayPalCheckout
 class PayPalClient_Tests: XCTestCase {
 
     let config = CoreConfig(clientID: "testClientID", environment: .sandbox)
-    lazy var apiClient = MockAPIClient(coreConfig: config)
+    lazy var mockNetworkingClient = MockNetworkingClient(coreConfig: config)
 
     let nxoConfig = CheckoutConfig(
         clientID: "testClientID",
@@ -25,7 +25,7 @@ class PayPalClient_Tests: XCTestCase {
     lazy var payPalClient = PayPalNativeCheckoutClient(
         config: config,
         nativeCheckoutProvider: mockNativeCheckoutProvider,
-        apiClient: apiClient
+        mockNetworkingClient: mockNetworkingClient
     )
 
     func testStart_whenNativeSDKOnApproveCalled_returnsPayPalResult() async {

--- a/UnitTests/PayPalNativePaymentsTests/PayPalClient_Tests.swift
+++ b/UnitTests/PayPalNativePaymentsTests/PayPalClient_Tests.swift
@@ -25,7 +25,7 @@ class PayPalClient_Tests: XCTestCase {
     lazy var payPalClient = PayPalNativeCheckoutClient(
         config: config,
         nativeCheckoutProvider: mockNativeCheckoutProvider,
-        mockNetworkingClient: mockNetworkingClient
+        networkingClient: mockNetworkingClient
     )
 
     func testStart_whenNativeSDKOnApproveCalled_returnsPayPalResult() async {

--- a/UnitTests/PayPalWebPaymentsTests/PayPalWebCheckoutClient_Tests.swift
+++ b/UnitTests/PayPalWebPaymentsTests/PayPalWebCheckoutClient_Tests.swift
@@ -9,17 +9,17 @@ class PayPalClient_Tests: XCTestCase {
     var config: CoreConfig!
     var mockWebAuthenticationSession: MockWebAuthenticationSession!
     var payPalClient: PayPalWebCheckoutClient!
-    var mockAPIClient: MockAPIClient!
+    var mockNetworkingClient: MockNetworkingClient!
     
     override func setUp() {
         super.setUp()
         config = CoreConfig(clientID: "testClientID", environment: .sandbox)
         mockWebAuthenticationSession = MockWebAuthenticationSession()
-        mockAPIClient = MockAPIClient(http: MockHTTP(coreConfig: config))
+        mockNetworkingClient = MockNetworkingClient(http: MockHTTP(coreConfig: config))
         
         payPalClient = PayPalWebCheckoutClient(
             config: config,
-            apiClient: mockAPIClient,
+            networkingClient: mockNetworkingClient,
             webAuthenticationSession: mockWebAuthenticationSession
         )
     }

--- a/UnitTests/PaymentsCoreTests/HTTPResponseParser_Tests.swift
+++ b/UnitTests/PaymentsCoreTests/HTTPResponseParser_Tests.swift
@@ -19,7 +19,7 @@ class HTTPResponseParser_Tests: XCTestCase {
         } catch {
             let error = error as! CoreSDKError
             XCTAssertEqual(error.localizedDescription, "An error occured due to missing HTTP response data. Contact developer.paypal.com/support.")
-            XCTAssertEqual(error.domain, APIClientError.domain)
+            XCTAssertEqual(error.domain, NetworkingClientError.domain)
         }
     }
     
@@ -64,7 +64,7 @@ class HTTPResponseParser_Tests: XCTestCase {
         } catch {
             let error = error as! CoreSDKError
             XCTAssertEqual(error.localizedDescription, "fake-error-name: fake-message")
-            XCTAssertEqual(error.domain, APIClientError.domain)
+            XCTAssertEqual(error.domain, NetworkingClientError.domain)
         }
     }
     
@@ -79,7 +79,7 @@ class HTTPResponseParser_Tests: XCTestCase {
         } catch {
             let error = error as! CoreSDKError
             XCTAssertEqual(error.localizedDescription, "An error occured due to missing HTTP response data. Contact developer.paypal.com/support.")
-            XCTAssertEqual(error.domain, APIClientError.domain)
+            XCTAssertEqual(error.domain, NetworkingClientError.domain)
         }
     }
     
@@ -105,7 +105,7 @@ class HTTPResponseParser_Tests: XCTestCase {
         } catch {
             let error = error as! CoreSDKError
             XCTAssertEqual(error.localizedDescription, "An error occured due to missing `data` key in GraphQL query response. Contact developer.paypal.com/support.")
-            XCTAssertEqual(error.domain, APIClientError.domain)
+            XCTAssertEqual(error.domain, NetworkingClientError.domain)
         }
     }
     
@@ -138,7 +138,7 @@ class HTTPResponseParser_Tests: XCTestCase {
         } catch {
             let error = error as! CoreSDKError
             XCTAssertEqual(error.localizedDescription, "fake-error-description")
-            XCTAssertEqual(error.domain, APIClientError.domain)
+            XCTAssertEqual(error.domain, NetworkingClientError.domain)
         }
     }
 }

--- a/UnitTests/PaymentsCoreTests/HTTP_Tests.swift
+++ b/UnitTests/PaymentsCoreTests/HTTP_Tests.swift
@@ -69,8 +69,8 @@ class HTTP_Tests: XCTestCase {
             _ = try await sut.performRequest(fakeHTTPRequest)
             XCTFail("Request succeeded. Expected error.")
         } catch let error as CoreSDKError {
-            XCTAssertEqual(error.domain, APIClientError.domain)
-            XCTAssertEqual(error.code, APIClientError.Code.invalidURLResponse.rawValue)
+            XCTAssertEqual(error.domain, NetworkingClientError.domain)
+            XCTAssertEqual(error.code, NetworkingClientError.Code.invalidURLResponse.rawValue)
             XCTAssertEqual(error.localizedDescription, "An error occured due to an invalid HTTP response. Contact developer.paypal.com/support.")
         } catch {
             XCTFail("Unexpected error type")

--- a/UnitTests/PaymentsCoreTests/NetworkingClient_Tests.swift
+++ b/UnitTests/PaymentsCoreTests/NetworkingClient_Tests.swift
@@ -2,11 +2,11 @@ import XCTest
 @testable import CorePayments
 @testable import TestShared
 
-class APIClient_Tests: XCTestCase {
+class NetworkingClient_Tests: XCTestCase {
     
     // MARK: - Helper Properties
     
-    var sut: APIClient!
+    var sut: NetworkingClient!
     var mockHTTP: MockHTTP!
     var coreConfig = CoreConfig(clientID: "fake-client-id", environment: .sandbox)
     let base64EncodedFakeClientID = "ZmFrZS1jbGllbnQtaWQ6" // "fake-client-id" encoded
@@ -19,7 +19,7 @@ class APIClient_Tests: XCTestCase {
         
         mockHTTP = MockHTTP(coreConfig: coreConfig)
         mockHTTP.stubHTTPResponse = stubHTTPResponse
-        sut = APIClient(http: mockHTTP)
+        sut = NetworkingClient(http: mockHTTP)
     }
     
     // MARK: - fetch() REST
@@ -27,7 +27,7 @@ class APIClient_Tests: XCTestCase {
     func testFetchREST_whenLive_usesProperPayPalURL() async throws {
         let mockHTTP = MockHTTP(coreConfig: CoreConfig(clientID: "123", environment: .live))
         mockHTTP.stubHTTPResponse = HTTPResponse(status: 200, body: nil)
-        let sut = APIClient(http: mockHTTP)
+        let sut = NetworkingClient(http: mockHTTP)
         
         let fakeGETRequest = RESTRequest(path: "", method: .get)
         
@@ -104,7 +104,7 @@ class APIClient_Tests: XCTestCase {
     func testFetchGraphQL_whenLive_usesProperPayPalURL() async throws {
         let mockHTTP = MockHTTP(coreConfig: CoreConfig(clientID: "123", environment: .live))
         mockHTTP.stubHTTPResponse = HTTPResponse(status: 200, body: nil)
-        let sut = APIClient(http: mockHTTP)
+        let sut = NetworkingClient(http: mockHTTP)
         
         let fakeGraphQLRequest = GraphQLRequest(query: "fake-query", variables: FakeRequest(fakeParam: "fake-param"))
         

--- a/UnitTests/PaymentsCoreTests/TrackingEventsAPI_Tests.swift
+++ b/UnitTests/PaymentsCoreTests/TrackingEventsAPI_Tests.swift
@@ -8,7 +8,7 @@ class TrackingEventsAPI_Tests: XCTestCase {
     // MARK: - Helper Properties
     
     var sut: TrackingEventsAPI!
-    var mockAPIClient: MockAPIClient!
+    var mockNetworkingClient: MockNetworkingClient!
     let coreConfig = CoreConfig(clientID: "fake-client-id", environment: .sandbox)
     let stubHTTPResponse = HTTPResponse(status: 200, body: nil)
     let fakeAnalyticsEventData = AnalyticsEventData(
@@ -24,9 +24,9 @@ class TrackingEventsAPI_Tests: XCTestCase {
         super.setUp()
         
         let mockHTTP = MockHTTP(coreConfig: coreConfig)
-        mockAPIClient = MockAPIClient(http: mockHTTP)
-        mockAPIClient.stubHTTPResponse = stubHTTPResponse
-        sut = TrackingEventsAPI(coreConfig: coreConfig, apiClient: mockAPIClient)
+        mockNetworkingClient = MockNetworkingClient(http: mockHTTP)
+        mockNetworkingClient.stubHTTPResponse = stubHTTPResponse
+        sut = TrackingEventsAPI(coreConfig: coreConfig, networkingClient: mockNetworkingClient)
     }
     
     // MARK: - sendEvent() REST
@@ -45,11 +45,11 @@ class TrackingEventsAPI_Tests: XCTestCase {
         )
         _ = try await sut.sendEvent(with: fakeAnalyticsEventData)
         
-        XCTAssertEqual(mockAPIClient.capturedRESTRequest?.path, "v1/tracking/events")
-        XCTAssertEqual(mockAPIClient.capturedRESTRequest?.method, .post)
-        XCTAssertNil(mockAPIClient.capturedRESTRequest?.queryParameters)
+        XCTAssertEqual(mockNetworkingClient.capturedRESTRequest?.path, "v1/tracking/events")
+        XCTAssertEqual(mockNetworkingClient.capturedRESTRequest?.method, .post)
+        XCTAssertNil(mockNetworkingClient.capturedRESTRequest?.queryParameters)
         
-        let postData = mockAPIClient.capturedRESTRequest?.postParameters as! AnalyticsEventData
+        let postData = mockNetworkingClient.capturedRESTRequest?.postParameters as! AnalyticsEventData
         XCTAssertEqual(postData.environment, "my-env")
         XCTAssertEqual(postData.eventName, "my-event-name")
         XCTAssertEqual(postData.clientID, "my-id")
@@ -62,15 +62,15 @@ class TrackingEventsAPI_Tests: XCTestCase {
         XCTAssertEqual(httpResponse, stubHTTPResponse)
     }
     
-    func testSendEvent_whenError_bubblesAPIClientErrorThrow() async throws {
-        mockAPIClient.stubHTTPError = CoreSDKError(code: 0, domain: "", errorDescription: "Fake error from APIClient")
+    func testSendEvent_whenError_bubblesNetworkingClientErrorThrow() async throws {
+        mockNetworkingClient.stubHTTPError = CoreSDKError(code: 0, domain: "", errorDescription: "Fake error from NetworkingClient")
         
         do {
             _ = try await sut.sendEvent(with: fakeAnalyticsEventData)
             XCTFail("Expected an error to be thrown.")
         } catch {
             let error = error as NSError
-            XCTAssertEqual(error.localizedDescription, "Fake error from APIClient")
+            XCTAssertEqual(error.localizedDescription, "Fake error from NetworkingClient")
         }
     }
 }

--- a/UnitTests/TestShared/MockNetworkingClient.swift
+++ b/UnitTests/TestShared/MockNetworkingClient.swift
@@ -1,7 +1,7 @@
 import Foundation
 @testable import CorePayments
 
-class MockAPIClient: APIClient {
+class MockNetworkingClient: NetworkingClient {
 
     var stubHTTPResponse: HTTPResponse?
     var stubHTTPError: Error?


### PR DESCRIPTION
### Reason for changes

This change came out of our series of [networking layer refactor PRs](https://github.com/paypal/paypal-ios/pulls?q=is%3Apr+networking+label%3Anetworking-refactor) which introduces the `<PPaaS>API.swift` files. 

The `APIClient` has a different responsibility now, to transform GraphQL & REST requests into the HTTP protocol + execute the request.

### Feedback

Do folks think this rename is helpful? Do folks have a better name idea for this class? I think we tend to overuse the term `Client`.

### Summary of changes

- Rename `APIClient` to `NetworkingClient`

### Checklist

- ~Added a changelog entry~

### Authors
@scannillo 