### PR TITLE
Vault Without Purchase Analytics

### DIFF
--- a/Sources/CorePayments/AnalyticsEventData.swift
+++ b/Sources/CorePayments/AnalyticsEventData.swift
@@ -28,6 +28,7 @@ struct AnalyticsEventData: Encodable {
         case merchantAppVersion = "mapv"
         case deviceModel = "mobile_device_model"
         case platform = "platform"
+        case setupToken = "vault_setup_token"
         case timestamp = "t"
         case tenantName = "tenant_name"
     }
@@ -54,7 +55,7 @@ struct AnalyticsEventData: Encodable {
     
     let environment: String
     
-    let orderID: String
+    let orderID: String?
 
     let packageManager: String = {
         #if COCOAPODS
@@ -88,17 +89,20 @@ struct AnalyticsEventData: Encodable {
     }()
 
     let platform = "iOS"
+  
+    let setupToken: String?
 
     let timestamp = String(Date().timeIntervalSince1970 * 1000)
 
     let tenantName = "PayPal"
     
-    init(environment: String, eventName: String, clientID: String, orderID: String, correlationID: String?) {
+    init(environment: String, eventName: String, clientID: String, orderID: String?, correlationID: String?, setupToken: String?) {
         self.environment = environment
         self.eventName = eventName
         self.clientID = clientID
         self.orderID = orderID
         self.correlationID = correlationID
+        self.setupToken = setupToken
     }
     
     func encode(to encoder: Encoder) throws {
@@ -125,5 +129,6 @@ struct AnalyticsEventData: Encodable {
         try eventParameters.encode(orderID, forKey: .orderID)
         try eventParameters.encode(timestamp, forKey: .timestamp)
         try eventParameters.encode(tenantName, forKey: .tenantName)
+        try eventParameters.encode(setupToken, forKey: .setupToken)
     }
 }

--- a/Sources/CorePayments/Networking/AnalyticsService.swift
+++ b/Sources/CorePayments/Networking/AnalyticsService.swift
@@ -8,16 +8,24 @@ public struct AnalyticsService {
     
     private let coreConfig: CoreConfig
     private let trackingEventsAPI: TrackingEventsAPI
-    private let orderID: String
-        
+    private let orderID: String?
+    private let setupToken: String?
     // MARK: - Initializer
     
     public init(coreConfig: CoreConfig, orderID: String) {
         self.coreConfig = coreConfig
         self.trackingEventsAPI = TrackingEventsAPI(coreConfig: coreConfig)
         self.orderID = orderID
+        self.setupToken = nil
     }
-    
+
+    public init(coreConfig: CoreConfig, setupToken: String) {
+        self.coreConfig = coreConfig
+        self.trackingEventsAPI = TrackingEventsAPI(coreConfig: coreConfig)
+        self.setupToken = setupToken
+        self.orderID = nil
+    }
+
     // MARK: - Internal Initializer
 
     /// Exposed for testing
@@ -25,6 +33,7 @@ public struct AnalyticsService {
         self.coreConfig = coreConfig
         self.trackingEventsAPI = trackingEventsAPI
         self.orderID = orderID
+        self.setupToken = nil
     }
     
     // MARK: - Public Methods
@@ -54,7 +63,8 @@ public struct AnalyticsService {
                 eventName: name,
                 clientID: clientID,
                 orderID: orderID,
-                correlationID: correlationID
+                correlationID: correlationID,
+                setupToken: setupToken
             )
             
             let (_) = try await trackingEventsAPI.sendEvent(with: eventData)

--- a/Sources/PayPalWebPayments/PayPalWebCheckoutClient.swift
+++ b/Sources/PayPalWebPayments/PayPalWebCheckoutClient.swift
@@ -104,6 +104,10 @@ public class PayPalWebCheckoutClient: NSObject {
     /// - Returns: PayPalVaultResult
     /// - Throws: PayPalSDK error if vaulting could not complete successfully
     public func vault(url: URL) {
+        if let setupToken = getQueryStringParameter(url: url.absoluteString, param: "approval_session_id") {
+            analyticsService = AnalyticsService(coreConfig: config, setupToken: setupToken)
+        }
+        analyticsService?.sendEvent("paypal-web-payments:vault-wo-purchase:started")
         webAuthenticationSession.start(
             url: url,
             context: self,
@@ -164,15 +168,17 @@ public class PayPalWebCheckoutClient: NSObject {
     }
 
     private func notifyVaultSuccess(for result: PayPalVaultResult) {
+        analyticsService?.sendEvent("paypal-web-payments:vault-wo-purchase:succeeded")
         vaultDelegate?.paypal(self, didFinishWithVaultResult: result)
     }
 
     private func notifyVaultFailure(with error: CoreSDKError) {
-        analyticsService?.sendEvent("paypal-web-payments:failed")
+        analyticsService?.sendEvent("paypal-web-payments:vault-wo-purchase:failed")
         vaultDelegate?.paypal(self, didFinishWithVaultError: error)
     }
 
     private func notifyVaultCancellation() {
+        analyticsService?.sendEvent("paypal-web-payments:vault-wo-purchase:canceled")
         vaultDelegate?.paypalDidCancel(self)
     }
 }

--- a/UnitTests/PaymentsCoreTests/AnalyticsEventData_Tests.swift
+++ b/UnitTests/PaymentsCoreTests/AnalyticsEventData_Tests.swift
@@ -15,7 +15,8 @@ class AnalyticsEventData_Tests: XCTestCase {
             eventName: "fake-name",
             clientID: "fake-client-id",
             orderID: "fake-order",
-            correlationID: "fake-correlation-id"
+            correlationID: "fake-correlation-id",
+            setupToken: "fake-setup-token"
         )
     }
 
@@ -48,6 +49,7 @@ class AnalyticsEventData_Tests: XCTestCase {
         XCTAssertGreaterThanOrEqual(eventParams["t"] as! String, currentTime)
         XCTAssertLessThanOrEqual(eventParams["t"] as! String, oneSecondLater)
         XCTAssertEqual(eventParams["tenant_name"] as? String, "PayPal")
+        XCTAssertEqual(eventParams["vault_setup_token"] as? String, "fake-setup-token")
     }
 }
 

--- a/UnitTests/PaymentsCoreTests/TrackingEventsAPI_Tests.swift
+++ b/UnitTests/PaymentsCoreTests/TrackingEventsAPI_Tests.swift
@@ -16,7 +16,8 @@ class TrackingEventsAPI_Tests: XCTestCase {
         eventName: "my-event-name",
         clientID: "my-id",
         orderID: "my-order",
-        correlationID: nil
+        correlationID: nil,
+        setupToken: nil
     )
     
     // MARK: - Test Lifecycle
@@ -43,7 +44,8 @@ class TrackingEventsAPI_Tests: XCTestCase {
             eventName: "my-event-name",
             clientID: "my-id",
             orderID: "my-order",
-            correlationID: "fake-correlation-id"
+            correlationID: "fake-correlation-id",
+            setupToken: "fake-setup-token"
         )
         _ = try await sut.sendEvent(with: fakeAnalyticsEventData)
         


### PR DESCRIPTION
### Reason for changes

We want to add analytics to the flow to track merchant’s usage of vault without purchase.

### Summary of changes
Added analytics events for vault without purchase flows

**PayPal Wallet Vault Events**
`paypal-web-payments:vault-wo-purchase:started`
`paypal-web-payments:vault-wo-purchase:canceled`
`paypal-web-payments:vault-wo-purchase:succeeded`
`paypal-web-payments:vault-wo-purchase:failed`

**Card Vault Events**
`card-payments:vault-wo-purchase:started`
`card-payments:vault-wo-purchase:challenge-required`
`card-payments:vault-wo-purchase:challenge:canceled`
`card-payments:vault-wo-purchase:succeeded`
`card-payments:vault-wo-purchase:failed`

### Checklist

- [ ] Added a changelog entry

### Authors
> List GitHub usernames for everyone who contributed to this pull request.

- vradopp