### PR TITLE
Create Request Object for PayPalWebCheckoutClient.vault()

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,8 +16,9 @@
   * Add `cardThreeDSecureDidCancel()` to `CardVaultDelegate`
   * Add `cardThreeDSecureWillLaunch()` to `CardVaultDelegate`
   * Add `cardThreeDSecureDidFinish()` to `CardVaultDelegate`
-* PayPalWebPayments
-  * Add `vault(url:)` method to `PayPalWebCheckoutClient`
+* PayPalWebPayments  
+  * Add `PayPalVaultRequest` type for interacting with `vault` method
+  * Add `vault` method to `PayPalWebCheckoutClient`
   * Add `PayPalVaultResult` type to return vault result
   * Add `PayPalVaultDelegate` to handle results from vault flow
   * Add `PayPalWebCheckoutClientError.paypalVaultResponseError` for missing or invalid response from vaulting

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,7 +18,7 @@
   * Add `cardThreeDSecureDidFinish()` to `CardVaultDelegate`
 * PayPalWebPayments  
   * Add `PayPalVaultRequest` type for interacting with `vault` method
-  * Add `vault` method to `PayPalWebCheckoutClient`
+  * Add `vault(_:)` method to `PayPalWebCheckoutClient`
   * Add `PayPalVaultResult` type to return vault result
   * Add `PayPalVaultDelegate` to handle results from vault flow
   * Add `PayPalWebCheckoutClientError.paypalVaultResponseError` for missing or invalid response from vaulting

--- a/Demo/Demo/SwiftUIComponents/PayPalVaultViews/PayPalVaultView.swift
+++ b/Demo/Demo/SwiftUIComponents/PayPalVaultViews/PayPalVaultView.swift
@@ -14,10 +14,11 @@ struct PayPalVaultView: View {
                         paymentSourceType: PaymentSourceType.paypal(usageType: "MERCHANT")
                     )
                     SetupTokenResultView(vaultViewModel: paypalVaultViewModel)
-                    if let url = paypalVaultViewModel.state.setupToken?.paypalURL {
+                    if let urlString = paypalVaultViewModel.state.setupToken?.paypalURL,
+                        let setupTokenID = paypalVaultViewModel.state.setupToken?.id {
                         Button("Vault PayPal") {
                             Task {
-                                await paypalVaultViewModel.vault(url: url)
+                                await paypalVaultViewModel.vault(url: urlString, setupTokenID: setupTokenID)
                             }
                         }
                         .buttonStyle(RoundedBlueButtonStyle())

--- a/Demo/Demo/ViewModels/PayPalVaultViewModel.swift
+++ b/Demo/Demo/ViewModels/PayPalVaultViewModel.swift
@@ -6,7 +6,7 @@ class PayPalVaultViewModel: VaultViewModel, PayPalVaultDelegate {
 
     let configManager = CoreConfigManager(domain: "PayPal Vault")
 
-    func vault(url: String) async {
+    func vault(url: String, setupTokenID: String) async {
         guard let paypalUrl = URL(string: url) else {
             return
         }
@@ -17,7 +17,8 @@ class PayPalVaultViewModel: VaultViewModel, PayPalVaultDelegate {
             let config = try await configManager.getCoreConfig()
             let paypalClient = PayPalWebCheckoutClient(config: config)
             paypalClient.vaultDelegate = self
-            paypalClient.vault(url: paypalUrl)
+            let vaultRequest = PayPalVaultRequest(url: paypalUrl, setupTokenID: setupTokenID)
+            paypalClient.vault(vaultRequest)
         } catch {
             print("Error in vaulting PayPal Payment")
         }

--- a/Demo/Demo/ViewModels/PayPalVaultViewModel.swift
+++ b/Demo/Demo/ViewModels/PayPalVaultViewModel.swift
@@ -7,7 +7,7 @@ class PayPalVaultViewModel: VaultViewModel, PayPalVaultDelegate {
     let configManager = CoreConfigManager(domain: "PayPal Vault")
 
     func vault(url: String, setupTokenID: String) async {
-        guard let paypalUrl = URL(string: url) else {
+        guard let payPalURL = URL(string: url) else {
             return
         }
         DispatchQueue.main.async {
@@ -17,7 +17,7 @@ class PayPalVaultViewModel: VaultViewModel, PayPalVaultDelegate {
             let config = try await configManager.getCoreConfig()
             let paypalClient = PayPalWebCheckoutClient(config: config)
             paypalClient.vaultDelegate = self
-            let vaultRequest = PayPalVaultRequest(url: paypalUrl, setupTokenID: setupTokenID)
+            let vaultRequest = PayPalVaultRequest(url: payPalURL, setupTokenID: setupTokenID)
             paypalClient.vault(vaultRequest)
         } catch {
             print("Error in vaulting PayPal Payment")

--- a/PayPal.xcodeproj/project.pbxproj
+++ b/PayPal.xcodeproj/project.pbxproj
@@ -18,6 +18,7 @@
 		3B109B3C2A85CC6200D8135F /* MockCardVaultDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3B109B3A2A85B54800D8135F /* MockCardVaultDelegate.swift */; };
 		3B22E8B62A840ECF00962E34 /* CardVaultDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3B22E8B52A840ECF00962E34 /* CardVaultDelegate.swift */; };
 		3B22E8B82A841AEA00962E34 /* CardVaultResult.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3B22E8B72A841AEA00962E34 /* CardVaultResult.swift */; };
+		3B29C3972B9148F70077741D /* PayPalVaultRequest.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3B29C3962B9148F70077741D /* PayPalVaultRequest.swift */; };
 		3B3C51122B20C962009125FE /* PayPalVaultDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3B3C51112B20C962009125FE /* PayPalVaultDelegate.swift */; };
 		3B3C51182B2221C9009125FE /* MockPayPalVaultDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3B3C51172B2221C9009125FE /* MockPayPalVaultDelegate.swift */; };
 		3B3C511E2B2395B5009125FE /* PayPalVaultResult.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3B3C511D2B2395B5009125FE /* PayPalVaultResult.swift */; };
@@ -218,6 +219,7 @@
 		3B109B3A2A85B54800D8135F /* MockCardVaultDelegate.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MockCardVaultDelegate.swift; sourceTree = "<group>"; };
 		3B22E8B52A840ECF00962E34 /* CardVaultDelegate.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CardVaultDelegate.swift; sourceTree = "<group>"; };
 		3B22E8B72A841AEA00962E34 /* CardVaultResult.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CardVaultResult.swift; sourceTree = "<group>"; };
+		3B29C3962B9148F70077741D /* PayPalVaultRequest.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PayPalVaultRequest.swift; sourceTree = "<group>"; };
 		3B3C51112B20C962009125FE /* PayPalVaultDelegate.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PayPalVaultDelegate.swift; sourceTree = "<group>"; };
 		3B3C51172B2221C9009125FE /* MockPayPalVaultDelegate.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MockPayPalVaultDelegate.swift; sourceTree = "<group>"; };
 		3B3C511D2B2395B5009125FE /* PayPalVaultResult.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PayPalVaultResult.swift; sourceTree = "<group>"; };
@@ -743,6 +745,7 @@
 				CB51FF7127FCB947001A97F5 /* PayPalWebCheckoutFundingSource.swift */,
 				3B3C51112B20C962009125FE /* PayPalVaultDelegate.swift */,
 				3B3C511D2B2395B5009125FE /* PayPalVaultResult.swift */,
+				3B29C3962B9148F70077741D /* PayPalVaultRequest.swift */,
 			);
 			name = PayPalWebPayments;
 			path = Sources/PayPalWebPayments;
@@ -1431,6 +1434,7 @@
 			isa = PBXSourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				3B29C3972B9148F70077741D /* PayPalVaultRequest.swift in Sources */,
 				3B3C511E2B2395B5009125FE /* PayPalVaultResult.swift in Sources */,
 				BE4F785327EB656400FF4C0E /* Environment+PayPalWebCheckout.swift in Sources */,
 				BE4F785427EB656400FF4C0E /* PayPalWebCheckoutClient.swift in Sources */,

--- a/Sources/PayPalWebPayments/PayPalVaultRequest.swift
+++ b/Sources/PayPalWebPayments/PayPalVaultRequest.swift
@@ -12,7 +12,7 @@ public struct PayPalVaultRequest {
     /// Creates an instance of a PayPal vault request
     /// - Parameters:
     ///    - url: The PayPal URL for the approval web page
-    ///    - setupTokenID: An ID for the setup token to update
+    ///    - setupTokenID: An ID for the setup token associated with the vault
     public init(url: URL, setupTokenID: String) {
         self.url = url
         self.setupTokenID = setupTokenID

--- a/Sources/PayPalWebPayments/PayPalVaultRequest.swift
+++ b/Sources/PayPalWebPayments/PayPalVaultRequest.swift
@@ -3,10 +3,11 @@ import Foundation
 /// A request to vault a PayPal payment method
 public struct PayPalVaultRequest {
 
-    /// PayPal URL for the approval web page
+    /// PayPal approval URL returned as the `href` from the setup token API call
     public let url: URL
 
     /// ID for the setup token associated with the vault
+    /// Returned as  top level `id` from the setup token API call
     public let setupTokenID: String
 
     /// Creates an instance of a PayPal vault request

--- a/Sources/PayPalWebPayments/PayPalVaultRequest.swift
+++ b/Sources/PayPalWebPayments/PayPalVaultRequest.swift
@@ -1,0 +1,16 @@
+import Foundation
+
+/// A request to vault a PayPal payment method
+public struct PayPalVaultRequest {
+
+    /// PayPal URL for the approval web page
+    public let url: URL
+
+    /// ID for the setup token associated with the vault
+    public let setupTokenID: String
+
+    public init(url: URL, setupTokenID: String) {
+        self.url = url
+        self.setupTokenID = setupTokenID
+    }
+}

--- a/Sources/PayPalWebPayments/PayPalVaultRequest.swift
+++ b/Sources/PayPalWebPayments/PayPalVaultRequest.swift
@@ -9,6 +9,10 @@ public struct PayPalVaultRequest {
     /// ID for the setup token associated with the vault
     public let setupTokenID: String
 
+    /// Creates an instance of a PayPal vault request
+    /// - Parameters:
+    ///    - url: The PayPal URL for the approval web page
+    ///    - setupTokenID: An ID for the setup token to update
     public init(url: URL, setupTokenID: String) {
         self.url = url
         self.setupTokenID = setupTokenID

--- a/Sources/PayPalWebPayments/PayPalVaultRequest.swift
+++ b/Sources/PayPalWebPayments/PayPalVaultRequest.swift
@@ -12,7 +12,7 @@ public struct PayPalVaultRequest {
 
     /// Creates an instance of a PayPal vault request
     /// - Parameters:
-    ///    - url: The PayPal URL for the approval web page
+    ///    - url: PayPal approval URL returned as the `href` from the setup token API call
     ///    - setupTokenID: An ID for the setup token associated with the vault
     public init(url: URL, setupTokenID: String) {
         self.url = url

--- a/Sources/PayPalWebPayments/PayPalWebCheckoutClient.swift
+++ b/Sources/PayPalWebPayments/PayPalWebCheckoutClient.swift
@@ -102,7 +102,6 @@ public class PayPalWebCheckoutClient: NSObject {
     /// - Parameters:
     ///   - vaultRequest: Request created with url for vault approval and setupTokenID
     public func vault(_ vaultRequest: PayPalVaultRequest) {
-
         analyticsService = AnalyticsService(coreConfig: config, setupToken: vaultRequest.setupTokenID)
         analyticsService?.sendEvent("paypal-web-payments:vault-wo-purchase:started")
         

--- a/Sources/PayPalWebPayments/PayPalWebCheckoutClient.swift
+++ b/Sources/PayPalWebPayments/PayPalWebCheckoutClient.swift
@@ -102,9 +102,8 @@ public class PayPalWebCheckoutClient: NSObject {
     /// - Parameters:
     ///   - vaultRequest: Request created with url for vault approval and setupTokenID
     public func vault(_ vaultRequest: PayPalVaultRequest) {
-        if let setupToken = getQueryStringParameter(url: vaultRequest.url.absoluteString, param: "approval_session_id") {
-            analyticsService = AnalyticsService(coreConfig: config, setupToken: setupToken)
-        }
+
+        analyticsService = AnalyticsService(coreConfig: config, setupToken: vaultRequest.setupTokenID)
         analyticsService?.sendEvent("paypal-web-payments:vault-wo-purchase:started")
         
         webAuthenticationSession.start(

--- a/Sources/PayPalWebPayments/PayPalWebCheckoutClient.swift
+++ b/Sources/PayPalWebPayments/PayPalWebCheckoutClient.swift
@@ -100,12 +100,10 @@ public class PayPalWebCheckoutClient: NSObject {
     /// Starts a web session for vaulting PayPal Payment Method
     /// After setupToken successfullly attaches a payment method, you will need to create a payment token with the setup token
     /// - Parameters:
-    ///   - url: URL created from string value from setupToken API
-    /// - Returns: PayPalVaultResult
-    /// - Throws: PayPalSDK error if vaulting could not complete successfully
-    public func vault(url: URL) {
+    ///   - vaultRequest: Request created with url for vault approval and setupTokenID
+    public func vault(_ vaultRequest: PayPalVaultRequest) {
         webAuthenticationSession.start(
-            url: url,
+            url: vaultRequest.url,
             context: self,
             sessionDidDisplay: { [weak self] didDisplay in
                 if didDisplay {

--- a/UnitTests/PayPalWebPaymentsTests/PayPalWebCheckoutClient_Tests.swift
+++ b/UnitTests/PayPalWebPaymentsTests/PayPalWebCheckoutClient_Tests.swift
@@ -41,7 +41,8 @@ class PayPalClient_Tests: XCTestCase {
             XCTFail("Invoked error() callback. Should invoke success().")
         })
         payPalClient.vaultDelegate = mockVaultDelegate
-        payPalClient.vault(url: url!)
+        let vaultRequest = PayPalVaultRequest(url: url!, setupTokenID: "fakeTokenID")
+        payPalClient.vault(vaultRequest)
 
         waitForExpectations(timeout: 10)
     }
@@ -65,7 +66,8 @@ class PayPalClient_Tests: XCTestCase {
             expectation.fulfill()
         })
         payPalClient.vaultDelegate = mockVaultDelegate
-        payPalClient.vault(url: url!)
+        let vaultRequest = PayPalVaultRequest(url: url!, setupTokenID: "fakeTokenID")
+        payPalClient.vault(vaultRequest)
 
         waitForExpectations(timeout: 10)
     }
@@ -91,7 +93,8 @@ class PayPalClient_Tests: XCTestCase {
             XCTFail("Invoked cancel callback. Should invoke error().")
         })
         payPalClient.vaultDelegate = mockVaultDelegate
-        payPalClient.vault(url: url!)
+        let vaultRequest = PayPalVaultRequest(url: url!, setupTokenID: "fakeTokenID")
+        payPalClient.vault(vaultRequest)
 
         waitForExpectations(timeout: 10)
     }
@@ -116,7 +119,8 @@ class PayPalClient_Tests: XCTestCase {
             expectation.fulfill()
         })
         payPalClient.vaultDelegate = mockVaultDelegate
-        payPalClient.vault(url: url!)
+        let vaultRequest = PayPalVaultRequest(url: url!, setupTokenID: "fakeTokenID")
+        payPalClient.vault(vaultRequest)
 
         waitForExpectations(timeout: 10)
     }


### PR DESCRIPTION
### Summary of changes

- Create PayPalVaultRequest
- Refactor PayPalWebCheckout.vault(url: String) to PayPalWebCheckout.vault(_ vaultRequest: PayPaylVaultRequest)
- Adjust PayPalClient_Tests with modified vault function argument
- Change demo app to pass in setupTokenID and url in PayPalVaultRequest into vault function

### Checklist

- [x] Added a changelog entry

### Authors
> List GitHub usernames for everyone who contributed to this pull request.

- @KunJeongPark 