### PR TITLE
Make PayPalError and CardError Code enum consistent with error naming pattern

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,7 +16,9 @@
       * Add `vault(vaultRequest:) async throws -> PayPalVaultResult`
       * Add `.checkoutCanceled` and `.vaultCanceled` to `PayPalWebCheckoutClientError`
       * Rename `PayPalWebCheckoutClientError` to `PayPalError`
+      * Add `.checkoutCanceledError` and `vaultCanceledError` to `PayPalError`
       * Add public static functions `isCheckoutCanceled(Error)` and `isVaultCanceled(Error)` to `PayPalError` to distinguish cancellation errors in PayPal flows. 
+      * Make `PayPalError` public to expose cancellation error handling helpers
   * CardPayments
     * Replace delegate pattern with completion handlers and Swift concurrency
       * Remove `CardDelegate` and `CardVaultDelegate`
@@ -27,16 +29,13 @@
       * Add `approveOrder(request:) async throws -> CardResult`
       * Add `vault(vaultRequest:) async throws -> CardVaultResult`   
       * Add `.threeDSecureCanceled` to `CardClientError` 
-      * Rename `PayPalClientError` to `PayPalError`
-      * Add public static function `isThreeDSecureCanceled(Error)` to `CardClientError` to distinguish cancellation error from threeDSecure verification
+      * Rename `CardClientError` to `CardError`
+      * Add `threeDSecureCanceledError` to `CardError`
+      * Add public static function `isThreeDSecureCanceled(Error)` to `CardError` to distinguish cancellation error from threeDSecure verification
+      * Make `CardError` public to expose cancellation error handling helper
 * PayPalWebPayments
   * Deprecate `PayPalVaultRequest(url:setupTokenID:)`
   * Add `PayPalVaultRequest(setupTokenID:)`
-  * Add new error types for cancellation handling:
-    * `PayPalWebCheckoutClientError.payPalCancellationError`
-    * `PayPalWebCheckoutClientError.payPalVaultCancellationError`
-* CardPayments
-  * Add new error type `CardClientError.threeDSecureCancellation` for handling 3DS cancellation
 
 ## 1.4.0 (2024-07-09)
 * PayPalNativePayments (DEPRECATED)  

--- a/Sources/CardPayments/CardClient.swift
+++ b/Sources/CardPayments/CardClient.swift
@@ -170,7 +170,7 @@ public class CardClient: NSObject {
                 if let error = error {
                     switch error {
                     case ASWebAuthenticationSessionError.canceledLogin:
-                        self.notifyCheckoutCancelWithError(with: CardError.threeDSecureCanceled, completion: completion)
+                        self.notifyCheckoutCancelWithError(with: CardError.threeDSecureCanceledError, completion: completion)
                         return
                     default:
                         self.notifyCheckoutFailure(with: CardError.threeDSecureError(error), completion: completion)
@@ -210,7 +210,7 @@ public class CardClient: NSObject {
                 if let error = error {
                     switch error {
                     case ASWebAuthenticationSessionError.canceledLogin:
-                        self.notifyVaultCancelWithError(with: CardError.threeDSecureCanceled, completion: completion)
+                        self.notifyVaultCancelWithError(with: CardError.threeDSecureCanceledError, completion: completion)
                         return
                     default:
                         self.notifyVaultFailure(with: CardError.threeDSecureError(error), completion: completion)

--- a/Sources/CardPayments/CardError.swift
+++ b/Sources/CardPayments/CardError.swift
@@ -39,7 +39,7 @@ public enum CardError {
         case malformedDeeplinkURLError
 
         /// 10. Cancellation from 3DS verification
-        case threeDSCancellationError
+        case threeDSecureCanceledError
     }
 
     static let unknownError = CoreSDKError(
@@ -68,8 +68,8 @@ public enum CardError {
         errorDescription: "An invalid 3DS URL was returned. Contact developer.paypal.com/support."
     )
 
-    static let threeDSecureCanceled = CoreSDKError(
-        code: Code.threeDSCancellationError.rawValue,
+    static let threeDSecureCanceledError = CoreSDKError(
+        code: Code.threeDSecureCanceledError.rawValue,
         domain: domain,
         errorDescription: "3DS verification has been canceled by the user."
     )
@@ -97,6 +97,6 @@ public enum CardError {
         guard let error = error as? CoreSDKError else {
             return false
         }
-        return error.domain == CardError.domain && error.code == CardError.threeDSecureCanceled.code
+        return error.domain == CardError.domain && error.code == CardError.threeDSecureCanceledError.code
     }
 }

--- a/Sources/PayPalWebPayments/PayPalError.swift
+++ b/Sources/PayPalWebPayments/PayPalError.swift
@@ -24,11 +24,11 @@ public enum PayPalError {
         /// 4. Vault result did not return a token id
         case payPalVaultResponseError
 
-        /// 5. Websession is cancelled by the user
-        case payPalCancellationError
+        /// 5. Checkout websession is cancelled by the user
+        case checkoutCanceledError
 
-        /// 6. Websession is cancelled by the user
-        case payPalVaultCancellationError
+        /// 6. Vault websession is cancelled by the user
+        case vaultCanceledError
     }
 
     static let webSessionError: (Error) -> CoreSDKError = { error in
@@ -57,14 +57,14 @@ public enum PayPalError {
         errorDescription: "Error parsing PayPal vault response"
     )
 
-    static let checkoutCanceled = CoreSDKError(
-        code: Code.payPalCancellationError.rawValue,
+    static let checkoutCanceledError = CoreSDKError(
+        code: Code.checkoutCanceledError.rawValue,
         domain: domain,
         errorDescription: "PayPal checkout has been canceled by the user"
     )
 
-    static let vaultCanceled = CoreSDKError(
-        code: Code.payPalVaultCancellationError.rawValue,
+    static let vaultCanceledError = CoreSDKError(
+        code: Code.vaultCanceledError.rawValue,
         domain: domain,
         errorDescription: "PayPal vault has been canceled by the user"
     )
@@ -74,7 +74,7 @@ public enum PayPalError {
         guard let error = error as? CoreSDKError else {
             return false
         }
-        return error.domain == PayPalError.domain && error.code == PayPalError.checkoutCanceled.code
+        return error.domain == PayPalError.domain && error.code == PayPalError.checkoutCanceledError.code
     }
 
     // Helper function that allows handling of PayPal vault cancel errors separately without having to cast the error to CoreSDKError and checking code and domain properties.
@@ -82,6 +82,6 @@ public enum PayPalError {
         guard let error = error as? CoreSDKError else {
             return false
         }
-        return error.domain == PayPalError.domain && error.code == PayPalError.vaultCanceled.code
+        return error.domain == PayPalError.domain && error.code == PayPalError.vaultCanceledError.code
     }
 }

--- a/Sources/PayPalWebPayments/PayPalWebCheckoutClient.swift
+++ b/Sources/PayPalWebPayments/PayPalWebCheckoutClient.swift
@@ -64,7 +64,7 @@ public class PayPalWebCheckoutClient: NSObject {
                     switch error {
                     case ASWebAuthenticationSessionError.canceledLogin:
                         self.notifyCheckoutCancelWithError(
-                            with: PayPalError.checkoutCanceled,
+                            with: PayPalError.checkoutCanceledError,
                             completion: completion
                         )
                         return
@@ -153,7 +153,7 @@ public class PayPalWebCheckoutClient: NSObject {
                     switch error {
                     case ASWebAuthenticationSessionError.canceledLogin:
                         self.notifyVaultCancelWithError(
-                            with: PayPalError.vaultCanceled,
+                            with: PayPalError.vaultCanceledError,
                             completion: completion
                         )
                         return

--- a/UnitTests/CardPaymentsTests/CardClient_Tests.swift
+++ b/UnitTests/CardPaymentsTests/CardClient_Tests.swift
@@ -204,8 +204,8 @@ class CardClient_Tests: XCTestCase {
             XCTAssertNil(result)
             if let error {
                 XCTAssertEqual(error.domain, CardError.domain)
-                XCTAssertEqual(error.code, CardError.Code.threeDSCancellationError.rawValue)
-                XCTAssertEqual(error.localizedDescription, CardError.threeDSecureCanceled.localizedDescription)
+                XCTAssertEqual(error.code, CardError.Code.threeDSecureCanceledError.rawValue)
+                XCTAssertEqual(error.localizedDescription, CardError.threeDSecureCanceledError.localizedDescription)
             } else {
                 XCTFail("Expected error not to be nil")
             }
@@ -364,8 +364,8 @@ class CardClient_Tests: XCTestCase {
             XCTAssertNil(result)
             if let error = error {
                 XCTAssertEqual(error.domain, CardError.domain)
-                XCTAssertEqual(error.code, CardError.threeDSecureCanceled.code)
-                XCTAssertEqual(error.localizedDescription, CardError.threeDSecureCanceled.localizedDescription)
+                XCTAssertEqual(error.code, CardError.threeDSecureCanceledError.code)
+                XCTAssertEqual(error.localizedDescription, CardError.threeDSecureCanceledError.localizedDescription)
             } else {
                 XCTFail("Expected error")
             }

--- a/UnitTests/PayPalWebPaymentsTests/PayPalWebCheckoutClient_Tests.swift
+++ b/UnitTests/PayPalWebPaymentsTests/PayPalWebCheckoutClient_Tests.swift
@@ -79,7 +79,7 @@ class PayPalClient_Tests: XCTestCase {
             XCTAssertNil(result)
             if let error {
                 XCTAssertEqual(error.domain, PayPalError.domain)
-                XCTAssertEqual(error.code, PayPalError.Code.payPalVaultCancellationError.rawValue)
+                XCTAssertEqual(error.code, PayPalError.Code.vaultCanceledError.rawValue)
                 XCTAssertEqual(error.localizedDescription, "PayPal vault has been canceled by the user")
             } else {
                 XCTFail("Expected error not to be nil")
@@ -182,8 +182,8 @@ class PayPalClient_Tests: XCTestCase {
             XCTAssertNil(result)
             if let error {
                 XCTAssertEqual(error.domain, PayPalError.domain)
-                XCTAssertEqual(error.code, PayPalError.checkoutCanceled.code)
-                XCTAssertEqual(error.localizedDescription, PayPalError.checkoutCanceled.localizedDescription)
+                XCTAssertEqual(error.code, PayPalError.checkoutCanceledError.code)
+                XCTAssertEqual(error.localizedDescription, PayPalError.checkoutCanceledError.localizedDescription)
             } else {
                 XCTFail("Expected error not to be nil")
             }


### PR DESCRIPTION
### Summary of changes

- Make PayPalError and CardError Code enum consistent with error naming pattern
- Changelog entries

### Checklist

- [x] Added a changelog entry

### Authors
> List GitHub usernames for everyone who contributed to this pull request.

- @KunJeongPark 