### PR TITLE
Merge resource_bundle declarations 

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,10 @@
 
 # PayPal iOS SDK Release Notes
 
+## unreleased
+* PaymentButtons
+  * Fix assets not rendering when importing CocoaPods
+  
 ## 1.2.0 (2024-03-27)
 * Bump to PPRiskMagnes v5.5.0 with code signing & a privacy manifest file
 * Require Xcode 15.0+ and Swift 5.9+ (per [App Store requirements](https://developer.apple.com/news/?id=khzvxn8a))

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,7 @@
 ## unreleased
 * PaymentButtons
   * Fix assets not rendering when importing CocoaPods
-  
+
 ## 1.2.0 (2024-03-27)
 * Bump to PPRiskMagnes v5.5.0 with code signing & a privacy manifest file
 * Require Xcode 15.0+ and Swift 5.9+ (per [App Store requirements](https://developer.apple.com/news/?id=khzvxn8a))

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,7 +3,7 @@
 
 ## unreleased
 * PaymentButtons
-  * Fix assets not rendering when importing CocoaPods
+  * Resolve assets not rendering when importing via CocoaPods (fixes #267)
 
 ## 1.2.0 (2024-03-27)
 * Bump to PPRiskMagnes v5.5.0 with code signing & a privacy manifest file

--- a/PayPal.podspec
+++ b/PayPal.podspec
@@ -29,7 +29,7 @@ Pod::Spec.new do |s|
     s.dependency "PayPal/CorePayments"
     s.resource_bundle = {
     	'PayPalSDK' => ['Sources/PaymentButtons/*.xcassets'],
-         "PaymentButtons_PrivacyInfo" => "Sources/PaymentButtons/PrivacyInfo.xcprivacy"
+        "PaymentButtons_PrivacyInfo" => "Sources/PaymentButtons/PrivacyInfo.xcprivacy"
     }
   end
 

--- a/PayPal.podspec
+++ b/PayPal.podspec
@@ -28,9 +28,9 @@ Pod::Spec.new do |s|
     s.source_files  = "Sources/PaymentButtons/*.swift"
     s.dependency "PayPal/CorePayments"
     s.resource_bundle = {
-    	'PayPalSDK' => ['Sources/PaymentButtons/*.xcassets']
+    	'PayPalSDK' => ['Sources/PaymentButtons/*.xcassets'],
+         "PaymentButtons_PrivacyInfo" => "Sources/PaymentButtons/PrivacyInfo.xcprivacy"
     }
-    s.resource_bundle = { "PaymentButtons_PrivacyInfo" => "Sources/PaymentButtons/PrivacyInfo.xcprivacy" }
   end
 
   s.subspec "PayPalWebPayments" do |s|


### PR DESCRIPTION
### Reason for changes

 - Fixes https://github.com/paypal/paypal-ios/issues/267
 
### Summary of changes

- Consolidated multiple resource bundle (_resource_bundle_) declarations into a single block. Previously, having two separate declarations led to only the `Privacy Manifest` being copied to the target bundle, causing the `assets` not to display

### Checklist

- [x] Added a changelog entry

### Authors

- @richherrera  