### PR TITLE
Fix for iOS Demo App to Handle Vault "Approved" State

### DIFF
--- a/Demo/Demo/Models/Order.swift
+++ b/Demo/Demo/Models/Order.swift
@@ -36,9 +36,9 @@ struct Order: Codable, Equatable {
 
     struct Vault: Codable, Equatable {
         
-        let id: String
+        let id: String?
         let status: String
-        let customer: Customer
+        let customer: Customer?
     }
 
     struct Customer: Codable, Equatable {

--- a/Demo/Demo/SwiftUIComponents/CardPaymentViews/CardOrderCompletionResultView.swift
+++ b/Demo/Demo/SwiftUIComponents/CardPaymentViews/CardOrderCompletionResultView.swift
@@ -43,11 +43,15 @@ struct CardOrderCompletionResultView: View {
                 LeadingText("Brand", weight: .bold)
                 LeadingText("\(brand)")
             }
+            if let vaultStatus = orderResponse.paymentSource?.card?.attributes?.vault.status {
+                LeadingText("Vault Status", weight: .bold)
+                LeadingText("\(vaultStatus)")
+            }
             if let vaultID = orderResponse.paymentSource?.card?.attributes?.vault.id {
                 LeadingText("Vault ID / Payment Token", weight: .bold)
                 LeadingText("\(vaultID)")
             }
-            if let customerID = orderResponse.paymentSource?.card?.attributes?.vault.customer.id {
+            if let customerID = orderResponse.paymentSource?.card?.attributes?.vault.customer?.id {
                 LeadingText("Customer ID", weight: .bold)
                 LeadingText("\(customerID)")
             }

--- a/Demo/Demo/SwiftUIComponents/PayPalWebPayments/PayPalWebResultView.swift
+++ b/Demo/Demo/SwiftUIComponents/PayPalWebPayments/PayPalWebResultView.swift
@@ -42,7 +42,7 @@ struct PayPalWebResultView: View {
                 LabelViewText("Payment Token:", bodyText: vaultID)
             }
 
-            if let customerID = payPalWebViewModel.order?.paymentSource?.paypal?.attributes?.vault.customer.id {
+            if let customerID = payPalWebViewModel.order?.paymentSource?.paypal?.attributes?.vault.customer?.id {
                 LabelViewText("Customer ID:", bodyText: customerID)
             }
         }


### PR DESCRIPTION
### Reason for changes

Demo app was expecting vault struct from Order to have vaultID and customerID.
This is not the case when the vault status is "APPROVED"

### Summary of changes

- made vaultID and customer optional fields in vault struct
Before:

https://github.com/paypal/paypal-ios/assets/9273272/86adfa63-d301-4dcc-bf80-362b62f3a08f

After:

https://github.com/paypal/paypal-ios/assets/9273272/1f8a0fc1-1229-42ec-bdfe-820cd40f6297


### Checklist

~- [ ] Added a changelog entry~

### Authors
> List GitHub usernames for everyone who contributed to this pull request.

- @KunJeongPark 