### PR TITLE
Remove PayPalVaultRequest required URL param

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,11 @@
 
 # PayPal iOS SDK Release Notes
 
+## unreleased
+* PayPalWebPayments
+  * Deprecate `PayPalVaultRequest.init(url:setupTokenID:)`
+  * Add `PayPalVaultRequest.init(setupTokenID:)`
+
 ## 1.3.2 (2024-05-23)
 * PaymentButtons
   * Add black boundary around white buttons

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,8 +3,8 @@
 
 ## unreleased
 * PayPalWebPayments
-  * Deprecate `PayPalVaultRequest.init(url:setupTokenID:)`
-  * Add `PayPalVaultRequest.init(setupTokenID:)`
+  * Deprecate `PayPalVaultRequest(url:setupTokenID:)`
+  * Add `PayPalVaultRequest(setupTokenID:)`
 
 ## 1.3.2 (2024-05-23)
 * PaymentButtons

--- a/Demo/Demo/Models/CreateSetupTokenResponse.swift
+++ b/Demo/Demo/Models/CreateSetupTokenResponse.swift
@@ -9,9 +9,6 @@ struct CreateSetupTokenResponse: Decodable, Equatable {
     let id, status: String
     let customer: Customer?
     let links: [Link]
-    var paypalURL: String? {
-        links.first { $0.rel == "approve" }?.href
-    }
 
     struct Customer: Decodable {
         

--- a/Demo/Demo/Models/CreateSetupTokenResponse.swift
+++ b/Demo/Demo/Models/CreateSetupTokenResponse.swift
@@ -8,15 +8,9 @@ struct CreateSetupTokenResponse: Decodable, Equatable {
     
     let id, status: String
     let customer: Customer?
-    let links: [Link]
 
     struct Customer: Decodable {
         
         let id: String
-    }
-
-    struct Link: Decodable {
-
-        let href, rel, method: String
     }
 }

--- a/Demo/Demo/SwiftUIComponents/PayPalVaultViews/PayPalVaultView.swift
+++ b/Demo/Demo/SwiftUIComponents/PayPalVaultViews/PayPalVaultView.swift
@@ -14,11 +14,10 @@ struct PayPalVaultView: View {
                         paymentSourceType: PaymentSourceType.paypal(usageType: "MERCHANT")
                     )
                     SetupTokenResultView(vaultViewModel: paypalVaultViewModel)
-                    if let urlString = paypalVaultViewModel.state.setupToken?.paypalURL,
-                        let setupTokenID = paypalVaultViewModel.state.setupToken?.id {
+                    if let setupTokenID = paypalVaultViewModel.state.setupToken?.id {
                         Button("Vault PayPal") {
                             Task {
-                                await paypalVaultViewModel.vault(url: urlString, setupTokenID: setupTokenID)
+                                await paypalVaultViewModel.vault(setupTokenID: setupTokenID)
                             }
                         }
                         .buttonStyle(RoundedBlueButtonStyle())

--- a/Demo/Demo/SwiftUIComponents/VaultViews/SetupTokenResultView.swift
+++ b/Demo/Demo/SwiftUIComponents/VaultViews/SetupTokenResultView.swift
@@ -28,10 +28,6 @@ struct SetupTokenResultView: View {
             LeadingText("\(setupTokenResponse.customer?.id ?? "")")
             LeadingText("Status", weight: .bold)
             LeadingText("\(setupTokenResponse.status)")
-            if let url = setupTokenResponse.paypalURL {
-                LeadingText("PayPalURL", weight: .bold)
-                LeadingText("\(url)")
-            }
         }
         .frame(maxWidth: .infinity)
         .padding()

--- a/Demo/Demo/ViewModels/PayPalVaultViewModel.swift
+++ b/Demo/Demo/ViewModels/PayPalVaultViewModel.swift
@@ -6,10 +6,7 @@ class PayPalVaultViewModel: VaultViewModel, PayPalVaultDelegate {
 
     let configManager = CoreConfigManager(domain: "PayPal Vault")
 
-    func vault(url: String, setupTokenID: String) async {
-        guard let payPalURL = URL(string: url) else {
-            return
-        }
+    func vault(setupTokenID: String) async {
         DispatchQueue.main.async {
             self.state.paypalVaultTokenResponse = .loading
         }
@@ -17,7 +14,7 @@ class PayPalVaultViewModel: VaultViewModel, PayPalVaultDelegate {
             let config = try await configManager.getCoreConfig()
             let paypalClient = PayPalWebCheckoutClient(config: config)
             paypalClient.vaultDelegate = self
-            let vaultRequest = PayPalVaultRequest(url: payPalURL, setupTokenID: setupTokenID)
+            let vaultRequest = PayPalVaultRequest(setupTokenID: setupTokenID)
             paypalClient.vault(vaultRequest)
         } catch {
             print("Error in vaulting PayPal Payment")

--- a/Sources/CorePayments/Networking/Enums/Environment.swift
+++ b/Sources/CorePayments/Networking/Enums/Environment.swift
@@ -23,8 +23,8 @@ public enum Environment {
         }
     }
     
-    /// URL used to display Vault w/o Purchase experience in web browser
-    public var vaultCheckoutURL: URL {
+    /// URL used to display the PayPal Vault w/o Purchase experience in web browser
+    public var paypalVaultCheckoutURL: URL {
         switch self {
         case .sandbox:
             return URL(string: "https://sandbox.paypal.com/agreements/approve")!

--- a/Sources/CorePayments/Networking/Enums/Environment.swift
+++ b/Sources/CorePayments/Networking/Enums/Environment.swift
@@ -23,6 +23,16 @@ public enum Environment {
         }
     }
     
+    /// URL used to display Vault w/o Purchase experience in web browser
+    public var vaultCheckoutURL: URL {
+        switch self {
+        case .sandbox:
+            return URL(string: "https://sandbox.paypal.com/agreements/approve")!
+        case .live:
+            return URL(string: "https://paypal.com/agreements/approve")!
+        }
+    }
+    
     public var toString: String {
         switch self {
         case .sandbox:

--- a/Sources/PayPalWebPayments/PayPalVaultRequest.swift
+++ b/Sources/PayPalWebPayments/PayPalVaultRequest.swift
@@ -4,7 +4,7 @@ import Foundation
 public struct PayPalVaultRequest {
 
     /// PayPal approval URL returned as the `href` from the setup token API call
-    public let url: URL
+    public let url: URL? = nil
 
     /// ID for the setup token associated with the vault
     /// Returned as  top level `id` from the setup token API call
@@ -14,8 +14,14 @@ public struct PayPalVaultRequest {
     /// - Parameters:
     ///    - url: PayPal approval URL returned as the `href` from the setup token API call
     ///    - setupTokenID: An ID for the setup token associated with the vault
+    @available(*, deprecated, message: "Use `init(setupTokenID:)` instead.")
     public init(url: URL, setupTokenID: String) {
-        self.url = url
+        self.setupTokenID = setupTokenID
+    }
+    
+    /// Creates an instance of a PayPal vault request
+    /// - Parameter setupTokenID: An ID for the setup token associated with the vault
+    public init(setupTokenID: String) {
         self.setupTokenID = setupTokenID
     }
 }

--- a/Sources/PayPalWebPayments/PayPalVaultRequest.swift
+++ b/Sources/PayPalWebPayments/PayPalVaultRequest.swift
@@ -3,8 +3,8 @@ import Foundation
 /// A request to vault a PayPal payment method
 public struct PayPalVaultRequest {
 
-    /// PayPal approval URL returned as the `href` from the setup token API call
     // NEXT_MAJOR_VERSION: - Remove URL property
+    /// PayPal approval URL returned as the `href` from the setup token API call
     public let url: URL? = nil
 
     /// ID for the setup token associated with the vault

--- a/Sources/PayPalWebPayments/PayPalVaultRequest.swift
+++ b/Sources/PayPalWebPayments/PayPalVaultRequest.swift
@@ -4,6 +4,7 @@ import Foundation
 public struct PayPalVaultRequest {
 
     /// PayPal approval URL returned as the `href` from the setup token API call
+    // NEXT_MAJOR_VERSION: - Remove URL property
     public let url: URL? = nil
 
     /// ID for the setup token associated with the vault

--- a/Sources/PayPalWebPayments/PayPalWebCheckoutClient.swift
+++ b/Sources/PayPalWebPayments/PayPalWebCheckoutClient.swift
@@ -105,7 +105,7 @@ public class PayPalWebCheckoutClient: NSObject {
         analyticsService = AnalyticsService(coreConfig: config, setupToken: vaultRequest.setupTokenID)
         analyticsService?.sendEvent("paypal-web-payments:vault-wo-purchase:started")
         
-        var vaultURLComponents = URLComponents(url: config.environment.vaultCheckoutURL, resolvingAgainstBaseURL: false)
+        var vaultURLComponents = URLComponents(url: config.environment.paypalVaultCheckoutURL, resolvingAgainstBaseURL: false)
         let queryItems = [URLQueryItem(name: "approval_session_id", value: vaultRequest.setupTokenID)]
         vaultURLComponents?.queryItems = queryItems
         

--- a/Sources/PayPalWebPayments/PayPalWebCheckoutClient.swift
+++ b/Sources/PayPalWebPayments/PayPalWebCheckoutClient.swift
@@ -105,8 +105,17 @@ public class PayPalWebCheckoutClient: NSObject {
         analyticsService = AnalyticsService(coreConfig: config, setupToken: vaultRequest.setupTokenID)
         analyticsService?.sendEvent("paypal-web-payments:vault-wo-purchase:started")
         
+        var vaultURLComponents = URLComponents(url: config.environment.vaultCheckoutURL, resolvingAgainstBaseURL: false)
+        let queryItems = [URLQueryItem(name: "approval_session_id", value: vaultRequest.setupTokenID)]
+        vaultURLComponents?.queryItems = queryItems
+        
+        guard let vaultCheckoutURL = vaultURLComponents?.url else {
+            notifyVaultFailure(with: PayPalWebCheckoutClientError.payPalURLError)
+            return
+        }
+        
         webAuthenticationSession.start(
-            url: vaultRequest.url,
+            url: vaultCheckoutURL,
             context: self,
             sessionDidDisplay: { [weak self] didDisplay in
                 if didDisplay {

--- a/UnitTests/PayPalWebPaymentsTests/PayPalWebCheckoutClient_Tests.swift
+++ b/UnitTests/PayPalWebPaymentsTests/PayPalWebCheckoutClient_Tests.swift
@@ -24,13 +24,33 @@ class PayPalClient_Tests: XCTestCase {
         )
     }
     
+    func testVault_whenSandbox_launchesCorrectURLInWebSession() {
+        let vaultRequest = PayPalVaultRequest(setupTokenID: "fake-token")
+        payPalClient.vault(vaultRequest)
+        
+        XCTAssertEqual(mockWebAuthenticationSession.lastLaunchedURL?.absoluteString, "https://sandbox.paypal.com/agreements/approve?approval_session_id=fake-token")
+    }
+    
+    func testVault_whenLive_launchesCorrectURLInWebSession() {
+        config = CoreConfig(clientID: "testClientID", environment: .live)
+        let payPalClient = PayPalWebCheckoutClient(
+            config: config,
+            networkingClient: mockNetworkingClient,
+            webAuthenticationSession: mockWebAuthenticationSession
+        )
+        
+        let vaultRequest = PayPalVaultRequest(setupTokenID: "fake-token")
+        payPalClient.vault(vaultRequest)
+        
+        XCTAssertEqual(mockWebAuthenticationSession.lastLaunchedURL?.absoluteString, "https://paypal.com/agreements/approve?approval_session_id=fake-token")
+    }
+    
     func testVault_whenSuccessUrl_ReturnsVaultToken() {
 
         mockWebAuthenticationSession.cannedResponseURL = URL(string: "sdk.ios.paypal://vault/success?approval_token_id=fakeTokenID&approval_session_id=fakeSessionID")
 
         let expectation = expectation(description: "vault(url:) completed")
 
-        let url = URL(string: "https://sandbox.paypal.com/vault")
         let expectedTokenIDResult = "fakeTokenID"
         let expectedSessionIDResult = "fakeSessionID"
         let mockVaultDelegate = MockPayPalVaultDelegate(success: {_, result in
@@ -41,7 +61,7 @@ class PayPalClient_Tests: XCTestCase {
             XCTFail("Invoked error() callback. Should invoke success().")
         })
         payPalClient.vaultDelegate = mockVaultDelegate
-        let vaultRequest = PayPalVaultRequest(url: url!, setupTokenID: "fakeTokenID")
+        let vaultRequest = PayPalVaultRequest(setupTokenID: "fakeTokenID")
         payPalClient.vault(vaultRequest)
 
         waitForExpectations(timeout: 10)
@@ -56,7 +76,6 @@ class PayPalClient_Tests: XCTestCase {
 
         let expectation = expectation(description: "vault(url:) completed")
 
-        let url = URL(string: "https://sandbox.paypal.com/vault")
         let mockVaultDelegate = MockPayPalVaultDelegate(success: {_, _ in
             XCTFail("Invoked success callback. Should invoke cancel().")
         }, error: {_, _ in
@@ -66,7 +85,7 @@ class PayPalClient_Tests: XCTestCase {
             expectation.fulfill()
         })
         payPalClient.vaultDelegate = mockVaultDelegate
-        let vaultRequest = PayPalVaultRequest(url: url!, setupTokenID: "fakeTokenID")
+        let vaultRequest = PayPalVaultRequest(setupTokenID: "fakeTokenID")
         payPalClient.vault(vaultRequest)
 
         waitForExpectations(timeout: 10)
@@ -83,7 +102,6 @@ class PayPalClient_Tests: XCTestCase {
 
         let expectation = expectation(description: "vault(url:) completed")
 
-        let url = URL(string: "https://sandbox.paypal.com/vault")
         let mockVaultDelegate = MockPayPalVaultDelegate(success: {_, _ in
             XCTFail("Invoked success callback. Should invoke error().")
         }, error: {_, vaultError in
@@ -93,7 +111,7 @@ class PayPalClient_Tests: XCTestCase {
             XCTFail("Invoked cancel callback. Should invoke error().")
         })
         payPalClient.vaultDelegate = mockVaultDelegate
-        let vaultRequest = PayPalVaultRequest(url: url!, setupTokenID: "fakeTokenID")
+        let vaultRequest = PayPalVaultRequest(setupTokenID: "fakeTokenID")
         payPalClient.vault(vaultRequest)
 
         waitForExpectations(timeout: 10)
@@ -105,7 +123,6 @@ class PayPalClient_Tests: XCTestCase {
 
         let expectation = expectation(description: "vault(url:) completed")
 
-        let url = URL(string: "https://sandbox.paypal.com/vault")
         let expectedError = CoreSDKError(
             code: PayPalWebCheckoutClientError.payPalVaultResponseError.code,
             domain: PayPalWebCheckoutClientError.domain,
@@ -119,7 +136,7 @@ class PayPalClient_Tests: XCTestCase {
             expectation.fulfill()
         })
         payPalClient.vaultDelegate = mockVaultDelegate
-        let vaultRequest = PayPalVaultRequest(url: url!, setupTokenID: "fakeTokenID")
+        let vaultRequest = PayPalVaultRequest(setupTokenID: "fakeTokenID")
         payPalClient.vault(vaultRequest)
 
         waitForExpectations(timeout: 10)

--- a/UnitTests/TestShared/MockWebAuthenticationSession.swift
+++ b/UnitTests/TestShared/MockWebAuthenticationSession.swift
@@ -7,6 +7,7 @@ class MockWebAuthenticationSession: WebAuthenticationSession {
     var cannedResponseURL: URL?
     var cannedErrorResponse: Error?
     var cannedDidDisplayResult = true
+    var lastLaunchedURL: URL? = nil
 
     override func start(
         url: URL,
@@ -14,6 +15,7 @@ class MockWebAuthenticationSession: WebAuthenticationSession {
         sessionDidDisplay: @escaping (Bool) -> Void,
         sessionDidComplete: @escaping (URL?, Error?) -> Void
     ) {
+        lastLaunchedURL = url
         sessionDidDisplay(cannedDidDisplayResult)
         sessionDidComplete(cannedResponseURL, cannedErrorResponse)
     }

--- a/UnitTests/TestShared/MockWebAuthenticationSession.swift
+++ b/UnitTests/TestShared/MockWebAuthenticationSession.swift
@@ -7,7 +7,7 @@ class MockWebAuthenticationSession: WebAuthenticationSession {
     var cannedResponseURL: URL?
     var cannedErrorResponse: Error?
     var cannedDidDisplayResult = true
-    var lastLaunchedURL: URL? = nil
+    var lastLaunchedURL: URL?
 
     override func start(
         url: URL,


### PR DESCRIPTION
### Reason for changes

DTMOBILES-680

- Currently, a merchant has to provide the SDK a URL to launch for the PP Vault w/o Purchase flow. This is not a great dev-ex since the SDK should provide more value and know which URL to launch.
- The JS SDK hard codes the URLs to launch for this experience, so the mobile SDKs can follow suit.

### Summary of changes

- Deprecate `PayPalVaultRequest.init(url:setupTokenID:)`
- Add `PayPalVaultRequest.init(setupTokenID:)`
- Add logic to SDK to construct vault w/o purchase URL itself

### Checklist

- [X] Added a changelog entry

### Authors
@scannillo 