### PR TITLE
Fix release bug for accurate SDK version # in analytics

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -25,10 +25,9 @@ jobs:
       - name: Update version
         run: |
           today=$(date +'%Y-%m-%d')
-          
           sed -i '' 's/## unreleased.*/## '"${{ github.event.inputs.version }}"' ('"$today"')/' CHANGELOG.md
           sed -i '' 's/\(s\.version *= *\).*/\1"'"${{ github.event.inputs.version }}"'\"/' PayPal.podspec
-
+          sed -i '' 's/payPalSDKVersion: String =.*/payPalSDKVersion: String = "${{ github.event.inputs.version }}"/' Sources/CorePayments/PayPalCoreConstants.swift
           plutil -replace CFBundleShortVersionString -string ${{ github.event.inputs.version }} -- 'Demo/Demo/Info.plist'
 
           git add .


### PR DESCRIPTION
### Reason for changes

- I noticed in our analytics that _all_ events from iOS are registered as `c_sdk_ver = 0.0.3`. This is inaccurate, as many merchants have since updated from that version.
- Turns out our release.yml wasn't actually bumping the version #

#### See sample data set
![Screenshot 2023-12-15 at 5 06 27 PM](https://github.com/paypal/paypal-ios/assets/35243507/c2d34a0a-d75e-4fe3-a37c-d7a38a67fd34)

### Summary of changes

- Bump the SDK version # in `PayPalCoreConstants.swift` in our release GH action

### Checklist

- ~Added a changelog entry~

### Authors
@scannillo 
