### PR TITLE
Revert deprecated `PaymentButton` colors

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,8 +3,6 @@
 
 ## unreleased
 * PaymentButtons
-  * Undeprecate `PaymentButtonColor` `.black`, `.silver`, `.blue`, and `.darkBlue`
-  * Remove `PayPalCreditButton` enum case `gold`
   * Add `custom` case for `PaymentButtonEdges`
   * Support VoiceOver by adding button accessibility labels
   * Add `custom` case for `PaymentButtonEdges`

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,8 +3,8 @@
 
 ## unreleased
 * PaymentButtons
-  * Deprecate `PaymentButtonColor` `.black`, `.silver`, `.blue`, and `.darkBlue`
-  * Add `PaymentButtonColor.gold` for `PayPalCreditButton`
+  * Undeprecate `PaymentButtonColor` `.black`, `.silver`, `.blue`, and `.darkBlue`
+  * Remove `PayPalCreditButton` enum case `gold`
   * Add `custom` case for `PaymentButtonEdges`
   * Support VoiceOver by adding button accessibility labels
   * Add `custom` case for `PaymentButtonEdges`

--- a/Demo/Demo/Extensions/PaymentButtonEnums+Extension.swift
+++ b/Demo/Demo/Extensions/PaymentButtonEnums+Extension.swift
@@ -25,7 +25,7 @@ extension PayPalButton.Color: CaseIterable {
 extension PayPalCreditButton.Color: CaseIterable {
 
     public static var allCases: [PayPalCreditButton.Color] {
-        [.gold, .white, .black, .darkBlue]
+        [.white, .black, .darkBlue]
     }
 
     static func allCasesAsString() -> [String] {

--- a/Demo/Demo/SwiftUIComponents/PayPalWebPayments/PayPalWebButtonsView.swift
+++ b/Demo/Demo/SwiftUIComponents/PayPalWebPayments/PayPalWebButtonsView.swift
@@ -27,7 +27,7 @@ struct PayPalWebButtonsView: View {
 
                 switch selectedFundingSource {
                 case .paypalCredit:
-                    PayPalCreditButton.Representable(color: .gold, size: .full) {
+                    PayPalCreditButton.Representable(color: .black, size: .full) {
                         payPalWebViewModel.paymentButtonTapped(funding: .paypalCredit)
                     }
                 case .paylater:

--- a/Sources/PaymentButtons/PayPalCreditButton.swift
+++ b/Sources/PaymentButtons/PayPalCreditButton.swift
@@ -8,13 +8,12 @@ public final class PayPalCreditButton: PaymentButton {
     Available colors for PayPalCreditButton.
     */
     public enum Color: String {
-        case gold
         case white
         case black
         case darkBlue
 
         var color: PaymentButtonColor {
-            PaymentButtonColor(rawValue: rawValue) ?? .white
+            PaymentButtonColor(rawValue: rawValue) ?? .darkBlue
         }
     }
 

--- a/Sources/PaymentButtons/PaymentButtonColor.swift
+++ b/Sources/PaymentButtons/PaymentButtonColor.swift
@@ -5,19 +5,15 @@ public enum PaymentButtonColor: String {
     /// The gold background and blue wordmark, monogram, and black text.
     case gold
 
-    /// The white background and blue wordmark, blue border, monogram, and black text.
+    /// The white background and blue wordmark, monogram, and black text.
     case white
 
-	@available(*, deprecated, message: "Deprecated color. Replace with `white` button color.")
     case black
 
-	@available(*, deprecated, message: "Deprecated color. Replace with `white` button color.")
     case silver
 
-	@available(*, deprecated, message: "Deprecated color. Replace with `white` button color.")
     case blue
 
-	@available(*, deprecated, message: "Deprecated color. Replace with `white` button color.")
     case darkBlue
 
     var color: UIColor {

--- a/Sources/PaymentButtons/PaymentButtonColor.swift
+++ b/Sources/PaymentButtons/PaymentButtonColor.swift
@@ -8,12 +8,16 @@ public enum PaymentButtonColor: String {
     /// The white background and blue wordmark, monogram, and black text.
     case white
 
+    /// The black background and monochrome wordmark, monogram, and white text.
     case black
 
+    /// The silver background and blue wordmark, monogram, and black text.
     case silver
 
+    /// The blue background and white wordmark, blue monogram, and white text.
     case blue
 
+    /// The dark blue background with PayPal Credit wordmark and monogram.
     case darkBlue
 
     var color: UIColor {


### PR DESCRIPTION
### Reason for changes

Design leadership is working on re-branding PayPal. We do not want to make any branding changes before this major update happens.

Revert the changes that deprecated the button colors. Previously merged PR https://github.com/paypal/paypal-ios/pull/231

### Summary of changes

- Undeprecated colors blue, dark blue, silver, black

### Checklist

- [x] Added a changelog entry

### Authors
> List GitHub usernames for everyone who contributed to this pull request.

- @stechiu 