### PR TITLE
Bug fix for live graphQL url

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,9 +2,10 @@
 # PayPal iOS SDK Release Notes
 
 ## unreleased
-* PayPalWebPayments
-  * Deprecate `PayPalVaultRequest(url:setupTokenID:)`
-  * Add `PayPalVaultRequest(setupTokenID:)`
+* Breaking Changes
+  * PayPalWebPayments
+    * Deprecate `PayPalVaultRequest(url:setupTokenID:)`
+    * Add `PayPalVaultRequest(setupTokenID:)`
 * CorePayments
   * Bug fix for live graphQL url
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,10 +2,9 @@
 # PayPal iOS SDK Release Notes
 
 ## unreleased
-* Breaking Changes
-  * PayPalWebPayments
-    * Deprecate `PayPalVaultRequest(url:setupTokenID:)`
-    * Add `PayPalVaultRequest(setupTokenID:)`
+* PayPalWebPayments
+  * Deprecate `PayPalVaultRequest(url:setupTokenID:)`
+  * Add `PayPalVaultRequest(setupTokenID:)`
 * CorePayments
   * Bug fix for live graphQL url
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,8 @@
 * PayPalWebPayments
   * Deprecate `PayPalVaultRequest(url:setupTokenID:)`
   * Add `PayPalVaultRequest(setupTokenID:)`
+* CorePayments
+  * Bug fix for live graphQL url
 
 ## 1.4.0 (2024-07-09)
 * PayPalNativePayments (DEPRECATED)  

--- a/Sources/CorePayments/Networking/Enums/Environment.swift
+++ b/Sources/CorePayments/Networking/Enums/Environment.swift
@@ -19,7 +19,7 @@ public enum Environment {
         case .sandbox:
             return URL(string: "https://www.sandbox.paypal.com/graphql")!
         case .live:
-            return URL(string: "https://paypal.com/graphql")!
+            return URL(string: "https://www.paypal.com/graphql")!
         }
     }
     

--- a/UnitTests/PaymentsCoreTests/NetworkingClient_Tests.swift
+++ b/UnitTests/PaymentsCoreTests/NetworkingClient_Tests.swift
@@ -109,7 +109,7 @@ class NetworkingClient_Tests: XCTestCase {
         let fakeGraphQLRequest = GraphQLRequest(query: "fake-query", variables: FakeRequest(fakeParam: "fake-param"))
         
         _ = try await sut.fetch(request: fakeGraphQLRequest)
-        XCTAssertEqual(mockHTTP.capturedHTTPRequest?.url.absoluteString, "https://paypal.com/graphql")
+        XCTAssertEqual(mockHTTP.capturedHTTPRequest?.url.absoluteString, "https://www.paypal.com/graphql")
     }
     
     func testFetchGraphQL_whenSandbox_usesProperPayPalURL() async throws {


### PR DESCRIPTION
### Summary of changes

-  Explicit `www.` in prod graphql url for updating setup token for cards vault without purchase flow.

### Checklist

- [x] Added a changelog entry

### Authors
> List GitHub usernames for everyone who contributed to this pull request.

- @KunJeongPark 