### PR TITLE
Fix Demo App Funding Source

### DIFF
--- a/Demo/Demo/SwiftUIComponents/PayPalWebPayments/PayPalWebButtonsView.swift
+++ b/Demo/Demo/SwiftUIComponents/PayPalWebPayments/PayPalWebButtonsView.swift
@@ -20,8 +20,8 @@ struct PayPalWebButtonsView: View {
                 .font(.headline)
                 Picker("Funding Source", selection: $selectedFundingSource) {
                     Text("PayPal").tag(PayPalWebCheckoutFundingSource.paypal)
-                    Text("PayPal Credit").tag(PayPalWebCheckoutFundingSource.paylater)
-                    Text("Pay Later").tag(PayPalWebCheckoutFundingSource.paypalCredit)
+                    Text("PayPal Credit").tag(PayPalWebCheckoutFundingSource.paypalCredit)
+                    Text("Pay Later").tag(PayPalWebCheckoutFundingSource.paylater)
                 }
                 .pickerStyle(SegmentedPickerStyle())
 


### PR DESCRIPTION
### Reason for changes

The funding source tags were flipped for PayPal Pay Later and PayPal Credit in the Demo app.

### Summary of changes

- Associate `PayPalWebCheckoutFundingSource` with the correct tags/buttons - clicking on the expected picker button will now lead to the expected PayPal Pay Later or PayPal Credit flow and button

### Visuals
| Before | After |
|-----|-----|
|![Simulator Screen Recording - iPhone 15 - 2024-01-10 at 11 16 06](https://github.com/paypal/paypal-ios/assets/20733831/e217ae6f-aa44-480a-ba90-646419a1daab)|![Simulator Screen Recording - iPhone 15 - 2024-01-10 at 11 14 56](https://github.com/paypal/paypal-ios/assets/20733831/7c6b6401-6154-4036-bd2e-7c206666ca71)|

### Checklist

- ~[ ] Added a changelog entry~

### Authors

- @jaxdesmarais 