### PR TITLE
Vault with Purchase PayPalWeb

### DIFF
--- a/Demo/Demo/Models/CreateOrderParams.swift
+++ b/Demo/Demo/Models/CreateOrderParams.swift
@@ -63,6 +63,11 @@ struct Attributes: Encodable {
 
     let vault: Vault
     let customer: VaultCustomer?
+
+    init(vault: Vault, customer: VaultCustomer? = nil) {
+        self.vault = vault
+        self.customer = customer
+    }
 }
 
 struct Vault: Encodable {

--- a/Demo/Demo/Models/CreateOrderParams.swift
+++ b/Demo/Demo/Models/CreateOrderParams.swift
@@ -62,9 +62,9 @@ struct VaultCard: Encodable {
 struct Attributes: Encodable {
 
     let vault: Vault
-    let customer: VaultCustomer?
+    let customer: Customer?
 
-    init(vault: Vault, customer: VaultCustomer? = nil) {
+    init(vault: Vault, customer: Customer? = nil) {
         self.vault = vault
         self.customer = customer
     }
@@ -76,12 +76,6 @@ struct Vault: Encodable {
     let usageType: String?
     let customerType: String?
 }
-
-struct VaultCustomer: Encodable {
-
-    let id: String
-}
-
 
 struct PurchaseUnit: Encodable {
 

--- a/Demo/Demo/Models/CreateOrderParams.swift
+++ b/Demo/Demo/Models/CreateOrderParams.swift
@@ -3,7 +3,7 @@ struct CreateOrderParams: Encodable {
     let applicationContext: ApplicationContext?
     let intent: String
     var purchaseUnits: [PurchaseUnit]?
-    var paymentSource: VaultCardPaymentSource?
+    var paymentSource: VaultPaymentSource?
 }
 
 struct ApplicationContext: Codable {
@@ -15,6 +15,38 @@ struct ApplicationContext: Codable {
         case userAction
         case shippingPreference
     }
+}
+
+enum VaultPaymentSource: Encodable {
+    case card(VaultCardPaymentSource)
+    case paypal(VaultPayPalPaymentSource)
+
+    func encode(to encoder: Encoder) throws {
+        var container = encoder.singleValueContainer()
+        switch self {
+        case .card(let cardSource):
+            try container.encode(cardSource)
+        case .paypal(let paypalSource):
+            try container.encode(paypalSource)
+        }
+    }
+}
+
+struct VaultPayPalPaymentSource: Encodable {
+
+    let paypal: VaultPayPal
+}
+
+struct VaultPayPal: Encodable {
+
+    let attributes: Attributes
+    let experienceContext: ExperienceContext
+}
+
+struct ExperienceContext: Encodable {
+
+    let returnURL: String
+    let cancelURL: String
 }
 
 struct VaultCardPaymentSource: Encodable {
@@ -30,15 +62,17 @@ struct VaultCard: Encodable {
 struct Attributes: Encodable {
 
     let vault: Vault
-    let customer: CardVaultCustomer?
+    let customer: VaultCustomer?
 }
 
 struct Vault: Encodable {
 
     let storeInVault: String
+    let usageType: String?
+    let customerType: String?
 }
 
-struct CardVaultCustomer: Encodable {
+struct VaultCustomer: Encodable {
 
     let id: String
 }

--- a/Demo/Demo/Models/CreateOrderParams.swift
+++ b/Demo/Demo/Models/CreateOrderParams.swift
@@ -45,6 +45,7 @@ struct VaultPayPal: Encodable {
 
 struct ExperienceContext: Encodable {
 
+    // these fields are not encoded for our SDK but are required for create order with PayPal vault option
     let returnURL: String
     let cancelURL: String
 }

--- a/Demo/Demo/Models/CreateOrderParams.swift
+++ b/Demo/Demo/Models/CreateOrderParams.swift
@@ -76,6 +76,12 @@ struct Vault: Encodable {
     let storeInVault: String
     let usageType: String?
     let customerType: String?
+
+    init(storeInVault: String, usageType: String? = nil, customerType: String? = nil) {
+        self.storeInVault = storeInVault
+        self.usageType = usageType
+        self.customerType = customerType
+    }
 }
 
 struct PurchaseUnit: Encodable {

--- a/Demo/Demo/Models/Order.swift
+++ b/Demo/Demo/Models/Order.swift
@@ -3,11 +3,18 @@ struct Order: Codable, Equatable {
     let id: String
     let status: String
     var paymentSource: PaymentSource?
-    
+    var links: [Link]?
+
     struct PaymentSource: Codable, Equatable {
         
         let card: Card?
         let paypal: PayPal?
+    }
+
+    struct Link: Codable, Equatable {
+
+        let href: String?
+        let rel, method: String?
     }
 
     init(id: String, status: String, paymentSource: PaymentSource? = nil) {
@@ -25,7 +32,8 @@ struct Order: Codable, Equatable {
 
     struct PayPal: Codable, Equatable {
 
-        let emailAddress: String
+        let emailAddress: String?
+        let attributes: Attributes?
     }
 
     struct Attributes: Codable, Equatable {

--- a/Demo/Demo/Models/Order.swift
+++ b/Demo/Demo/Models/Order.swift
@@ -3,18 +3,11 @@ struct Order: Codable, Equatable {
     let id: String
     let status: String
     var paymentSource: PaymentSource?
-    var links: [Link]?
 
     struct PaymentSource: Codable, Equatable {
         
         let card: Card?
         let paypal: PayPal?
-    }
-
-    struct Link: Codable, Equatable {
-
-        let href: String?
-        let rel, method: String?
     }
 
     init(id: String, status: String, paymentSource: PaymentSource? = nil) {

--- a/Demo/Demo/Models/PaymentTokenResponse.swift
+++ b/Demo/Demo/Models/PaymentTokenResponse.swift
@@ -7,8 +7,8 @@ struct PaymentTokenResponse: Decodable, Equatable {
     let paymentSource: PaymentSource
 }
 
-struct Customer: Decodable, Equatable {
-    
+struct Customer: Codable, Equatable {
+
     let id: String
 }
 

--- a/Demo/Demo/SwiftUIComponents/PayPalWebViews/CreateOrderPayPalWebView.swift
+++ b/Demo/Demo/SwiftUIComponents/PayPalWebViews/CreateOrderPayPalWebView.swift
@@ -5,7 +5,6 @@ struct CreateOrderPayPalWebView: View {
     @ObservedObject var paypalWebViewModel: PayPalWebViewModel
 
     @State private var selectedIntent: Intent = .authorize
-    @State private var vaultCustomerID: String = ""
     @State var shouldVaultSelected = false
 
     let selectedMerchantIntegration: MerchantIntegration
@@ -28,7 +27,6 @@ struct CreateOrderPayPalWebView: View {
                 Toggle("Should Vault with Purchase", isOn: $shouldVaultSelected)
                 Spacer()
             }
-            FloatingLabelTextField(placeholder: "Vault Customer ID (Optional)", text: $vaultCustomerID)
             ZStack {
                 Button("Create an Order") {
                     Task {
@@ -38,8 +36,7 @@ struct CreateOrderPayPalWebView: View {
                                 amount: "10.00",
                                 selectedMerchantIntegration: DemoSettings.merchantIntegration,
                                 intent: selectedIntent.rawValue,
-                                shouldVault: shouldVaultSelected,
-                                customerID: vaultCustomerID.isEmpty ? nil : vaultCustomerID
+                                shouldVault: shouldVaultSelected
                             )
                         } catch {
                             print("Error in getting setup token. \(error.localizedDescription)")

--- a/Demo/Demo/SwiftUIComponents/PayPalWebViews/CreateOrderPayPalWebView.swift
+++ b/Demo/Demo/SwiftUIComponents/PayPalWebViews/CreateOrderPayPalWebView.swift
@@ -5,6 +5,8 @@ struct CreateOrderPayPalWebView: View {
     @ObservedObject var paypalWebViewModel: PayPalWebViewModel
 
     @State private var selectedIntent: Intent = .authorize
+    @State private var vaultCustomerID: String = ""
+    @State var shouldVaultSelected = false
 
     let selectedMerchantIntegration: MerchantIntegration
 
@@ -22,6 +24,11 @@ struct CreateOrderPayPalWebView: View {
                 Text("CAPTURE").tag(Intent.capture)
             }
             .pickerStyle(SegmentedPickerStyle())
+            HStack {
+                Toggle("Should Vault with Purchase", isOn: $shouldVaultSelected)
+                Spacer()
+            }
+            FloatingLabelTextField(placeholder: "Vault Customer ID (Optional)", text: $vaultCustomerID)
             ZStack {
                 Button("Create an Order") {
                     Task {
@@ -30,7 +37,10 @@ struct CreateOrderPayPalWebView: View {
                             try await paypalWebViewModel.createOrder(
                                 amount: "10.00",
                                 selectedMerchantIntegration: DemoSettings.merchantIntegration,
-                                intent: selectedIntent.rawValue)
+                                intent: selectedIntent.rawValue,
+                                shouldVault: shouldVaultSelected,
+                                customerID: vaultCustomerID.isEmpty ? nil : vaultCustomerID
+                            )
                         } catch {
                             print("Error in getting setup token. \(error.localizedDescription)")
                         }

--- a/Demo/Demo/SwiftUIComponents/PayPalWebViews/PayPalWebOrderCompletionResultView.swift
+++ b/Demo/Demo/SwiftUIComponents/PayPalWebViews/PayPalWebOrderCompletionResultView.swift
@@ -39,6 +39,14 @@ struct PayPalWebOrderCompletionResultView: View {
                 LeadingText("Email", weight: .bold)
                 LeadingText("\(email)")
             }
+            if let vaultID = orderResponse.paymentSource?.paypal?.attributes?.vault.id {
+                LeadingText("Vault ID / Payment Token", weight: .bold)
+                LeadingText("\(vaultID)")
+            }
+            if let customerID = orderResponse.paymentSource?.paypal?.attributes?.vault.customer.id {
+                LeadingText("Customer ID", weight: .bold)
+                LeadingText("\(customerID)")
+            }
             Text("")
                 .id("bottomView")
         }

--- a/Demo/Demo/ViewModels/CardPaymentViewModel.swift
+++ b/Demo/Demo/ViewModels/CardPaymentViewModel.swift
@@ -23,9 +23,9 @@ class CardPaymentViewModel: ObservableObject, CardDelegate {
 
         var vaultCardPaymentSource: VaultCardPaymentSource?
         if shouldVault {
-            var customer: VaultCustomer?
+            var customer: Customer?
             if let customerID {
-                customer = VaultCustomer(id: customerID)
+                customer = Customer(id: customerID)
             }
             let attributes = Attributes(vault: Vault(storeInVault: "ON_SUCCESS", usageType: nil, customerType: nil), customer: customer)
             let card = VaultCard(attributes: attributes)

--- a/Demo/Demo/ViewModels/CardPaymentViewModel.swift
+++ b/Demo/Demo/ViewModels/CardPaymentViewModel.swift
@@ -27,7 +27,7 @@ class CardPaymentViewModel: ObservableObject, CardDelegate {
             if let customerID {
                 customer = Customer(id: customerID)
             }
-            let attributes = Attributes(vault: Vault(storeInVault: "ON_SUCCESS", usageType: nil, customerType: nil), customer: customer)
+            let attributes = Attributes(vault: Vault(storeInVault: "ON_SUCCESS"), customer: customer)
             let card = VaultCard(attributes: attributes)
             vaultCardPaymentSource = VaultCardPaymentSource(card: card)
         }

--- a/Demo/Demo/ViewModels/CardPaymentViewModel.swift
+++ b/Demo/Demo/ViewModels/CardPaymentViewModel.swift
@@ -21,15 +21,20 @@ class CardPaymentViewModel: ObservableObject, CardDelegate {
         let amountRequest = Amount(currencyCode: "USD", value: amount)
         // TODO: might need to pass in payee as payee object or as auth header
 
-        var vaultPaymentSource: VaultCardPaymentSource?
+        var vaultCardPaymentSource: VaultCardPaymentSource?
         if shouldVault {
-            var customer: CardVaultCustomer?
+            var customer: VaultCustomer?
             if let customerID {
-                customer = CardVaultCustomer(id: customerID)
+                customer = VaultCustomer(id: customerID)
             }
-            let attributes = Attributes(vault: Vault(storeInVault: "ON_SUCCESS"), customer: customer)
+            let attributes = Attributes(vault: Vault(storeInVault: "ON_SUCCESS", usageType: nil, customerType: nil), customer: customer)
             let card = VaultCard(attributes: attributes)
-            vaultPaymentSource = VaultCardPaymentSource(card: card)
+            vaultCardPaymentSource = VaultCardPaymentSource(card: card)
+        }
+
+        var vaultPaymentSource: VaultPaymentSource?
+        if let vaultCardPaymentSource {
+            vaultPaymentSource = .card(vaultCardPaymentSource)
         }
 
         let orderRequestParams = CreateOrderParams(

--- a/Demo/Demo/ViewModels/PayPalWebViewModel.swift
+++ b/Demo/Demo/ViewModels/PayPalWebViewModel.swift
@@ -28,8 +28,7 @@ class PayPalWebViewModel: ObservableObject, PayPalWebCheckoutDelegate {
                     storeInVault: "ON_SUCCESS",
                     usageType: "MERCHANT",
                     customerType: "CONSUMER"
-                ),
-                customer: nil as VaultCustomer?
+                )
             )
             let paypal = VaultPayPal(attributes: attributes, experienceContext: ExperienceContext(returnURL: "https://example.com/returnUrl", cancelURL: "https://example.com/cancelUrl"))
             vaultPayPalPaymentSource = VaultPayPalPaymentSource(paypal: paypal)

--- a/Demo/Demo/ViewModels/PayPalWebViewModel.swift
+++ b/Demo/Demo/ViewModels/PayPalWebViewModel.swift
@@ -14,8 +14,7 @@ class PayPalWebViewModel: ObservableObject, PayPalWebCheckoutDelegate {
         amount: String,
         selectedMerchantIntegration: MerchantIntegration,
         intent: String,
-        shouldVault: Bool,
-        customerID: String? = nil
+        shouldVault: Bool
     ) async throws {
         // might need to pass in payee as payee object or as auth header
 
@@ -24,17 +23,13 @@ class PayPalWebViewModel: ObservableObject, PayPalWebCheckoutDelegate {
 
         var vaultPayPalPaymentSource: VaultPayPalPaymentSource?
         if shouldVault {
-            var customer: VaultCustomer?
-            if let customerID {
-                customer = VaultCustomer(id: customerID)
-            }
             let attributes = Attributes(
                 vault: Vault(
                     storeInVault: "ON_SUCCESS",
                     usageType: "MERCHANT",
                     customerType: "CONSUMER"
                 ),
-                customer: customer
+                customer: nil as VaultCustomer?
             )
             let paypal = VaultPayPal(attributes: attributes, experienceContext: ExperienceContext(returnURL: "https://example.com/returnUrl", cancelURL: "https://example.com/cancelUrl"))
             vaultPayPalPaymentSource = VaultPayPalPaymentSource(paypal: paypal)

--- a/Demo/Demo/ViewModels/PayPalWebViewModel.swift
+++ b/Demo/Demo/ViewModels/PayPalWebViewModel.swift
@@ -23,14 +23,8 @@ class PayPalWebViewModel: ObservableObject, PayPalWebCheckoutDelegate {
 
         var vaultPayPalPaymentSource: VaultPayPalPaymentSource?
         if shouldVault {
-            let attributes = Attributes(
-                vault: Vault(
-                    storeInVault: "ON_SUCCESS",
-                    usageType: "MERCHANT",
-                    customerType: "CONSUMER"
-                )
-            )
-            // The returnURL is not used in our mobile SDK, but a required field for create order with PayPal payment source.
+            let attributes = Attributes(vault: Vault(storeInVault: "ON_SUCCESS", usageType: "MERCHANT", customerType: "CONSUMER"))
+            // The returnURL is not used in our mobile SDK, but a required field for create order with PayPal payment source. DTPPCPSDK-1492 to track this issue
             let paypal = VaultPayPal(attributes: attributes, experienceContext: ExperienceContext(returnURL: "https://example.com/returnUrl", cancelURL: "https://example.com/cancelUrl"))
             vaultPayPalPaymentSource = VaultPayPalPaymentSource(paypal: paypal)
         }

--- a/Demo/Demo/ViewModels/PayPalWebViewModel.swift
+++ b/Demo/Demo/ViewModels/PayPalWebViewModel.swift
@@ -30,6 +30,7 @@ class PayPalWebViewModel: ObservableObject, PayPalWebCheckoutDelegate {
                     customerType: "CONSUMER"
                 )
             )
+            // The returnURL is not used in our mobile SDK, but a required field for create order with PayPal payment source.
             let paypal = VaultPayPal(attributes: attributes, experienceContext: ExperienceContext(returnURL: "https://example.com/returnUrl", cancelURL: "https://example.com/cancelUrl"))
             vaultPayPalPaymentSource = VaultPayPalPaymentSource(paypal: paypal)
         }


### PR DESCRIPTION
### Summary of changes

- Created UI for vault option for PayPalWeb checkout in demo app
- Added experience_context and vault parameters with vault option selected in create order 
- Display vaultID and customerID in capture/authorize if PayPal payment is vaulted with checkout


https://github.com/paypal/paypal-ios/assets/9273272/2ec267d0-4b2d-487f-998d-a322cf9ff5ad


### Checklist

~- [ ] Added a changelog entry~

### Authors
- @KunJeongPark 