### PR TITLE
Fix demo app build on device

### DIFF
--- a/Demo/Demo.xcodeproj/project.pbxproj
+++ b/Demo/Demo.xcodeproj/project.pbxproj
@@ -94,6 +94,7 @@
 		CBC16DD929ED90B600307117 /* UpdateOrderParams.swift in Sources */ = {isa = PBXBuildFile; fileRef = CBC16DD829ED90B600307117 /* UpdateOrderParams.swift */; };
 		CBDEEA222989990200A460A6 /* CorePayments.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = CBDEEA212989990200A460A6 /* CorePayments.framework */; };
 		CBDEEA232989990200A460A6 /* CorePayments.framework in Embed Frameworks */ = {isa = PBXBuildFile; fileRef = CBDEEA212989990200A460A6 /* CorePayments.framework */; settings = {ATTRIBUTES = (CodeSignOnCopy, RemoveHeadersOnCopy, ); }; };
+		EE58CBCF2B5080C1003F2666 /* PayPalCheckout in Frameworks */ = {isa = PBXBuildFile; productRef = EE58CBCE2B5080C1003F2666 /* PayPalCheckout */; };
 /* End PBXBuildFile section */
 
 /* Begin PBXContainerItemProxy section */
@@ -225,6 +226,7 @@
 				CB1AC3B82982AAD70081AED6 /* CardPayments.framework in Frameworks */,
 				CB1AC3C02982C4030081AED6 /* PayPalWebPayments.framework in Frameworks */,
 				CB1AC3BB2982BB130081AED6 /* PaymentButtons.framework in Frameworks */,
+				EE58CBCF2B5080C1003F2666 /* PayPalCheckout in Frameworks */,
 				CBDEEA222989990200A460A6 /* CorePayments.framework in Frameworks */,
 				8052E2A529B684BA00B33FBC /* PPRiskMagnes.xcframework in Frameworks */,
 				CB1AC3C72982E32D0081AED6 /* FraudProtection.framework in Frameworks */,
@@ -506,6 +508,7 @@
 			);
 			name = Demo;
 			packageProductDependencies = (
+				EE58CBCE2B5080C1003F2666 /* PayPalCheckout */,
 			);
 			productName = Demo;
 			productReference = 806F1E3526B85367007A60E6 /* Demo.app */;
@@ -558,6 +561,7 @@
 			);
 			mainGroup = 806F1E2C26B85367007A60E6;
 			packageReferences = (
+				EE58CBCD2B5080C1003F2666 /* XCRemoteSwiftPackageReference "paypalcheckout-ios" */,
 			);
 			productRefGroup = 806F1E3626B85367007A60E6 /* Products */;
 			projectDirPath = "";
@@ -926,6 +930,25 @@
 			defaultConfigurationName = Release;
 		};
 /* End XCConfigurationList section */
+
+/* Begin XCRemoteSwiftPackageReference section */
+		EE58CBCD2B5080C1003F2666 /* XCRemoteSwiftPackageReference "paypalcheckout-ios" */ = {
+			isa = XCRemoteSwiftPackageReference;
+			repositoryURL = "https://github.com/paypal/paypalcheckout-ios";
+			requirement = {
+				kind = upToNextMajorVersion;
+				minimumVersion = 1.2.0;
+			};
+		};
+/* End XCRemoteSwiftPackageReference section */
+
+/* Begin XCSwiftPackageProductDependency section */
+		EE58CBCE2B5080C1003F2666 /* PayPalCheckout */ = {
+			isa = XCSwiftPackageProductDependency;
+			package = EE58CBCD2B5080C1003F2666 /* XCRemoteSwiftPackageReference "paypalcheckout-ios" */;
+			productName = PayPalCheckout;
+		};
+/* End XCSwiftPackageProductDependency section */
 	};
 	rootObject = 806F1E2D26B85367007A60E6 /* Project object */;
 }


### PR DESCRIPTION
### Reason for changes

The demo app would crash when trying to build it on device due to not being able to find PayPalCheckoutFramework

### Summary of changes

- Added PayPalCheckout as a package dependency to the demo app 

### Checklist

~~- [ ] Added a changelog entry~~

### Authors
> List GitHub usernames for everyone who contributed to this pull request.

- @vradopp 