### PR TITLE
FraudProtection Privacy Manifest - DeviceID

### DIFF
--- a/Sources/FraudProtection/PrivacyInfo.xcprivacy
+++ b/Sources/FraudProtection/PrivacyInfo.xcprivacy
@@ -3,6 +3,19 @@
 <plist version="1.0">
 <dict>
 	<key>NSPrivacyCollectedDataTypes</key>
-	<array/>
+	<array>
+		<dict>
+			<key>NSPrivacyCollectedDataType</key>
+			<string>NSPrivacyCollectedDataTypeDeviceID</string>
+			<key>NSPrivacyCollectedDataTypeLinked</key>
+			<false/>
+			<key>NSPrivacyCollectedDataTypeTracking</key>
+			<false/>
+			<key>NSPrivacyCollectedDataTypePurposes</key>
+			<array>
+				<string>NSPrivacyCollectedDataTypePurposeAppFunctionality</string>
+			</array>
+		</dict>
+	</array>
 </dict>
 </plist>


### PR DESCRIPTION
### Reason for changes

- Add missing DeviceID Privacy info in FraudProtection Module

### Summary of changes

- Add DeviceID in collection type and reason in PrivacyInfo.xcprivacy file

### Checklist

- [ ] Added a changelog entry

### Authors
> List GitHub usernames for everyone who contributed to this pull request.

- @KunJeongPark 