### PR TITLE
Update GitHub Action CI for Forks

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,5 +1,5 @@
 name: Build
-on: [pull_request, workflow_dispatch]
+on: [pull_request]
 concurrency:
   group: build-${{ github.event.number }}
   cancel-in-progress: true
@@ -10,6 +10,9 @@ jobs:
     steps:
       - name: Check out repository
         uses: actions/checkout@v3
+        with:
+          ref: ${{ github.event.pull_request.head.ref }}
+          repository: ${{ github.event.pull_request.head.repo.full_name }}
       - name: Use Xcode 14
         run: sudo xcode-select -switch /Applications/Xcode_14.3.app
       - name: Run pod lib lint
@@ -20,10 +23,13 @@ jobs:
     steps:
       - name: Check out repository
         uses: actions/checkout@v3
+        with:
+          ref: ${{ github.event.pull_request.head.ref }}
+          repository: ${{ github.event.pull_request.head.repo.full_name }}
       - name: Use Xcode 14
         run: sudo xcode-select -switch /Applications/Xcode_14.3.app
       - name: Use current branch
-        run: sed -i '' 's/branch = .*/branch = \"'"$GITHUB_HEAD_REF"'\";/' SampleApps/SPMTest/SPMTest.xcodeproj/project.pbxproj
+        run: sed -i '' 's/branch = .*/branch = \"'"${GITHUB_HEAD_REF//\//\/}"'\";/' SampleApps/SPMTest/SPMTest.xcodeproj/project.pbxproj
       - name: Run swift package resolve
         run: cd SampleApps/SPMTest && swift package resolve
       - name: Build & archive SPMTest

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -1,5 +1,5 @@
 name: Tests
-on: [pull_request, workflow_dispatch]
+on: [pull_request]
 concurrency:
   group: tests-${{ github.event.number }}
   cancel-in-progress: true
@@ -10,6 +10,9 @@ jobs:
     steps:
       - name: Checkout repository
         uses: actions/checkout@v3
+        with:
+          ref: ${{ github.event.pull_request.head.ref }}
+          repository: ${{ github.event.pull_request.head.repo.full_name }}
       - name: Use Xcode 14
         run: sudo xcode-select -switch /Applications/Xcode_14.3.app
       - name: Run Unit Tests


### PR DESCRIPTION
### Reason for changes

CI should run as expected on forks!

### Summary of changes

- We made this change a while ago on BT and never got around to adding it here but now that we have some outside contributors we should ensure that all PRs (even forks) work as expected
    - Pulled from the BT [test.yml](https://github.com/braintree/braintree_ios/blob/main/.github/workflows/tests.yml) and [build.yml](https://github.com/braintree/braintree_ios/blob/main/.github/workflows/build.yml)

### Checklist

- ~[ ] Added a changelog entry~

### Authors

- @jaxdesmarais 