### PR TITLE
PrivacyInfo Files for PPCP Modules

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,13 +2,13 @@
 # PayPal iOS SDK Release Notes
 
 ## unreleased
+* [Meets Apple's new Privacy Update requirements](https://developer.apple.com/news/?id=3d8a9yyh)
 * PaymentButtons
   * Add `custom` case for `PaymentButtonEdges`
   * Support VoiceOver by adding button accessibility labels
   * Fixed frame alignment and width issue occuring in SwiftUI
   * Fixed button alignment and size bug in SwiftUI with `intrinsicContentSize`
     * The height cannot be set smaller than 38px or width shorter than 300px
-  * Add PrivacyInfo.xcprivacy file
 * CardPayments
   * Add `status` property to `CardVaultResult`
   * Add `didAttemptThreeDSecureAuthentication` property to `CardVaultResult`
@@ -17,19 +17,11 @@
   * Add `cardThreeDSecureDidCancel()` to `CardVaultDelegate`
   * Add `cardThreeDSecureWillLaunch()` to `CardVaultDelegate`
   * Add `cardThreeDSecureDidFinish()` to `CardVaultDelegate`
-  * Add PrivacyInfo.xcprivacy file
 * PayPalWebPayments
   * Add `vault(url:)` method to `PayPalWebCheckoutClient`
   * Add `PayPalVaultResult` type to return vault result
   * Add `PayPalVaultDelegate` to handle results from vault flow
   * Add `PayPalWebCheckoutClientError.paypalVaultResponseError` for missing or invalid response from vaulting
-  * Add PrivacyInfo.xcprivacy file
-* CorePayments
-  * Add PrivacyInfo.xcprivacy file
-* PayPalNativePayments
-  * Add PrivacyInfo.xcprivacy file
-* FraudProtection
-  * Add PrivacyInfo.xcprivacy file
 
 ## 1.1.0 (2023-11-16)
 * PayPalNativePayments

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@
   * Fixed frame alignment and width issue occuring in SwiftUI
   * Fixed button alignment and size bug in SwiftUI with `intrinsicContentSize`
     * The height cannot be set smaller than 38px or width shorter than 300px
+  * Add PrivacyInfo.xcprivacy file
 * CardPayments
   * Add `status` property to `CardVaultResult`
   * Add `didAttemptThreeDSecureAuthentication` property to `CardVaultResult`
@@ -16,11 +17,19 @@
   * Add `cardThreeDSecureDidCancel()` to `CardVaultDelegate`
   * Add `cardThreeDSecureWillLaunch()` to `CardVaultDelegate`
   * Add `cardThreeDSecureDidFinish()` to `CardVaultDelegate`
+  * Add PrivacyInfo.xcprivacy file
 * PayPalWebPayments
   * Add `vault(url:)` method to `PayPalWebCheckoutClient`
   * Add `PayPalVaultResult` type to return vault result
   * Add `PayPalVaultDelegate` to handle results from vault flow
   * Add `PayPalWebCheckoutClientError.paypalVaultResponseError` for missing or invalid response from vaulting
+  * Add PrivacyInfo.xcprivacy file
+* CorePayments
+  * Add PrivacyInfo.xcprivacy file
+* PayPalNativePayments
+  * Add PrivacyInfo.xcprivacy file
+* FraudProtection
+  * Add PrivacyInfo.xcprivacy file
 
 ## 1.1.0 (2023-11-16)
 * PayPalNativePayments

--- a/Package.swift
+++ b/Package.swift
@@ -38,27 +38,33 @@ let package = Package(
         // Targets can depend on other targets in this package, and on products in packages this package depends on.
         .target(
             name: "CorePayments",
-            dependencies: []
+            dependencies: [],
+            resources: [.copy("PrivacyInfo.xcprivacy")]
         ),
         .target(
             name: "CardPayments",
-            dependencies: ["CorePayments"]
+            dependencies: ["CorePayments"],
+            resources: [.copy("PrivacyInfo.xcprivacy")]
         ),
         .target(
            name: "PayPalNativePayments",
-           dependencies: ["CorePayments", "PayPalCheckout"]
+           dependencies: ["CorePayments", "PayPalCheckout"],
+           resources: [.copy("PrivacyInfo.xcprivacy")]
         ),
         .target(
             name: "PaymentButtons",
-            dependencies: ["CorePayments"]
+            dependencies: ["CorePayments"],
+            resources: [.copy("PrivacyInfo.xcprivacy")]
         ),
         .target(
             name: "PayPalWebPayments",
-            dependencies: ["CorePayments"]
+            dependencies: ["CorePayments"],
+            resources: [.copy("PrivacyInfo.xcprivacy")]
         ),
         .target(
             name: "FraudProtection",
-            dependencies: ["CorePayments", "PPRiskMagnes"]
+            dependencies: ["CorePayments", "PPRiskMagnes"],
+            resources: [.copy("PrivacyInfo.xcprivacy")]
         ),
         .binaryTarget(
             name: "PPRiskMagnes",

--- a/PayPal.podspec
+++ b/PayPal.podspec
@@ -14,12 +14,14 @@ Pod::Spec.new do |s|
   s.subspec "CardPayments" do |s|
     s.source_files  = "Sources/CardPayments/**/*.swift"
     s.dependency "PayPal/CorePayments"
+    s.resource_bundle = { "PayPalCard_PrivacyInfo" => "Sources/CardPayments/PrivacyInfo.xcprivacy" }
   end
 
   s.subspec "PayPalNativePayments" do |s|
    s.source_files  = "Sources/PayPalNativePayments/**/*.swift"
    s.dependency "PayPal/CorePayments"
    s.dependency "PayPalCheckout", "1.2.0"
+   s.resource_bundle = { "PayPalNative_PrivacyInfo" => "Sources/PayPalNativePayments/PrivacyInfo.xcprivacy" }
   end
 
   s.subspec "PaymentButtons" do |s|
@@ -28,11 +30,13 @@ Pod::Spec.new do |s|
     s.resource_bundle = {
     	'PayPalSDK' => ['Sources/PaymentButtons/*.xcassets']
     }
+    s.resource_bundle = { "PayPalButtons_PrivacyInfo" => "Sources/PaymentButtons/PrivacyInfo.xcprivacy" }
   end
 
   s.subspec "PayPalWebPayments" do |s|
     s.source_files  = "Sources/PayPalWebPayments/*.swift"
     s.dependency "PayPal/CorePayments"
+    s.resource_bundle = { "PayPalWeb_PrivacyInfo" => "Sources/PayPalWebPayments/PrivacyInfo.xcprivacy" }
   end
 
   s.subspec "FraudProtection" do |s|

--- a/PayPal.podspec
+++ b/PayPal.podspec
@@ -14,14 +14,14 @@ Pod::Spec.new do |s|
   s.subspec "CardPayments" do |s|
     s.source_files  = "Sources/CardPayments/**/*.swift"
     s.dependency "PayPal/CorePayments"
-    s.resource_bundle = { "PayPalCard_PrivacyInfo" => "Sources/CardPayments/PrivacyInfo.xcprivacy" }
+    s.resource_bundle = { "CardPayments_PrivacyInfo" => "Sources/CardPayments/PrivacyInfo.xcprivacy" }
   end
 
   s.subspec "PayPalNativePayments" do |s|
    s.source_files  = "Sources/PayPalNativePayments/**/*.swift"
    s.dependency "PayPal/CorePayments"
    s.dependency "PayPalCheckout", "1.2.0"
-   s.resource_bundle = { "PayPalNative_PrivacyInfo" => "Sources/PayPalNativePayments/PrivacyInfo.xcprivacy" }
+   s.resource_bundle = { "PayPalNativePayments_PrivacyInfo" => "Sources/PayPalNativePayments/PrivacyInfo.xcprivacy" }
   end
 
   s.subspec "PaymentButtons" do |s|
@@ -30,22 +30,24 @@ Pod::Spec.new do |s|
     s.resource_bundle = {
     	'PayPalSDK' => ['Sources/PaymentButtons/*.xcassets']
     }
-    s.resource_bundle = { "PayPalButtons_PrivacyInfo" => "Sources/PaymentButtons/PrivacyInfo.xcprivacy" }
+    s.resource_bundle = { "PaymentButtons_PrivacyInfo" => "Sources/PaymentButtons/PrivacyInfo.xcprivacy" }
   end
 
   s.subspec "PayPalWebPayments" do |s|
     s.source_files  = "Sources/PayPalWebPayments/*.swift"
     s.dependency "PayPal/CorePayments"
-    s.resource_bundle = { "PayPalWeb_PrivacyInfo" => "Sources/PayPalWebPayments/PrivacyInfo.xcprivacy" }
+    s.resource_bundle = { "PayPalWebPayments_PrivacyInfo" => "Sources/PayPalWebPayments/PrivacyInfo.xcprivacy" }
   end
 
   s.subspec "FraudProtection" do |s|
     s.source_files = "Sources/FraudProtection/*.swift"
     s.dependency "PayPal/CorePayments"
     s.vendored_frameworks = "Frameworks/XCFrameworks/PPRiskMagnes.xcframework"
+    s.resource_bundle = { "FraudProtection_PrivacyInfo" => "Sources/FraudProtection/PrivacyInfo.xcprivacy" }
   end
 
   s.subspec "CorePayments" do |s|
     s.source_files  = "Sources/CorePayments/**/*.swift"
+    s.resource_bundle = { "CorePayments_PrivacyInfo" => "Sources/CorePayments/PrivacyInfo.xcprivacy" }
   end
 end

--- a/PayPal.xcodeproj/project.pbxproj
+++ b/PayPal.xcodeproj/project.pbxproj
@@ -26,6 +26,12 @@
 		3B80D50C2A27979000D2EAC4 /* FailingJSONEncoder.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3B80D50B2A27979000D2EAC4 /* FailingJSONEncoder.swift */; };
 		3BD82DBB2A835AF900CBE764 /* UpdateSetupTokenResponse.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3BD82DBA2A835AF900CBE764 /* UpdateSetupTokenResponse.swift */; };
 		3BDB34942A80CE6E008100D7 /* CardVaultRequest.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3BDB34932A80CE6E008100D7 /* CardVaultRequest.swift */; };
+		3BE738682B9A66D800598F05 /* PrivacyInfo.xcprivacy in Resources */ = {isa = PBXBuildFile; fileRef = 3BE738622B9A482800598F05 /* PrivacyInfo.xcprivacy */; };
+		3BE738692B9A66E600598F05 /* PrivacyInfo.xcprivacy in Resources */ = {isa = PBXBuildFile; fileRef = 3BE738632B9A4A4500598F05 /* PrivacyInfo.xcprivacy */; };
+		3BE7386A2B9A66EE00598F05 /* PrivacyInfo.xcprivacy in Resources */ = {isa = PBXBuildFile; fileRef = 3BE738642B9A566200598F05 /* PrivacyInfo.xcprivacy */; };
+		3BE7386B2B9A66F600598F05 /* PrivacyInfo.xcprivacy in Resources */ = {isa = PBXBuildFile; fileRef = 3BE738652B9A58AE00598F05 /* PrivacyInfo.xcprivacy */; };
+		3BE7386C2B9A66FC00598F05 /* PrivacyInfo.xcprivacy in Resources */ = {isa = PBXBuildFile; fileRef = 3BE738672B9A598200598F05 /* PrivacyInfo.xcprivacy */; };
+		3BE7386D2B9A670400598F05 /* PrivacyInfo.xcprivacy in Resources */ = {isa = PBXBuildFile; fileRef = 3BE738662B9A593100598F05 /* PrivacyInfo.xcprivacy */; };
 		3D1763A22720722A00652E1C /* CardResult.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3D1763A12720722A00652E1C /* CardResult.swift */; };
 		3DC42BA927187E8300B71645 /* ErrorResponse.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3DC42BA827187E8300B71645 /* ErrorResponse.swift */; };
 		53A2A4E228A182AC0093441C /* NativeCheckoutProvider.swift in Sources */ = {isa = PBXBuildFile; fileRef = 53A2A4E128A182AC0093441C /* NativeCheckoutProvider.swift */; };
@@ -226,6 +232,12 @@
 		3B80D50B2A27979000D2EAC4 /* FailingJSONEncoder.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FailingJSONEncoder.swift; sourceTree = "<group>"; };
 		3BD82DBA2A835AF900CBE764 /* UpdateSetupTokenResponse.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = UpdateSetupTokenResponse.swift; sourceTree = "<group>"; };
 		3BDB34932A80CE6E008100D7 /* CardVaultRequest.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CardVaultRequest.swift; sourceTree = "<group>"; };
+		3BE738622B9A482800598F05 /* PrivacyInfo.xcprivacy */ = {isa = PBXFileReference; lastKnownFileType = text.xml; path = PrivacyInfo.xcprivacy; sourceTree = "<group>"; };
+		3BE738632B9A4A4500598F05 /* PrivacyInfo.xcprivacy */ = {isa = PBXFileReference; lastKnownFileType = text.xml; path = PrivacyInfo.xcprivacy; sourceTree = "<group>"; };
+		3BE738642B9A566200598F05 /* PrivacyInfo.xcprivacy */ = {isa = PBXFileReference; lastKnownFileType = text.xml; path = PrivacyInfo.xcprivacy; sourceTree = "<group>"; };
+		3BE738652B9A58AE00598F05 /* PrivacyInfo.xcprivacy */ = {isa = PBXFileReference; lastKnownFileType = text.xml; path = PrivacyInfo.xcprivacy; sourceTree = "<group>"; };
+		3BE738662B9A593100598F05 /* PrivacyInfo.xcprivacy */ = {isa = PBXFileReference; lastKnownFileType = text.xml; path = PrivacyInfo.xcprivacy; sourceTree = "<group>"; };
+		3BE738672B9A598200598F05 /* PrivacyInfo.xcprivacy */ = {isa = PBXFileReference; lastKnownFileType = text.xml; path = PrivacyInfo.xcprivacy; sourceTree = "<group>"; };
 		3D1763A12720722A00652E1C /* CardResult.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CardResult.swift; sourceTree = "<group>"; };
 		3D25238127344F330099E4EB /* NativeCheckoutStartable.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; name = NativeCheckoutStartable.swift; path = Sources/PayPalNativePayments/NativeCheckoutStartable.swift; sourceTree = SOURCE_ROOT; };
 		3D25238B273979170099E4EB /* MockNativeCheckoutProvider.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MockNativeCheckoutProvider.swift; sourceTree = "<group>"; };
@@ -575,6 +587,7 @@
 				807C5E6829102D9800ECECD8 /* AnalyticsEventData.swift */,
 				8021B68F29144E6D000FBC54 /* PayPalCoreConstants.swift */,
 				80DB2F752980795D00CFB86A /* CorePaymentsError.swift */,
+				3BE738632B9A4A4500598F05 /* PrivacyInfo.xcprivacy */,
 			);
 			name = CorePayments;
 			path = Sources/CorePayments;
@@ -594,6 +607,7 @@
 				80DBC9DD29C3B57200462539 /* PayPalNativeShippingAddress.swift */,
 				80DBC9DF29C3B8A800462539 /* PayPalNativeShippingMethod.swift */,
 				CBC16DD629E99D0D00307117 /* PayPalNativePaysheetActions.swift */,
+				3BE738652B9A58AE00598F05 /* PrivacyInfo.xcprivacy */,
 			);
 			name = PayPalNativePayments;
 			path = Sources/PayPalNativePayments;
@@ -636,6 +650,7 @@
 				3B22E8B52A840ECF00962E34 /* CardVaultDelegate.swift */,
 				80DBC9D829C336D500462539 /* APIRequests */,
 				065A4DBD26FCDA270007014A /* Models */,
+				3BE738622B9A482800598F05 /* PrivacyInfo.xcprivacy */,
 			);
 			name = CardPayments;
 			path = Sources/CardPayments;
@@ -682,6 +697,7 @@
 				BC9C18D727D279C70019B541 /* MagnesSDKResult.swift */,
 				BCF735EA27D160E800A52E03 /* MagnesSetupParams.swift */,
 				BCF735E627D15AB800A52E03 /* PayPalDataCollector.swift */,
+				3BE738642B9A566200598F05 /* PrivacyInfo.xcprivacy */,
 			);
 			name = FraudProtection;
 			path = Sources/FraudProtection;
@@ -715,6 +731,7 @@
 				CB1A47F92820BF6B00BD8184 /* PaymentButtonFont.swift */,
 				CB1A47FD2820C10700BD8184 /* PaymentButtonFundingSource.swift */,
 				CB1A48042822BCED00BD8184 /* PaymentButton+ImageAsset.swift */,
+				3BE738672B9A598200598F05 /* PrivacyInfo.xcprivacy */,
 			);
 			name = PaymentButtons;
 			path = Sources/PaymentButtons;
@@ -743,6 +760,7 @@
 				CB51FF7127FCB947001A97F5 /* PayPalWebCheckoutFundingSource.swift */,
 				3B3C51112B20C962009125FE /* PayPalVaultDelegate.swift */,
 				3B3C511D2B2395B5009125FE /* PayPalVaultResult.swift */,
+				3BE738662B9A593100598F05 /* PrivacyInfo.xcprivacy */,
 			);
 			name = PayPalWebPayments;
 			path = Sources/PayPalWebPayments;
@@ -1220,6 +1238,7 @@
 			isa = PBXResourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				3BE738692B9A66E600598F05 /* PrivacyInfo.xcprivacy in Resources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -1227,6 +1246,7 @@
 			isa = PBXResourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				3BE7386B2B9A66F600598F05 /* PrivacyInfo.xcprivacy in Resources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -1241,6 +1261,7 @@
 			isa = PBXResourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				3BE738682B9A66D800598F05 /* PrivacyInfo.xcprivacy in Resources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -1255,6 +1276,7 @@
 			isa = PBXResourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				3BE7386D2B9A670400598F05 /* PrivacyInfo.xcprivacy in Resources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -1262,6 +1284,7 @@
 			isa = PBXResourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				3BE7386A2B9A66EE00598F05 /* PrivacyInfo.xcprivacy in Resources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -1276,6 +1299,7 @@
 			isa = PBXResourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				3BE7386C2B9A66FC00598F05 /* PrivacyInfo.xcprivacy in Resources */,
 				BCFAC70527ED042500C3AF00 /* Assets.xcassets in Resources */,
 				045386092B5CB9AA0057AFDA /* PayPalOpen-Regular.otf in Resources */,
 			);

--- a/Sources/CardPayments/PrivacyInfo.xcprivacy
+++ b/Sources/CardPayments/PrivacyInfo.xcprivacy
@@ -1,0 +1,33 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+	<key>NSPrivacyCollectedDataTypes</key>
+	<array>
+		<dict>
+			<key>NSPrivacyCollectedDataType</key>
+			<string>NSPrivacyCollectedDataTypePaymentInfo</string>
+			<key>NSPrivacyCollectedDataTypeLinked</key>
+			<false/>
+			<key>NSPrivacyCollectedDataTypeTracking</key>
+			<false/>
+			<key>NSPrivacyCollectedDataTypePurposes</key>
+			<array>
+				<string>NSPrivacyCollectedDataTypePurposeAppFunctionality</string>
+			</array>
+		</dict>
+		<dict>
+			<key>NSPrivacyCollectedDataType</key>
+			<string>NSPrivacyCollectedDataTypePhysicalAddress</string>
+			<key>NSPrivacyCollectedDataTypeLinked</key>
+			<false/>
+			<key>NSPrivacyCollectedDataTypeTracking</key>
+			<false/>
+			<key>NSPrivacyCollectedDataTypePurposes</key>
+			<array>
+				<string>NSPrivacyCollectedDataTypePurposeAppFunctionality</string>
+			</array>
+		</dict>
+	</array>
+</dict>
+</plist>

--- a/Sources/CorePayments/PrivacyInfo.xcprivacy
+++ b/Sources/CorePayments/PrivacyInfo.xcprivacy
@@ -1,0 +1,21 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+	<key>NSPrivacyCollectedDataTypes</key>
+	<array>
+		<dict>
+			<key>NSPrivacyCollectedDataType</key>
+			<string></string>
+			<key>NSPrivacyCollectedDataTypeLinked</key>
+			<false/>
+			<key>NSPrivacyCollectedDataTypeTracking</key>
+			<false/>
+			<key>NSPrivacyCollectedDataTypePurposes</key>
+			<array>
+				<string></string>
+			</array>
+		</dict>
+	</array>
+</dict>
+</plist>

--- a/Sources/CorePayments/PrivacyInfo.xcprivacy
+++ b/Sources/CorePayments/PrivacyInfo.xcprivacy
@@ -3,19 +3,6 @@
 <plist version="1.0">
 <dict>
 	<key>NSPrivacyCollectedDataTypes</key>
-	<array>
-		<dict>
-			<key>NSPrivacyCollectedDataType</key>
-			<string></string>
-			<key>NSPrivacyCollectedDataTypeLinked</key>
-			<false/>
-			<key>NSPrivacyCollectedDataTypeTracking</key>
-			<false/>
-			<key>NSPrivacyCollectedDataTypePurposes</key>
-			<array>
-				<string></string>
-			</array>
-		</dict>
-	</array>
+	<array/>
 </dict>
 </plist>

--- a/Sources/FraudProtection/PrivacyInfo.xcprivacy
+++ b/Sources/FraudProtection/PrivacyInfo.xcprivacy
@@ -1,0 +1,21 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+	<key>NSPrivacyCollectedDataTypes</key>
+	<array>
+		<dict>
+			<key>NSPrivacyCollectedDataType</key>
+			<string>NSPrivacyCollectedDataTypeDeviceID</string>
+			<key>NSPrivacyCollectedDataTypeLinked</key>
+			<false/>
+			<key>NSPrivacyCollectedDataTypeTracking</key>
+			<false/>
+			<key>NSPrivacyCollectedDataTypePurposes</key>
+			<array>
+				<string>NSPrivacyCollectedDataTypePurposeAppFunctionality</string>
+			</array>
+		</dict>
+	</array>
+</dict>
+</plist>

--- a/Sources/FraudProtection/PrivacyInfo.xcprivacy
+++ b/Sources/FraudProtection/PrivacyInfo.xcprivacy
@@ -3,19 +3,6 @@
 <plist version="1.0">
 <dict>
 	<key>NSPrivacyCollectedDataTypes</key>
-	<array>
-		<dict>
-			<key>NSPrivacyCollectedDataType</key>
-			<string>NSPrivacyCollectedDataTypeDeviceID</string>
-			<key>NSPrivacyCollectedDataTypeLinked</key>
-			<false/>
-			<key>NSPrivacyCollectedDataTypeTracking</key>
-			<false/>
-			<key>NSPrivacyCollectedDataTypePurposes</key>
-			<array>
-				<string>NSPrivacyCollectedDataTypePurposeAppFunctionality</string>
-			</array>
-		</dict>
-	</array>
+	<array/>
 </dict>
 </plist>

--- a/Sources/PayPalNativePayments/PrivacyInfo.xcprivacy
+++ b/Sources/PayPalNativePayments/PrivacyInfo.xcprivacy
@@ -1,0 +1,21 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+	<key>NSPrivacyCollectedDataTypes</key>
+	<array>
+		<dict>
+			<key>NSPrivacyCollectedDataType</key>
+			<string>NSPrivacyCollectedDataTypeEmailAddress</string>
+			<key>NSPrivacyCollectedDataTypeLinked</key>
+			<false/>
+			<key>NSPrivacyCollectedDataTypeTracking</key>
+			<false/>
+			<key>NSPrivacyCollectedDataTypePurposes</key>
+			<array>
+				<string>NSPrivacyCollectedDataTypePurposeAppFunctionality</string>
+			</array>
+		</dict>
+	</array>
+</dict>
+</plist>

--- a/Sources/PayPalWebPayments/PrivacyInfo.xcprivacy
+++ b/Sources/PayPalWebPayments/PrivacyInfo.xcprivacy
@@ -1,0 +1,21 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+	<key>NSPrivacyCollectedDataTypes</key>
+	<array>
+		<dict>
+			<key>NSPrivacyCollectedDataType</key>
+			<string>NSPrivacyCollectedDataTypePaymentInfo</string>
+			<key>NSPrivacyCollectedDataTypeLinked</key>
+			<false/>
+			<key>NSPrivacyCollectedDataTypeTracking</key>
+			<false/>
+			<key>NSPrivacyCollectedDataTypePurposes</key>
+			<array>
+				<string>NSPrivacyCollectedDataTypePurposeAppFunctionality</string>
+			</array>
+		</dict>
+	</array>
+</dict>
+</plist>

--- a/Sources/PaymentButtons/PrivacyInfo.xcprivacy
+++ b/Sources/PaymentButtons/PrivacyInfo.xcprivacy
@@ -1,0 +1,21 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+	<key>NSPrivacyCollectedDataTypes</key>
+	<array>
+		<dict>
+			<key>NSPrivacyCollectedDataType</key>
+			<string></string>
+			<key>NSPrivacyCollectedDataTypeLinked</key>
+			<false/>
+			<key>NSPrivacyCollectedDataTypeTracking</key>
+			<false/>
+			<key>NSPrivacyCollectedDataTypePurposes</key>
+			<array>
+				<string></string>
+			</array>
+		</dict>
+	</array>
+</dict>
+</plist>

--- a/Sources/PaymentButtons/PrivacyInfo.xcprivacy
+++ b/Sources/PaymentButtons/PrivacyInfo.xcprivacy
@@ -3,19 +3,6 @@
 <plist version="1.0">
 <dict>
 	<key>NSPrivacyCollectedDataTypes</key>
-	<array>
-		<dict>
-			<key>NSPrivacyCollectedDataType</key>
-			<string></string>
-			<key>NSPrivacyCollectedDataTypeLinked</key>
-			<false/>
-			<key>NSPrivacyCollectedDataTypeTracking</key>
-			<false/>
-			<key>NSPrivacyCollectedDataTypePurposes</key>
-			<array>
-				<string></string>
-			</array>
-		</dict>
-	</array>
+	<array/>
 </dict>
 </plist>


### PR DESCRIPTION
### Summary of changes

- Create PrivacyInfo.xcprivacy files for all PPCP modules -  CorePayments, CardPayments, PayPalNativePayments,
PaymentButtons, PayPalWebPayments and FraudProtection 

Generated Privacy Report from demo app:
[Demo-PrivacyReport 2024-03-08 07-52-14_4.pdf](https://github.com/paypal/paypal-ios/files/14540209/Demo-PrivacyReport.2024-03-08.07-52-14_4.pdf)

### Checklist

- [x] Added a changelog entry

### Authors
> List GitHub usernames for everyone who contributed to this pull request.

- @KunJeongPark 