### PR TITLE
Remove Payment Button labels

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,10 +17,6 @@
   * Add `custom` case for `PaymentButtonEdges`
   * Support VoiceOver by adding button accessibility labels
   * Add new `PaymentButtonSize` case `.miniWithWordmark`
-  * Add new `PayPalButton.Labels` cases: `.addMoneyWith`, `.bookWith`, `.buyWith`, `.buyNowWith`,
-  `.checkoutWith`, `.continueWith`, `.contributeWith`, `.orderWith`, `.payLaterWith`, `.payWith`,
-  `.reloadWith`, `.rentWith`, `.reserveWith`, `.subscribeWith`, `.supportWith`, `.tipWith`,
-  `.topUpWith`
   * `PayPalButtonSize` `.mini` changed to rectangular button to meet brand guidelines
   * Font typeface changed to "PayPalOpen" to meet brand guidelines
 * Breaking Changes

--- a/Demo/Demo/Extensions/PaymentButtonEnums+Extension.swift
+++ b/Demo/Demo/Extensions/PaymentButtonEnums+Extension.swift
@@ -73,7 +73,7 @@ extension PayPalButton.Label: CaseIterable {
             .none,
             .checkout,
             .buyNow,
-            .payWith,
+            .payWith
         ]
     }
     

--- a/Demo/Demo/Extensions/PaymentButtonEnums+Extension.swift
+++ b/Demo/Demo/Extensions/PaymentButtonEnums+Extension.swift
@@ -71,24 +71,9 @@ extension PayPalButton.Label: CaseIterable {
     public static var allCases: [PayPalButton.Label] {
         [
             .none,
-            .addMoneyWith,
-            .bookWith,
-            .buyNowWith,
-            .buyWith,
-            .checkoutWith,
-            .continueWith,
-            .contributeWith,
-            .orderWith,
+            .checkout,
+            .buyNow,
             .payWith,
-            .payLater,
-            .payLaterWith,
-            .reloadWith,
-            .rentWith,
-            .reserveWith,
-            .subscribeWith,
-            .supportWith,
-            .tipWith,
-            .topUpWith
         ]
     }
     

--- a/Sources/PaymentButtons/PayPalButton.swift
+++ b/Sources/PaymentButtons/PayPalButton.swift
@@ -19,67 +19,14 @@ public final class PayPalButton: PaymentButton {
         /// Display no label
         case none
         
-        /// Use on a website or app where the term ‘add money’ is used for a customer adding money to an account.
-        /// Add label to the left of the PayPal logo.
-        case addMoneyWith = "Add Money with"
+        /// Display "Checkout" on the right side of the button's logo
+        case checkout = "Checkout"
 
-        /// Use on product detail pages where customers are reserving an experience or service.
-        /// Add label to the left of the PayPal logo.
-        case bookWith = "Book with"
+        /// Display "Buy now" on the right side of the button's logo
+        case buyNow = "Buy Now"
 
-        /// Recommended for use on product detail pages to help give customers context on the resulting action.
-        /// Add label to the left of the PayPal logo.
-        case buyWith = "Buy with"
-
-        /// Add label to the left of the PayPal logo.
-        case buyNowWith = "Buy Now with"
-
-        /// Recommended for use on cart and checkout pages, where there is a purchasing context. Add label to the left of the PayPal logo.
-        case checkoutWith = "Checkout with"
-
-        /// Use as the call to action on a checkout page when PayPal is the selected payment method, and
-        /// the customer will return to the website or app to complete the purchase. Add label to the left of the PayPal logo.
-        case continueWith = "Continue with"
-
-        /// Add "Contribute" to the left of the PayPal logo. Add label to the left of the PayPal logo.
-        case contributeWith = "Contribue with"
-
-        /// Use on a website or app where a customer is placing an order, commonly associated with food purchases.
-        /// Add label to the left of the PayPal logo.
-        case orderWith = "Order with"
-
-        /// Add "Pay later" to the right of button's logo, only used for PayPalPayLaterButton.
-        /// Add label to the right of the PayPal logo.
-        case payLater = "Pay Later"
-
-        /// Add label to the left of the PayPal logo.
-        case payLaterWith = "Pay Later with"
-
-        /// Recommended for use on pages where customers are paying bills or invoices. Add label to the left of the PayPal logo.
+        /// Display "Pay with" on the left side of the button's logo
         case payWith = "Pay with"
-
-        /// Use on a website or app where the term ‘reload’ is used for a customer adding money to an account.
-        /// Add label to the left of the PayPal logo.
-        case reloadWith = "Reload with"
-
-        /// Use when a customer is renting an item. Add label to the left of the PayPal logo.
-        case rentWith = "Rent with"
-
-        /// Add label to the left of the PayPal logo.
-        case reserveWith = "Reserve with"
-
-        /// Use when a customer will start opt in to recurring payments to your store. Add label to the left of the PayPal logo.
-        case subscribeWith = "Subscribe with"
-
-        /// Add "Support with" to the left of the PayPal logo. Add label to the left of the PayPal logo.
-        case supportWith = "Support with"
-
-        /// Use when a customer is tipping for an item or service. Add label to the left of the PayPal logo.
-        case tipWith = "Tip with"
-
-        /// Use on a website or app where the term ‘top up’ is used for a customer adding money to an account.
-        /// Add label to the left of the PayPal logo.
-        case topUpWith = "Top Up with"
 
         var label: PaymentButtonLabel? {
             PaymentButtonLabel(rawValue: rawValue)

--- a/Sources/PaymentButtons/PayPalCreditButton.swift
+++ b/Sources/PaymentButtons/PayPalCreditButton.swift
@@ -23,7 +23,7 @@ public final class PayPalCreditButton: PaymentButton {
     ///   - size: Size of the button. Default to standard if not provided.
     public convenience init(
         insets: NSDirectionalEdgeInsets? = nil,
-        color: Color = .gold,
+        color: Color = .white,
         edges: PaymentButtonEdges = .softEdges,
         size: PaymentButtonSize = .standard
     ) {
@@ -56,7 +56,7 @@ public extension PayPalCreditButton {
         ///   - size: Size of the button. Default to standard if not provided.
         public init(
             insets: NSDirectionalEdgeInsets? = nil,
-            color: PayPalCreditButton.Color = .gold,
+            color: PayPalCreditButton.Color = .white,
             edges: PaymentButtonEdges = .softEdges,
             size: PaymentButtonSize = .standard,
             _ action: @escaping () -> Void = { }

--- a/UnitTests/PaymentButtonsTests/PayPalCreditButton_Tests.swift
+++ b/UnitTests/PaymentButtonsTests/PayPalCreditButton_Tests.swift
@@ -14,7 +14,7 @@ class PayPalCreditButton_Tests: XCTestCase {
         let sut = PayPalCreditButton()
         XCTAssertEqual(sut.edges, PaymentButtonEdges.softEdges)
         XCTAssertEqual(sut.size, PaymentButtonSize.standard)
-        XCTAssertEqual(sut.color, PaymentButtonColor.gold)
+        XCTAssertEqual(sut.color, PaymentButtonColor.white)
         XCTAssertNil(sut.insets)
         XCTAssertNil(sut.label)
     }


### PR DESCRIPTION
### Reason for changes

Design leadership is discussing changes to overall PayPal branding. Until new designs are finalized, we need to revert the changes to labels that were added.

### Summary of changes

- Removed new labels
- Added original labels

### Checklist

- [ ] Added a changelog entry

### Authors
> List GitHub usernames for everyone who contributed to this pull request.

- 