### PR TITLE
Add Black Boundary on White Button

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,8 @@
 ## 1.3.1 (2024-04-29)
 * FraudProtection
   * Include `DeviceID` privacy term in `PrivacyInfo.xcprivacy` file
+* PaymentButtons
+  * Add black boundary around white buttons
   
 ## 1.3.0 (2024-04-25)
 * PayPalNativePayments

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,11 +1,13 @@
 
 # PayPal iOS SDK Release Notes
 
+## unreleased
+* PaymentButtons
+  * Add black boundary around white buttons
+
 ## 1.3.1 (2024-04-29)
 * FraudProtection
   * Include `DeviceID` privacy term in `PrivacyInfo.xcprivacy` file
-* PaymentButtons
-  * Add black boundary around white buttons
   
 ## 1.3.0 (2024-04-25)
 * PayPalNativePayments

--- a/Sources/PaymentButtons/PaymentButton.swift
+++ b/Sources/PaymentButtons/PaymentButton.swift
@@ -48,6 +48,7 @@ public class PaymentButton: UIButton {
         self.label = label
         self.analyticsService.sendEvent("payment-button:initialized", buttonType: fundingSource.rawValue)
         super.init(frame: .zero)
+        customizeAppearance()
         self.addTarget(self, action: #selector(onTap), for: .touchUpInside)
     }
 
@@ -330,5 +331,15 @@ public class PaymentButton: UIButton {
         defer { UIGraphicsEndImageContext() }
         image.draw(in: CGRect(x: 0.0, y: 0.0, width: size.width, height: size.height))
         return UIGraphicsGetImageFromCurrentImageContext()
+    }
+
+    private func customizeAppearance() {
+        if self.color == .white {
+            self.containerView.layer.borderColor = UIColor.black.cgColor
+            self.containerView.layer.borderWidth = 2
+        } else {
+            self.containerView.layer.borderColor = UIColor.clear.cgColor
+            self.containerView.layer.borderWidth = 0
+        }
     }
 }

--- a/Sources/PaymentButtons/PaymentButton.swift
+++ b/Sources/PaymentButtons/PaymentButton.swift
@@ -335,6 +335,6 @@ public class PaymentButton: UIButton {
 
     private func customizeAppearance() {
         containerView.layer.borderColor = color == .white ? UIColor.black.cgColor : UIColor.clear.cgColor
-        containerView.layer.borderWidth = color == .white ? 2 : 0
+        containerView.layer.borderWidth = color == .white ? 1 : 0
     }
 }

--- a/Sources/PaymentButtons/PaymentButton.swift
+++ b/Sources/PaymentButtons/PaymentButton.swift
@@ -334,12 +334,7 @@ public class PaymentButton: UIButton {
     }
 
     private func customizeAppearance() {
-        if self.color == .white {
-            self.containerView.layer.borderColor = UIColor.black.cgColor
-            self.containerView.layer.borderWidth = 2
-        } else {
-            self.containerView.layer.borderColor = UIColor.clear.cgColor
-            self.containerView.layer.borderWidth = 0
-        }
+        containerView.layer.borderColor = color == .white ? UIColor.black.cgColor : UIColor.clear.cgColor
+        containerView.layer.borderWidth = color == .white ? 2 : 0
     }
 }


### PR DESCRIPTION
### Reason for changes
Inbound from Merchant LI-47312 asking for parity on appearance of white button having
black boundary on Android SDK vs none in iOS SDK (no black boundary on white button)

### Summary of changes

- Add black boundary if chosen color is white.

Before:
![buttonInboundPic](https://github.com/paypal/paypal-ios/assets/9273272/f380e69c-f0d0-4f32-bac8-034e0e673859)

After:
<img src="https://github.com/paypal/paypal-ios/assets/9273272/d2634249-ef1b-4c76-9c90-097cfe034602" width="400" height="800" alt="Pay Later Button">
<img src="https://github.com/paypal/paypal-ios/assets/9273272/c75a652c-26a3-4741-9ea1-630a8ec8982f" width="400" height="800" alt="PayPal Button">
<img src="https://github.com/paypal/paypal-ios/assets/9273272/26f0d2f1-6ae1-47d5-bdaf-0c29f0ba809e" width="400" height="800" alt="PayPal Button Mini">

### Checklist

- [x] Added a changelog entry

### Authors
> List GitHub usernames for everyone who contributed to this pull request.

- @KunJeongPark 