### PR TITLE
Resolve Compile Errors with Strict Swift Concurrency Checking

### DIFF
--- a/Sources/CardPayments/CardClient.swift
+++ b/Sources/CardPayments/CardClient.swift
@@ -161,6 +161,7 @@ public class CardClient: NSObject {
 
 extension CardClient: ASWebAuthenticationPresentationContextProviding {
 
+    @MainActor
     public func presentationAnchor(for session: ASWebAuthenticationSession) -> ASPresentationAnchor {
         if #available(iOS 15, *) {
             let firstScene = UIApplication.shared.connectedScenes.first as? UIWindowScene

--- a/Sources/CorePayments/AnalyticsEventData.swift
+++ b/Sources/CorePayments/AnalyticsEventData.swift
@@ -1,5 +1,6 @@
 import UIKit
 
+@MainActor
 struct AnalyticsEventData: Encodable {
     
     enum TopLevelKeys: String, CodingKey {

--- a/Sources/CorePayments/AnalyticsEventData.swift
+++ b/Sources/CorePayments/AnalyticsEventData.swift
@@ -102,7 +102,7 @@ struct AnalyticsEventData: Encodable {
         self.correlationID = correlationID
     }
     
-    func encode(to encoder: Encoder) throws {
+    nonisolated func encode(to encoder: Encoder) throws {
         var topLevel = encoder.container(keyedBy: TopLevelKeys.self)
         var events = topLevel.nestedContainer(keyedBy: EventKeys.self, forKey: .events)
         var eventParameters = events.nestedContainer(keyedBy: EventParameterKeys.self, forKey: .eventParameters)

--- a/Sources/CorePayments/Networking/AnalyticsService.swift
+++ b/Sources/CorePayments/Networking/AnalyticsService.swift
@@ -49,7 +49,7 @@ public struct AnalyticsService {
         do {
             let clientID = coreConfig.clientID
             
-            let eventData = AnalyticsEventData(
+            let eventData = await AnalyticsEventData(
                 environment: coreConfig.environment.toString,
                 eventName: name,
                 clientID: clientID,

--- a/Sources/PayPalWebPayments/PayPalWebCheckoutClient.swift
+++ b/Sources/PayPalWebPayments/PayPalWebCheckoutClient.swift
@@ -121,7 +121,8 @@ public class PayPalWebCheckoutClient: NSObject {
 // MARK: - ASWebAuthenticationPresentationContextProviding conformance
 
 extension PayPalWebCheckoutClient: ASWebAuthenticationPresentationContextProviding {
-    
+  
+    @MainActor
     public func presentationAnchor(for session: ASWebAuthenticationSession) -> ASPresentationAnchor {
         if #available(iOS 15, *) {
             let firstScene = UIApplication.shared.connectedScenes.first as? UIWindowScene

--- a/Sources/PaymentButtons/ImageAsset.swift
+++ b/Sources/PaymentButtons/ImageAsset.swift
@@ -1,5 +1,6 @@
 import UIKit
 
+@MainActor
 enum ImageAsset {
     static func paymentButtonLogo(for button: PaymentButton) -> UIImage? {
         var imageAssetString = ""

--- a/Sources/PaymentButtons/PayPalButton.swift
+++ b/Sources/PaymentButtons/PayPalButton.swift
@@ -79,6 +79,7 @@ public extension PayPalButton {
         ///   - edges: Edges of the button. Default to softEdges if not provided.
         ///   - size: Size of the button. Default to collapsed if not provided.
         ///   - label: Label displayed next to the button's logo. Default to no label.
+        @MainActor
         public init(
             insets: NSDirectionalEdgeInsets? = nil,
             color: PayPalButton.Color = .gold,

--- a/Sources/PaymentButtons/PayPalCreditButton.swift
+++ b/Sources/PaymentButtons/PayPalCreditButton.swift
@@ -56,6 +56,7 @@ public extension PayPalCreditButton {
         ///   - color: Color of the button. Default to dark blue if not provided.
         ///   - edges: Edges of the button. Default to softEdges if not provided.
         ///   - size: Size of the button. Default to collapsed if not provided.
+        @MainActor
         public init(
             insets: NSDirectionalEdgeInsets? = nil,
             color: PayPalCreditButton.Color = .darkBlue,

--- a/Sources/PaymentButtons/PayPalPayLaterButton.swift
+++ b/Sources/PaymentButtons/PayPalPayLaterButton.swift
@@ -55,6 +55,7 @@ public extension PayPalPayLaterButton {
         ///   - color: Color of the button. Default to gold if not provided.
         ///   - edges: Edges of the button. Default to softEdges if not provided.
         ///   - size: Size of the button. Default to collapsed if not provided.
+        @MainActor
         public init(
             insets: NSDirectionalEdgeInsets? = nil,
             color: PayPalPayLaterButton.Color = .gold,

--- a/Sources/PaymentButtons/PaymentButtonEdges.swift
+++ b/Sources/PaymentButtons/PaymentButtonEdges.swift
@@ -12,6 +12,7 @@ public enum PaymentButtonEdges: Int {
     /// Pill shaped corner radius.
     case rounded
 
+    @MainActor
     func cornerRadius(for view: UIView) -> CGFloat {
         switch self {
         case .hardEdges:

--- a/UnitTests/CardPaymentsTests/CardClient_Tests.swift
+++ b/UnitTests/CardPaymentsTests/CardClient_Tests.swift
@@ -5,6 +5,7 @@ import AuthenticationServices
 @testable import CardPayments
 @testable import TestShared
 
+@MainActor
 class CardClient_Tests: XCTestCase {
 
     // MARK: - Helper Properties

--- a/UnitTests/CardPaymentsTests/CardClient_Tests.swift
+++ b/UnitTests/CardPaymentsTests/CardClient_Tests.swift
@@ -5,7 +5,6 @@ import AuthenticationServices
 @testable import CardPayments
 @testable import TestShared
 
-@MainActor
 class CardClient_Tests: XCTestCase {
 
     // MARK: - Helper Properties
@@ -47,7 +46,7 @@ class CardClient_Tests: XCTestCase {
     
     // MARK: - vault() tests
 
-    func testVault_withValidResponse_returnsSuccess() {
+    func testVault_withValidResponse_returnsSuccess() async throws {
         let setupTokenID = "testToken1"
         let vaultStatus = "APPROVED"
         let vaultRequest = CardVaultRequest(card: card, setupTokenID: setupTokenID)
@@ -67,10 +66,10 @@ class CardClient_Tests: XCTestCase {
         sut.vaultDelegate = cardVaultDelegate
         sut.vault(vaultRequest)
         
-        waitForExpectations(timeout: 10)
+        await self.fulfillment(of: [expectation], timeout: 10)
     }
-    
-    func testVault_whenVaultAPIError_bubblesError() {
+
+    func testVault_whenVaultAPIError_bubblesError() async throws {
         let setupTokenID = "testToken1"
         let vaultRequest = CardVaultRequest(card: card, setupTokenID: setupTokenID)
                
@@ -88,10 +87,10 @@ class CardClient_Tests: XCTestCase {
         sut.vaultDelegate = cardVaultDelegate
         sut.vault(vaultRequest)
 
-        waitForExpectations(timeout: 10)
+        await self.fulfillment(of: [expectation], timeout: 10)
     }
 
-    func testVault_whenUnknownError_returnsVaultError() {
+    func testVault_whenUnknownError_returnsVaultError() async throws {
         let setupTokenID = "testToken1"
         let vaultRequest = CardVaultRequest(card: card, setupTokenID: setupTokenID)
 
@@ -109,12 +108,12 @@ class CardClient_Tests: XCTestCase {
         sut.vaultDelegate = cardVaultDelegate
         sut.vault(vaultRequest)
 
-        waitForExpectations(timeout: 10)
+        await self.fulfillment(of: [expectation], timeout: 10)
     }
 
     // MARK: - approveOrder() tests
 
-    func testApproveOrder_withInvalid3DSURL_returnsError() {
+    func testApproveOrder_withInvalid3DSURL_returnsError() async throws {
         mockCheckoutOrdersAPI.stubConfirmResponse = FakeConfirmPaymentResponse.withInvalid3DSURL
         
         let expectation = expectation(description: "approveOrder() completed")
@@ -133,10 +132,10 @@ class CardClient_Tests: XCTestCase {
         sut.delegate = mockCardDelegate
         sut.approveOrder(request: cardRequest)
 
-        waitForExpectations(timeout: 10)
+        await self.fulfillment(of: [expectation], timeout: 10)
     }
 
-    func testApproveOrder_withNoThreeDSecure_returnsOrderData() {
+    func testApproveOrder_withNoThreeDSecure_returnsOrderData() async throws {
         mockCheckoutOrdersAPI.stubConfirmResponse = FakeConfirmPaymentResponse.without3DS
         
         let expectation = expectation(description: "approveOrder() completed")
@@ -153,10 +152,10 @@ class CardClient_Tests: XCTestCase {
         sut.delegate = mockCardDelegate
         sut.approveOrder(request: cardRequest)
 
-        waitForExpectations(timeout: 10)
+        await self.fulfillment(of: [expectation], timeout: 10)
     }
 
-    func testApproveOrder_whenConfirmPaymentSDKError_bubblesError() {
+    func testApproveOrder_whenConfirmPaymentSDKError_bubblesError() async throws {
         mockCheckoutOrdersAPI.stubError = CoreSDKError(code: 123, domain: "sdk-domain", errorDescription: "sdk-error-desc")
 
         let expectation = expectation(description: "approveOrder() completed")
@@ -175,10 +174,10 @@ class CardClient_Tests: XCTestCase {
         sut.delegate = mockCardDelegate
         sut.approveOrder(request: cardRequest)
 
-        waitForExpectations(timeout: 10)
+        await self.fulfillment(of: [expectation], timeout: 10)
     }
     
-    func testApproveOrder_whenConfirmPaymentGeneralError_returnsUnknownError() {
+    func testApproveOrder_whenConfirmPaymentGeneralError_returnsUnknownError() async throws {
         mockCheckoutOrdersAPI.stubError = NSError(
             domain: "ns-fake-domain",
             code: 123,
@@ -201,10 +200,10 @@ class CardClient_Tests: XCTestCase {
         sut.delegate = mockCardDelegate
         sut.approveOrder(request: cardRequest)
 
-        waitForExpectations(timeout: 10)
+        await self.fulfillment(of: [expectation], timeout: 10)
     }
 
-    func testApproveOrder_withThreeDSecure_browserSwitchLaunches_getOrderReturnsSuccess() {
+    func testApproveOrder_withThreeDSecure_browserSwitchLaunches_getOrderReturnsSuccess() async throws {
         mockCheckoutOrdersAPI.stubConfirmResponse = FakeConfirmPaymentResponse.withValid3DSURL
 
         let expectation = expectation(description: "approveOrder() completed")
@@ -225,10 +224,10 @@ class CardClient_Tests: XCTestCase {
         sut.delegate = mockCardDelegate
         sut.approveOrder(request: cardRequest)
 
-        waitForExpectations(timeout: 10)
+        await self.fulfillment(of: [expectation], timeout: 10)
     }
 
-    func testApproveOrder_withThreeDSecure_userCancelsBrowser() {
+    func testApproveOrder_withThreeDSecure_userCancelsBrowser() async throws {
         mockCheckoutOrdersAPI.stubConfirmResponse = FakeConfirmPaymentResponse.withValid3DSURL
 
         mockWebAuthSession.cannedErrorResponse = ASWebAuthenticationSessionError(
@@ -257,10 +256,10 @@ class CardClient_Tests: XCTestCase {
         sut.delegate = mockCardDelegate
         sut.approveOrder(request: cardRequest)
 
-        waitForExpectations(timeout: 10)
+        await self.fulfillment(of: [expectation], timeout: 10)
     }
 
-    func testApproveOrder_withThreeDSecure_browserReturnsError() {
+    func testApproveOrder_withThreeDSecure_browserReturnsError() async throws {
         mockCheckoutOrdersAPI.stubConfirmResponse = FakeConfirmPaymentResponse.withValid3DSURL
 
         mockWebAuthSession.cannedErrorResponse = CoreSDKError(
@@ -292,6 +291,6 @@ class CardClient_Tests: XCTestCase {
         sut.delegate = mockCardDelegate
         sut.approveOrder(request: cardRequest)
 
-        waitForExpectations(timeout: 10)
+        await self.fulfillment(of: [expectation], timeout: 10)
     }
 }

--- a/UnitTests/PaymentButtonsTests/Coordinator_Tests.swift
+++ b/UnitTests/PaymentButtonsTests/Coordinator_Tests.swift
@@ -5,6 +5,7 @@ class Coordinator_Tests: XCTestCase {
 
     var actionString: String = ""
 
+    @MainActor
     func testCoordinator_init() {
         let action = { self.actionTest() }
         let coordinator = Coordinator(action: action)

--- a/UnitTests/PaymentButtonsTests/PayPalButton_Tests.swift
+++ b/UnitTests/PaymentButtonsTests/PayPalButton_Tests.swift
@@ -20,7 +20,8 @@ class PayPalButton_Tests: XCTestCase {
     }
 
     // MARK: - PayPalButton.Representable for SwiftUI
-    
+
+    @MainActor
     func testMakeCoordinator_whenOnActionIsCalled_executesActionPassedInInitializer() {
         let expectation = expectation(description: "Action is called")
         let sut = PayPalButton.Representable {

--- a/UnitTests/PaymentButtonsTests/PayPalButton_Tests.swift
+++ b/UnitTests/PaymentButtonsTests/PayPalButton_Tests.swift
@@ -1,6 +1,7 @@
 import XCTest
 @testable import PaymentButtons
 
+@MainActor
 class PayPalButton_Tests: XCTestCase {
 
     // MARK: - PayPalButton for UIKit

--- a/UnitTests/PaymentButtonsTests/PayPalButton_Tests.swift
+++ b/UnitTests/PaymentButtonsTests/PayPalButton_Tests.swift
@@ -22,7 +22,6 @@ class PayPalButton_Tests: XCTestCase {
 
     // MARK: - PayPalButton.Representable for SwiftUI
 
-    @MainActor
     func testMakeCoordinator_whenOnActionIsCalled_executesActionPassedInInitializer() {
         let expectation = expectation(description: "Action is called")
         let sut = PayPalButton.Representable {

--- a/UnitTests/PaymentButtonsTests/PayPalCreditButton_Tests.swift
+++ b/UnitTests/PaymentButtonsTests/PayPalCreditButton_Tests.swift
@@ -21,6 +21,7 @@ class PayPalCreditButton_Tests: XCTestCase {
 
     // MARK: - PayPalPayCreditButton.Representable for SwiftUI
     
+    @MainActor
     func testMakeCoordinator_whenOnActionIsCalled_executesActionPassedInInitializer() {
         let expectation = expectation(description: "Action is called")
         let sut = PayPalCreditButton.Representable {

--- a/UnitTests/PaymentButtonsTests/PayPalCreditButton_Tests.swift
+++ b/UnitTests/PaymentButtonsTests/PayPalCreditButton_Tests.swift
@@ -1,6 +1,7 @@
 import XCTest
 @testable import PaymentButtons
 
+@MainActor
 class PayPalCreditButton_Tests: XCTestCase {
 
     // MARK: - PayPalPayCreditButton for UIKit

--- a/UnitTests/PaymentButtonsTests/PayPalPayLaterButton_Tests.swift
+++ b/UnitTests/PaymentButtonsTests/PayPalPayLaterButton_Tests.swift
@@ -5,6 +5,7 @@ class PayPalPayLaterButton_Tests: XCTestCase {
     
     // MARK: - PayPalPayLaterButton for UIKit
     
+    @MainActor
     func testInit_whenPayPalPayLaterButtonCreated_hasDefaultUIValues() {
         let sut = PayPalPayLaterButton()
         XCTAssertEqual(sut.edges, PaymentButtonEdges.softEdges)

--- a/UnitTests/PaymentButtonsTests/PayPalPayLaterButton_Tests.swift
+++ b/UnitTests/PaymentButtonsTests/PayPalPayLaterButton_Tests.swift
@@ -16,6 +16,7 @@ class PayPalPayLaterButton_Tests: XCTestCase {
 
     // MARK: - PayPalPayLaterButton.Representable for SwiftUI
     
+    @MainActor
     func testMakeCoordinator_whenOnActionIsCalled_executesActionPassedInInitializer() {
         let expectation = expectation(description: "Action is called")
         let sut = PayPalPayLaterButton.Representable {

--- a/UnitTests/PaymentsCoreTests/AnalyticsEventData_Tests.swift
+++ b/UnitTests/PaymentsCoreTests/AnalyticsEventData_Tests.swift
@@ -8,6 +8,7 @@ class AnalyticsEventData_Tests: XCTestCase {
     let currentTime = String(Date().timeIntervalSince1970 * 1000)
     let oneSecondLater = String((Date().timeIntervalSince1970 * 1000) + 999)
     
+    @MainActor
     override func setUp() {
         super.setUp()
         sut = AnalyticsEventData(

--- a/UnitTests/PaymentsCoreTests/AnalyticsService_Tests.swift
+++ b/UnitTests/PaymentsCoreTests/AnalyticsService_Tests.swift
@@ -2,6 +2,7 @@ import XCTest
 @testable import CorePayments
 @testable import TestShared
 
+@MainActor
 class AnalyticsService_Tests: XCTestCase {
 
     // MARK: - Helper properties

--- a/UnitTests/PaymentsCoreTests/TrackingEventsAPI_Tests.swift
+++ b/UnitTests/PaymentsCoreTests/TrackingEventsAPI_Tests.swift
@@ -3,6 +3,7 @@ import XCTest
 @testable import TestShared
 @testable import CorePayments
 
+@MainActor
 class TrackingEventsAPI_Tests: XCTestCase {
     
     // MARK: - Helper Properties


### PR DESCRIPTION
### Reason for changes
Apple has suggested you work towards complete checking, not just to avoid potential problems, but also in preparation for the expected checking that a future release of Swift 6 will enforce. 

In WWDC 2022 video "[Eliminate data races using Swift Concurrency](https://developer.apple.com/videos/play/wwdc2022/110351/)", they state "Complete checking approximates the intended Swift 6 semantics to completely eliminate data races".


### Summary of changes
- Resolve compile errors with Swift Concurrency Check set to "Complete" in preparation for Swift 6 
    - References to properties in UIDevice, UIApplication in structs or classes result in an error unless
      the struct or classes or specific functions are referencing these properties are also explicitly guaranteed to run
      on main thread.
    - Unit tests using waitForExpectations function needed to be annotated with @MainActor to resolve compile errors
    - In PaymentButton's subclasses, their Representable structs that wrap the UIKit elements for SwiftUI views, needed to have initializers that are annotated @MainActor to resolve compile errors. 
   
      PaymentButton is a subclass of UIButton which is annotated as @MainActor. I think it is not enforced for the UIButton subclass initializers because of backward compatibility.
    
I will address some Sendable warnings in [another PR](https://github.com/paypal/paypal-ios/pull/215). 
We can decide when we want to implement these changes. 
It's good to be proactive in at least spiking potential scope of work before Swift 6.

### Checklist

~- [ ] Added a changelog entry~

### Authors
- @KunJeongPark 