### PR TITLE
[iOS] - Revert URL Parsing, CardResult change properties

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,15 +2,16 @@
 # PayPal iOS SDK Release Notes
 
 ## unreleased
+* Breaking Changes
+  * CardPayments
+    * Add `status` property to `CardResult`
+    * Add `didAttemptThreeDSecureAuthentication` property to `CardResult`
 * PaymentButtons
   * Add `custom` case for `PaymentButtonEdges`
   * Support VoiceOver by adding button accessibility labels
   * Add `custom` case for `PaymentButtonEdges`
   * Support VoiceOver by adding button accessibility labels
   * Font typeface changed to "PayPalOpen" to meet brand guidelines
-* CardPayments
-  * Add `status` property to `CardResult`
-  * Add `didAttemptThreeDSecureAuthentication` property to `CardResult`
 * PayPalWebPayments
   * Add `vault(url:)` method to `PayPalWebCheckoutClient`
   * Add `PayPalVaultResult` type to return vault result

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,10 +9,8 @@
   * Support VoiceOver by adding button accessibility labels
   * Font typeface changed to "PayPalOpen" to meet brand guidelines
 * CardPayments
-  * Add `liabilityShift` property to `CardResult`
-  * Add `CardClientError.threeDSVerificationError` for invalid verification
-  * Add `CardClientError.missingDeeplinkURLError` for missing deeplink URL
-  * Add `CardClientError.malformedDeeplinkURLError` for malformed or invalid deeplink
+  * Add `status` property to `CardResult`
+  * Add `didAttemptThreeDSecureAuthentication` property to `CardResult`
 * PayPalWebPayments
   * Add `vault(url:)` method to `PayPalWebCheckoutClient`
   * Add `PayPalVaultResult` type to return vault result

--- a/Demo/Demo/SwiftUIComponents/CardPaymentViews/CardApprovalResultView.swift
+++ b/Demo/Demo/SwiftUIComponents/CardPaymentViews/CardApprovalResultView.swift
@@ -24,8 +24,12 @@ struct CardApprovalResultView: View {
             }
             LeadingText("ID", weight: .bold)
             LeadingText("\(approvalResult.id)")
-            LeadingText("3DS URL", weight: .bold)
-            LeadingText("\(approvalResult.deepLinkURL ?? "NOT SET")")
+            if let status = approvalResult.status {
+                LeadingText("Order Status", weight: .bold)
+                LeadingText("\(status)")
+            }
+            LeadingText("didAttemptThreeDSecureAuthentication", weight: .bold)
+            LeadingText("\(approvalResult.didAttemptThreeDSecureAuthentication)")
         }
         .frame(maxWidth: .infinity)
         .padding()

--- a/Demo/Demo/ViewModels/CardPaymentState.swift
+++ b/Demo/Demo/ViewModels/CardPaymentState.swift
@@ -6,7 +6,8 @@ struct CardPaymentState: Equatable {
     struct CardResult: Decodable, Equatable {
 
         let id: String
-        let deepLinkURL: String?
+        let status: String?
+        let didAttemptThreeDSecureAuthentication: Bool
     }
 
     var createOrder: Order?

--- a/Demo/Demo/ViewModels/CardPaymentViewModel.swift
+++ b/Demo/Demo/ViewModels/CardPaymentViewModel.swift
@@ -139,7 +139,8 @@ class CardPaymentViewModel: ObservableObject, CardDelegate {
         approveResultSuccessResult(
             approveResult: CardPaymentState.CardResult(
                 id: result.orderID,
-                deepLinkURL: result.deepLinkURL?.absoluteString
+                status: result.status,
+                didAttemptThreeDSecureAuthentication: result.didAttemptThreeDSecureAuthentication
             )
         )
     }

--- a/Sources/CardPayments/CardClient.swift
+++ b/Sources/CardPayments/CardClient.swift
@@ -88,7 +88,7 @@ public class CardClient: NSObject {
                 } else {
                     analyticsService?.sendEvent("card-payments:3ds:confirm-payment-source:succeeded")
                     
-                    let cardResult = CardResult(orderID: result.id, status: result.status, threeDSecureAttempted: false)
+                    let cardResult = CardResult(orderID: result.id, status: result.status, didAttemptThreeDSecureAuthentication: false)
                     notifySuccess(for: cardResult)
                 }
             } catch let error as CoreSDKError {
@@ -130,7 +130,7 @@ public class CardClient: NSObject {
                     }
                 }
 
-                let cardResult = CardResult(orderID: orderId, status: nil, threeDSecureAttempted: true)
+                let cardResult = CardResult(orderID: orderId, status: nil, didAttemptThreeDSecureAuthentication: true)
                 self.notifySuccess(for: cardResult)
             }
         )

--- a/Sources/CardPayments/CardClientError.swift
+++ b/Sources/CardPayments/CardClientError.swift
@@ -82,22 +82,4 @@ enum CardClientError {
         domain: domain,
         errorDescription: "GraphQLClient is unexpectedly nil."
     )
-    
-    static let threeDSVerificationError = CoreSDKError(
-        code: Code.threeDSVerificationError.rawValue,
-        domain: domain,
-        errorDescription: "3DS Verification is returning an error."
-    )
-    
-    static let missingDeeplinkURLError = CoreSDKError(
-        code: Code.missingDeeplinkURLError.rawValue,
-        domain: domain,
-        errorDescription: "Missing deeplink URL from 3DS."
-    )
-    
-    static let malformedDeeplinkURLError = CoreSDKError(
-        code: Code.malformedDeeplinkURLError.rawValue,
-        domain: domain,
-        errorDescription: "Malformed deeplink URL."
-    )
 }

--- a/Sources/CardPayments/Models/CardResult.swift
+++ b/Sources/CardPayments/Models/CardResult.swift
@@ -9,10 +9,9 @@ public struct CardResult {
     /// The order ID associated with the transaction
     public let orderID: String
 
-    /// This is the deep link url returned from 3DS authentication
-    @_documentation(visibility: private)
-    public let deepLinkURL: URL?
-    
+    /// status of the order
+    public let status: String?
+
     /// Liability shift value returned from 3DS verification
-    public let liabilityShift: String?
+    public let threeDSecureAttempted: Bool
 }

--- a/Sources/CardPayments/Models/CardResult.swift
+++ b/Sources/CardPayments/Models/CardResult.swift
@@ -12,6 +12,6 @@ public struct CardResult {
     /// status of the order
     public let status: String?
 
-    /// 3DS verification was attempted. Use v3/setup-tokens/{id} in your server to get verification results.
+    /// 3DS verification was attempted. Use v2/checkout/orders/{orderID} in your server to get verification results.
     public let didAttemptThreeDSecureAuthentication: Bool
 }

--- a/Sources/CardPayments/Models/CardResult.swift
+++ b/Sources/CardPayments/Models/CardResult.swift
@@ -12,6 +12,6 @@ public struct CardResult {
     /// status of the order
     public let status: String?
 
-    /// Liability shift value returned from 3DS verification
-    public let threeDSecureAttempted: Bool
+    /// 3DS verification was attempted. Use v3/setup-tokens/{id} in your server to get verification results.
+    public let didAttemptThreeDSecureAuthentication: Bool
 }

--- a/UnitTests/CardPaymentsTests/CardClient_Tests.swift
+++ b/UnitTests/CardPaymentsTests/CardClient_Tests.swift
@@ -5,7 +5,6 @@ import AuthenticationServices
 @testable import CardPayments
 @testable import TestShared
 
-// swiftlint:disable type_body_length
 class CardClient_Tests: XCTestCase {
 
     // MARK: - Helper Properties
@@ -143,6 +142,8 @@ class CardClient_Tests: XCTestCase {
 
         let mockCardDelegate = MockCardDelegate(success: {_, result -> Void in
             XCTAssertEqual(result.orderID, "testOrderId")
+            XCTAssertEqual(result.status, "APPROVED")
+            XCTAssertFalse(result.threeDSecureAttempted)
             expectation.fulfill()
         }, error: { _, _ in
             XCTFail("Invoked error() callback. Should invoke success().")
@@ -214,7 +215,8 @@ class CardClient_Tests: XCTestCase {
         let mockCardDelegate = MockCardDelegate(
             success: {_, result in
                 XCTAssertEqual(result.orderID, "testOrderId")
-                XCTAssertEqual(result.liabilityShift, "POSSIBLE")
+                XCTAssertNil(result.status)
+                XCTAssertTrue(result.threeDSecureAttempted)
                 expectation.fulfill()
             },
             error: { _, error in
@@ -291,93 +293,6 @@ class CardClient_Tests: XCTestCase {
             },
             threeDSWillLaunch: { _ in XCTAssert(true) },
             threeDSLaunched: { _ in XCTAssert(true) })
-
-        sut.delegate = mockCardDelegate
-        sut.approveOrder(request: cardRequest)
-
-        waitForExpectations(timeout: 10)
-    }
-    
-    func testApproveOrder_withThreeDSecure_returns3DSVerificationError() {
-        mockCheckoutOrdersAPI.stubConfirmResponse = FakeConfirmPaymentResponse.withValid3DSURL
-
-        mockWebAuthSession.cannedResponseURL = .init(string: "sdk.ios.paypal://card/success?error=error&error_description=error&liability_shift=NO")
-
-        let expectation = expectation(description: "approveOrder() completed")
-
-        let mockCardDelegate = MockCardDelegate(
-            success: {_, _ in
-                XCTFail("Invoked success() callback. Should invoke error().")
-                expectation.fulfill()
-            },
-            error: { _, error in
-                XCTAssertEqual(error.domain, CardClientError.domain)
-                XCTAssertEqual(error.code, CardClientError.Code.threeDSVerificationError.rawValue)
-                XCTAssertEqual(error.errorDescription, "3DS Verification is returning an error.")
-                expectation.fulfill()
-            },
-            cancel: { _ in
-                XCTFail("Invoked cancel() callback. Should invoke error().")
-                expectation.fulfill()
-            },
-            threeDSWillLaunch: { _ in XCTAssert(true) },
-            threeDSLaunched: { _ in XCTAssert(true) })
-
-        sut.delegate = mockCardDelegate
-        sut.approveOrder(request: cardRequest)
-
-        waitForExpectations(timeout: 10)
-    }
-    
-    func testApproveOrder_withThreeDSecure_returnsMissingDeeplinkError() {
-        mockCheckoutOrdersAPI.stubConfirmResponse = FakeConfirmPaymentResponse.withValid3DSURL
-        
-        mockWebAuthSession.cannedResponseURL = nil
-        
-        let expectation = expectation(description: "approveOrder() completed")
-
-        let mockCardDelegate = MockCardDelegate(
-            success: {_, _ in
-                XCTFail("Invoked success() callback. Should invoke error().")
-                expectation.fulfill()
-            },
-            error: { _, error in
-                XCTAssertEqual(error.domain, CardClientError.domain)
-                XCTAssertEqual(error.code, CardClientError.Code.missingDeeplinkURLError.rawValue)
-                XCTAssertEqual(error.errorDescription, "Missing deeplink URL from 3DS.")
-                expectation.fulfill()
-            },
-            cancel: { _ in XCTFail("Invoked cancel() callback. Should invoke success().") },
-            threeDSWillLaunch: { _ -> Void in XCTAssert(true) },
-            threeDSLaunched: { _ -> Void in XCTAssert(true) })
-
-        sut.delegate = mockCardDelegate
-        sut.approveOrder(request: cardRequest)
-
-        waitForExpectations(timeout: 10)
-    }
-    
-    func testApproveOrder_withThreeDSecure_returnsMalformedDeeplinkError() {
-        mockCheckoutOrdersAPI.stubConfirmResponse = FakeConfirmPaymentResponse.withValid3DSURL
-        
-        mockWebAuthSession.cannedResponseURL = .init(string: "https://fakeURL")
-        
-        let expectation = expectation(description: "approveOrder() completed")
-
-        let mockCardDelegate = MockCardDelegate(
-            success: {_, _ in
-                XCTFail("Invoked success() callback. Should invoke error().")
-                expectation.fulfill()
-            },
-            error: { _, error in
-                XCTAssertEqual(error.domain, CardClientError.domain)
-                XCTAssertEqual(error.code, CardClientError.Code.malformedDeeplinkURLError.rawValue)
-                XCTAssertEqual(error.errorDescription, "Malformed deeplink URL.")
-                expectation.fulfill()
-            },
-            cancel: { _ in XCTFail("Invoked cancel() callback. Should invoke success().") },
-            threeDSWillLaunch: { _ -> Void in XCTAssert(true) },
-            threeDSLaunched: { _ -> Void in XCTAssert(true) })
 
         sut.delegate = mockCardDelegate
         sut.approveOrder(request: cardRequest)

--- a/UnitTests/CardPaymentsTests/CardClient_Tests.swift
+++ b/UnitTests/CardPaymentsTests/CardClient_Tests.swift
@@ -143,7 +143,7 @@ class CardClient_Tests: XCTestCase {
         let mockCardDelegate = MockCardDelegate(success: {_, result -> Void in
             XCTAssertEqual(result.orderID, "testOrderId")
             XCTAssertEqual(result.status, "APPROVED")
-            XCTAssertFalse(result.threeDSecureAttempted)
+            XCTAssertFalse(result.didAttemptThreeDSecureAuthentication)
             expectation.fulfill()
         }, error: { _, _ in
             XCTFail("Invoked error() callback. Should invoke success().")
@@ -216,7 +216,7 @@ class CardClient_Tests: XCTestCase {
             success: {_, result in
                 XCTAssertEqual(result.orderID, "testOrderId")
                 XCTAssertNil(result.status)
-                XCTAssertTrue(result.threeDSecureAttempted)
+                XCTAssertTrue(result.didAttemptThreeDSecureAuthentication)
                 expectation.fulfill()
             },
             error: { _, error in


### PR DESCRIPTION
### Summary of changes

- CardResult to return order status and boolean threeDSecureAttempted
- Revert parsing of return url

No 3DS Contingency:
https://github.com/paypal/paypal-ios/assets/9273272/6988c66b-9071-40e7-a3a8-9379382179f8

3DS Contingency:

https://github.com/paypal/paypal-ios/assets/9273272/548e7e9f-a647-4548-a519-9eca97dadc3d


### Checklist

- [x] Added a changelog entry

### Authors
> List GitHub usernames for everyone who contributed to this pull request.

- @KunJeongPark 