### PR TITLE
Make CoreSDKError Equatable

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,11 +5,11 @@
 * CorePayments
   * Make `CoreSDKError` conform to Equatable
   * Rename `NetworkingClientError` to `NetworkingError`
-  * Make `NetworkingError` and static constants public
+  * Make `NetworkingError` enum and static constants public
 * CardPayments
-  * Make `CardError` static constants public
+  * Make `CardError` enum and static constants public
 * PayPalPayments
-  * Make `PayPalError` static constants public
+  * Make `PayPalError` enum and static constants public
 
 ## 2.0.0-beta1 (2024-11-20)
 * Breaking Changes

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,16 @@
 
 # PayPal iOS SDK Release Notes
 
+## unreleased
+* CorePayments
+  * Make `CoreSDKError` conform to Equatable
+  * Rename `NetworkingClientError` to `NetworkingError`
+  * Make `NetworkingError` and static constants public
+* CardPayments
+  * Make `CardError` static constants public
+* PayPalPayments
+  * Make `PayPalError` static constants public
+
 ## 2.0.0-beta1 (2024-11-20)
 * Breaking Changes
   * PayPalNativePayments

--- a/Demo/Demo/SwiftUIComponents/PayPalWebPayments/PayPalWebViewModel.swift
+++ b/Demo/Demo/SwiftUIComponents/PayPalWebPayments/PayPalWebViewModel.swift
@@ -73,7 +73,7 @@ class PayPalWebViewModel: ObservableObject {
                     let payPalRequest = PayPalWebCheckoutRequest(orderID: orderID, fundingSource: funding)
                     payPalWebCheckoutClient.start(request: payPalRequest) { result, error in
                         if let error {
-                            if PayPalError.isCheckoutCanceled(error) {
+                            if error == PayPalError.checkoutCanceledError {
                                 print("Canceled")
                                 self.updateState(.idle)
                             } else {

--- a/Demo/Demo/ViewModels/CardPaymentViewModel.swift
+++ b/Demo/Demo/ViewModels/CardPaymentViewModel.swift
@@ -123,7 +123,7 @@ class CardPaymentViewModel: ObservableObject {
                     if error == CardError.threeDSecureCanceledError {
                         self.setApprovalCancelResult()
                     } else {
-                        self.setApprovalFailureResult(vaultError: error)
+                        self.setApprovalFailureResult(error: error)
                     }
                 } else if let result {
                     self.setApprovalSuccessResult(
@@ -136,7 +136,7 @@ class CardPaymentViewModel: ObservableObject {
                 }
             }
         } catch {
-            setApprovalFailureResult(vaultError: error)
+            setApprovalFailureResult(error: error)
             print("failed in checkout with card. \(error.localizedDescription)")
         }
     }
@@ -149,9 +149,9 @@ class CardPaymentViewModel: ObservableObject {
         }
     }
 
-    func setApprovalFailureResult(vaultError: Error) {
+    func setApprovalFailureResult(error: Error) {
         DispatchQueue.main.async {
-            self.state.approveResultResponse = .error(message: vaultError.localizedDescription)
+            self.state.approveResultResponse = .error(message: error.localizedDescription)
         }
     }
 

--- a/Demo/Demo/ViewModels/CardPaymentViewModel.swift
+++ b/Demo/Demo/ViewModels/CardPaymentViewModel.swift
@@ -120,7 +120,7 @@ class CardPaymentViewModel: ObservableObject {
             let cardRequest = CardRequest(orderID: orderID, card: card, sca: sca)
             cardClient?.approveOrder(request: cardRequest) { result, error in
                 if let error {
-                    if CardError.isThreeDSecureCanceled(error) {
+                    if error == CardError.threeDSecureCanceledError {
                         self.setApprovalCancelResult()
                     } else {
                         self.setApprovalFailureResult(vaultError: error)

--- a/Demo/Demo/ViewModels/CardVaultViewModel.swift
+++ b/Demo/Demo/ViewModels/CardVaultViewModel.swift
@@ -47,7 +47,7 @@ class CardVaultViewModel: VaultViewModel {
                     )
                 )
             } else if let vaultError {
-                if CardError.isThreeDSecureCanceled(vaultError) {
+                if let error = vaultError as? CoreSDKError, error == CardError.threeDSecureCanceledError {
                     print("Canceled")
                     self.state.updateSetupTokenResponse = .idle
                 } else {

--- a/Demo/Demo/ViewModels/PayPalVaultViewModel.swift
+++ b/Demo/Demo/ViewModels/PayPalVaultViewModel.swift
@@ -16,7 +16,7 @@ class PayPalVaultViewModel: VaultViewModel {
             let vaultRequest = PayPalVaultRequest(setupTokenID: setupTokenID)
             paypalClient.vault(vaultRequest) { result, error in
                 if let error {
-                    if PayPalError.isVaultCanceled(error) {
+                    if error == PayPalError.vaultCanceledError {
                         DispatchQueue.main.async {
                             print("Canceled")
                             self.state.paypalVaultTokenResponse = .idle

--- a/PayPal.xcodeproj/project.pbxproj
+++ b/PayPal.xcodeproj/project.pbxproj
@@ -110,7 +110,7 @@
 		BEA100E726EF9EDA0036A6A5 /* NetworkingClient.swift in Sources */ = {isa = PBXBuildFile; fileRef = BEA100E626EF9EDA0036A6A5 /* NetworkingClient.swift */; };
 		BEA100EC26EFA7790036A6A5 /* HTTPMethod.swift in Sources */ = {isa = PBXBuildFile; fileRef = BEA100EB26EFA7790036A6A5 /* HTTPMethod.swift */; };
 		BEA100EE26EFA7990036A6A5 /* HTTPHeader.swift in Sources */ = {isa = PBXBuildFile; fileRef = BEA100ED26EFA7990036A6A5 /* HTTPHeader.swift */; };
-		BEA100F026EFA7C20036A6A5 /* NetworkingClientError.swift in Sources */ = {isa = PBXBuildFile; fileRef = BEA100EF26EFA7C20036A6A5 /* NetworkingClientError.swift */; };
+		BEA100F026EFA7C20036A6A5 /* NetworkingError.swift in Sources */ = {isa = PBXBuildFile; fileRef = BEA100EF26EFA7C20036A6A5 /* NetworkingError.swift */; };
 		BEA100F226EFA7DE0036A6A5 /* Environment.swift in Sources */ = {isa = PBXBuildFile; fileRef = BEA100F126EFA7DE0036A6A5 /* Environment.swift */; };
 		CB16E6D8285B7A2B00FD6F52 /* FakeConfirmPaymentResponse.swift in Sources */ = {isa = PBXBuildFile; fileRef = CB16E6D7285B7A2B00FD6F52 /* FakeConfirmPaymentResponse.swift */; };
 		CB1A47F22820AFED00BD8184 /* PayPalPayLaterButton.swift in Sources */ = {isa = PBXBuildFile; fileRef = CB1A47F12820AFED00BD8184 /* PayPalPayLaterButton.swift */; };
@@ -275,7 +275,7 @@
 		BEA100E626EF9EDA0036A6A5 /* NetworkingClient.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = NetworkingClient.swift; sourceTree = "<group>"; };
 		BEA100EB26EFA7790036A6A5 /* HTTPMethod.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = HTTPMethod.swift; sourceTree = "<group>"; };
 		BEA100ED26EFA7990036A6A5 /* HTTPHeader.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = HTTPHeader.swift; sourceTree = "<group>"; };
-		BEA100EF26EFA7C20036A6A5 /* NetworkingClientError.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NetworkingClientError.swift; sourceTree = "<group>"; };
+		BEA100EF26EFA7C20036A6A5 /* NetworkingError.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NetworkingError.swift; sourceTree = "<group>"; };
 		BEA100F126EFA7DE0036A6A5 /* Environment.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Environment.swift; sourceTree = "<group>"; };
 		BEDB7FE32788AB8E00CEA554 /* Coordinator.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Coordinator.swift; sourceTree = "<group>"; };
 		BEF3FF1627AC5DF3006B4B69 /* Coordinator_Tests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Coordinator_Tests.swift; sourceTree = "<group>"; };
@@ -663,7 +663,7 @@
 				80E643822A1EBBD2008FD705 /* HTTPResponse.swift */,
 				80E2FDC22A8354AD0045593D /* RESTRequest.swift */,
 				807BF58E2A2A5D19002F32B3 /* HTTPResponseParser.swift */,
-				BEA100EF26EFA7C20036A6A5 /* NetworkingClientError.swift */,
+				BEA100EF26EFA7C20036A6A5 /* NetworkingError.swift */,
 				BC04836E27B2FB3600FA7B46 /* URLSessionProtocol.swift */,
 				BC04837327B2FC7300FA7B46 /* URLSession+URLSessionProtocol.swift */,
 				BEA100EA26EFA7670036A6A5 /* Enums */,
@@ -1165,7 +1165,7 @@
 				CB4BE27E2847EA7D00EA2DD1 /* WebAuthenticationSession.swift in Sources */,
 				80E2FDC12A83535A0045593D /* TrackingEventsAPI.swift in Sources */,
 				BEA100F226EFA7DE0036A6A5 /* Environment.swift in Sources */,
-				BEA100F026EFA7C20036A6A5 /* NetworkingClientError.swift in Sources */,
+				BEA100F026EFA7C20036A6A5 /* NetworkingError.swift in Sources */,
 				804E628629380B04004B9FEF /* AnalyticsService.swift in Sources */,
 				BC04837427B2FC7300FA7B46 /* URLSession+URLSessionProtocol.swift in Sources */,
 				80E2FDC32A8354AD0045593D /* RESTRequest.swift in Sources */,

--- a/Sources/CardPayments/CardError.swift
+++ b/Sources/CardPayments/CardError.swift
@@ -42,19 +42,19 @@ public enum CardError {
         case threeDSecureCanceledError
     }
 
-    static let unknownError = CoreSDKError(
+    public static let unknownError = CoreSDKError(
         code: Code.unknown.rawValue,
         domain: domain,
         errorDescription: "An unknown error has occured. Contact developer.paypal.com/support."
     )
     
-    static let encodingError = CoreSDKError(
+    public static let encodingError = CoreSDKError(
         code: Code.encodingError.rawValue,
         domain: domain,
         errorDescription: "An error occured encoding HTTP request body data. Contact developer.paypal.com/support."
     )
 
-    static let threeDSecureError: (Error) -> CoreSDKError = { error in
+    public static let threeDSecureError: (Error) -> CoreSDKError = { error in
         CoreSDKError(
             code: Code.threeDSecureError.rawValue,
             domain: domain,
@@ -62,13 +62,13 @@ public enum CardError {
         )
     }
     
-    static let threeDSecureURLError = CoreSDKError(
+    public static let threeDSecureURLError = CoreSDKError(
         code: Code.threeDSecureURLError.rawValue,
         domain: domain,
         errorDescription: "An invalid 3DS URL was returned. Contact developer.paypal.com/support."
     )
 
-    static let threeDSecureCanceledError = CoreSDKError(
+    public static let threeDSecureCanceledError = CoreSDKError(
         code: Code.threeDSecureCanceledError.rawValue,
         domain: domain,
         errorDescription: "3DS verification has been canceled by the user."

--- a/Sources/CardPayments/CardError.swift
+++ b/Sources/CardPayments/CardError.swift
@@ -86,7 +86,7 @@ public enum CardError {
         errorDescription: "An error occurred while vaulting a card."
     )
 
-    static let nilGraphQLClientError = CoreSDKError(
+    public static let nilGraphQLClientError = CoreSDKError(
         code: Code.nilGraphQLClientError.rawValue,
         domain: domain,
         errorDescription: "GraphQLClient is unexpectedly nil."

--- a/Sources/CardPayments/CardError.swift
+++ b/Sources/CardPayments/CardError.swift
@@ -74,13 +74,13 @@ public enum CardError {
         errorDescription: "3DS verification has been canceled by the user."
     )
 
-    static let noVaultTokenDataError = CoreSDKError(
+    public static let noVaultTokenDataError = CoreSDKError(
         code: Code.noVaultTokenDataError.rawValue,
         domain: domain,
         errorDescription: "No data was returned from update setup token service."
     )
     
-    static let vaultTokenError = CoreSDKError(
+    public static let vaultTokenError = CoreSDKError(
         code: Code.vaultTokenError.rawValue,
         domain: domain,
         errorDescription: "An error occurred while vaulting a card."

--- a/Sources/CorePayments/CoreSDKError.swift
+++ b/Sources/CorePayments/CoreSDKError.swift
@@ -1,7 +1,7 @@
 import Foundation
 
 /// Error structure that SDK errors conform to
-public struct CoreSDKError: Error, LocalizedError {
+public struct CoreSDKError: Error, LocalizedError, Equatable {
 
     /// The error code.
     public let code: Int?

--- a/Sources/CorePayments/Networking/HTTP.swift
+++ b/Sources/CorePayments/Networking/HTTP.swift
@@ -27,13 +27,13 @@ class HTTP {
         do {
             (data, response) = try await urlSession.performRequest(with: urlRequest)
         } catch _ as URLError {
-            throw NetworkingClientError.urlSessionError
+            throw NetworkingError.urlSessionError
         } catch {
-            throw NetworkingClientError.unknownError
+            throw NetworkingError.unknownError
         }
 
         guard let response = response as? HTTPURLResponse else {
-            throw NetworkingClientError.invalidURLResponseError
+            throw NetworkingError.invalidURLResponseError
         }
         
         return HTTPResponse(status: response.statusCode, body: data)

--- a/Sources/CorePayments/Networking/HTTPResponseParser.swift
+++ b/Sources/CorePayments/Networking/HTTPResponseParser.swift
@@ -16,7 +16,7 @@ public class HTTPResponseParser {
 
     public func parseREST<T: Decodable>(_ httpResponse: HTTPResponse, as type: T.Type) throws -> T {
         guard let data = httpResponse.body else {
-            throw NetworkingClientError.noResponseDataError
+            throw NetworkingError.noResponseDataError
         }
         
         if httpResponse.isSuccessful {
@@ -28,7 +28,7 @@ public class HTTPResponseParser {
     
     public func parseGraphQL<T: Decodable>(_ httpResponse: HTTPResponse, as type: T.Type) throws -> T {
         guard let data = httpResponse.body else {
-            throw NetworkingClientError.noResponseDataError
+            throw NetworkingError.noResponseDataError
         }
         
         if httpResponse.isSuccessful {
@@ -44,14 +44,14 @@ public class HTTPResponseParser {
         do {
             if isGraphQL {
                 guard let data = try decoder.decode(GraphQLHTTPResponse<T>.self, from: data).data else {
-                    throw NetworkingClientError.noGraphQLDataKey
+                    throw NetworkingError.noGraphQLDataKey
                 }
                 return data
             } else {
                 return try decoder.decode(T.self, from: data)
             }
         } catch {
-            throw NetworkingClientError.jsonDecodingError(error.localizedDescription)
+            throw NetworkingError.jsonDecodingError(error.localizedDescription)
         }
     }
     
@@ -59,13 +59,13 @@ public class HTTPResponseParser {
         do {
             if isGraphQL {
                 let errorData = try decoder.decode(GraphQLErrorResponse.self, from: data)
-                throw NetworkingClientError.serverResponseError(errorData.error)
+                throw NetworkingError.serverResponseError(errorData.error)
             } else {
                 let errorData = try decoder.decode(ErrorResponse.self, from: data)
-                throw NetworkingClientError.serverResponseError(errorData.readableDescription)
+                throw NetworkingError.serverResponseError(errorData.readableDescription)
             }
         } catch {
-            throw NetworkingClientError.jsonDecodingError(error.localizedDescription)
+            throw NetworkingError.jsonDecodingError(error.localizedDescription)
         }
     }
 }

--- a/Sources/CorePayments/Networking/NetworkingError.swift
+++ b/Sources/CorePayments/Networking/NetworkingError.swift
@@ -1,9 +1,8 @@
 import Foundation
 
-enum NetworkingClientError {
+public enum NetworkingError {
 
-    // NEXT_MAJOR_VERSION: - Change to "NetworkingClientErrorDomain"
-    static let domain = "APIClientErrorDomain"
+    static let domain = "NetworkingClientErrorDomain"
 
     enum Code: Int {
         /// 0. An unknown error occured.
@@ -31,19 +30,19 @@ enum NetworkingClientError {
         case noGraphQLDataKey
     }
 
-    static let unknownError = CoreSDKError(
+    public static let unknownError = CoreSDKError(
         code: Code.unknown.rawValue,
         domain: domain,
         errorDescription: "An unknown error occured. Contact developer.paypal.com/support."
     )
 
-    static let urlSessionError = CoreSDKError(
+    public static let urlSessionError = CoreSDKError(
         code: Code.urlSessionError.rawValue,
         domain: domain,
         errorDescription: "An error occured during network call. Contact developer.paypal.com/support."
     )
 
-    static let jsonDecodingError: (String) -> CoreSDKError = { description in
+    public static let jsonDecodingError: (String) -> CoreSDKError = { description in
         CoreSDKError(
             code: Code.jsonDecodingError.rawValue,
             domain: domain,
@@ -51,25 +50,25 @@ enum NetworkingClientError {
         )
     }
 
-    static let invalidURLResponseError = CoreSDKError(
+    public static let invalidURLResponseError = CoreSDKError(
         code: Code.invalidURLResponse.rawValue,
         domain: domain,
         errorDescription: "An error occured due to an invalid HTTP response. Contact developer.paypal.com/support."
     )
 
-    static let noResponseDataError = CoreSDKError(
+    public static let noResponseDataError = CoreSDKError(
         code: Code.noResponseData.rawValue,
         domain: domain,
         errorDescription: "An error occured due to missing HTTP response data. Contact developer.paypal.com/support."
     )
 
-    static let invalidURLRequestError = CoreSDKError(
+    public static let invalidURLRequestError = CoreSDKError(
         code: Code.invalidURLRequest.rawValue,
         domain: domain,
         errorDescription: "An error occured constructing an HTTP request. Contact developer.paypal.com/support."
     )
 
-    static let serverResponseError: (String) -> CoreSDKError = { description in
+    public static let serverResponseError: (String) -> CoreSDKError = { description in
         CoreSDKError(
             code: Code.serverResponseError.rawValue,
             domain: domain,
@@ -77,7 +76,7 @@ enum NetworkingClientError {
         )
     }
     
-    static let noGraphQLDataKey = CoreSDKError(
+    public static let noGraphQLDataKey = CoreSDKError(
         code: Code.noGraphQLDataKey.rawValue,
         domain: domain,
         errorDescription: "An error occured due to missing `data` key in GraphQL query response. Contact developer.paypal.com/support."

--- a/Sources/PayPalWebPayments/PayPalError.swift
+++ b/Sources/PayPalWebPayments/PayPalError.swift
@@ -31,7 +31,7 @@ public enum PayPalError {
         case vaultCanceledError
     }
 
-    static let webSessionError: (Error) -> CoreSDKError = { error in
+    public static let webSessionError: (Error) -> CoreSDKError = { error in
         CoreSDKError(
             code: Code.webSessionError.rawValue,
             domain: domain,
@@ -39,31 +39,31 @@ public enum PayPalError {
         )
     }
 
-    static let payPalURLError = CoreSDKError(
+    public static let payPalURLError = CoreSDKError(
         code: Code.payPalURLError.rawValue,
         domain: domain,
         errorDescription: "Error constructing URL for PayPal request."
     )
 
-    static let malformedResultError = CoreSDKError(
+    public static let malformedResultError = CoreSDKError(
         code: Code.malformedResultError.rawValue,
         domain: domain,
         errorDescription: "Result did not contain the expected data."
     )
 
-    static let payPalVaultResponseError = CoreSDKError(
+    public static let payPalVaultResponseError = CoreSDKError(
         code: Code.payPalVaultResponseError.rawValue,
         domain: domain,
         errorDescription: "Error parsing PayPal vault response"
     )
 
-    static let checkoutCanceledError = CoreSDKError(
+    public static let checkoutCanceledError = CoreSDKError(
         code: Code.checkoutCanceledError.rawValue,
         domain: domain,
         errorDescription: "PayPal checkout has been canceled by the user"
     )
 
-    static let vaultCanceledError = CoreSDKError(
+    public static let vaultCanceledError = CoreSDKError(
         code: Code.vaultCanceledError.rawValue,
         domain: domain,
         errorDescription: "PayPal vault has been canceled by the user"

--- a/UnitTests/PaymentsCoreTests/HTTPResponseParser_Tests.swift
+++ b/UnitTests/PaymentsCoreTests/HTTPResponseParser_Tests.swift
@@ -19,7 +19,7 @@ class HTTPResponseParser_Tests: XCTestCase {
         } catch {
             let error = error as! CoreSDKError
             XCTAssertEqual(error.localizedDescription, "An error occured due to missing HTTP response data. Contact developer.paypal.com/support.")
-            XCTAssertEqual(error.domain, NetworkingClientError.domain)
+            XCTAssertEqual(error.domain, NetworkingError.domain)
         }
     }
     
@@ -64,7 +64,7 @@ class HTTPResponseParser_Tests: XCTestCase {
         } catch {
             let error = error as! CoreSDKError
             XCTAssertEqual(error.localizedDescription, "fake-error-name: fake-message")
-            XCTAssertEqual(error.domain, NetworkingClientError.domain)
+            XCTAssertEqual(error.domain, NetworkingError.domain)
         }
     }
     
@@ -79,7 +79,7 @@ class HTTPResponseParser_Tests: XCTestCase {
         } catch {
             let error = error as! CoreSDKError
             XCTAssertEqual(error.localizedDescription, "An error occured due to missing HTTP response data. Contact developer.paypal.com/support.")
-            XCTAssertEqual(error.domain, NetworkingClientError.domain)
+            XCTAssertEqual(error.domain, NetworkingError.domain)
         }
     }
     
@@ -105,7 +105,7 @@ class HTTPResponseParser_Tests: XCTestCase {
         } catch {
             let error = error as! CoreSDKError
             XCTAssertEqual(error.localizedDescription, "An error occured due to missing `data` key in GraphQL query response. Contact developer.paypal.com/support.")
-            XCTAssertEqual(error.domain, NetworkingClientError.domain)
+            XCTAssertEqual(error.domain, NetworkingError.domain)
         }
     }
     
@@ -138,7 +138,7 @@ class HTTPResponseParser_Tests: XCTestCase {
         } catch {
             let error = error as! CoreSDKError
             XCTAssertEqual(error.localizedDescription, "fake-error-description")
-            XCTAssertEqual(error.domain, NetworkingClientError.domain)
+            XCTAssertEqual(error.domain, NetworkingError.domain)
         }
     }
 }

--- a/UnitTests/PaymentsCoreTests/HTTP_Tests.swift
+++ b/UnitTests/PaymentsCoreTests/HTTP_Tests.swift
@@ -58,8 +58,8 @@ class HTTP_Tests: XCTestCase {
             _ = try await sut.performRequest(fakeHTTPRequest)
             XCTFail("Request succeeded. Expected error.")
         } catch let error as CoreSDKError {
-            XCTAssertEqual(error.domain, NetworkingClientError.domain)
-            XCTAssertEqual(error.code, NetworkingClientError.Code.urlSessionError.rawValue)
+            XCTAssertEqual(error.domain, NetworkingError.domain)
+            XCTAssertEqual(error.code, NetworkingError.Code.urlSessionError.rawValue)
             XCTAssertEqual(error.localizedDescription, "An error occured during network call. Contact developer.paypal.com/support.")
         } catch {
             XCTFail("Unexpected error type")
@@ -73,8 +73,8 @@ class HTTP_Tests: XCTestCase {
             _ = try await sut.performRequest(fakeHTTPRequest)
             XCTFail("Request succeeded. Expected error.")
         } catch let error as CoreSDKError {
-            XCTAssertEqual(error.domain, NetworkingClientError.domain)
-            XCTAssertEqual(error.code, NetworkingClientError.Code.invalidURLResponse.rawValue)
+            XCTAssertEqual(error.domain, NetworkingError.domain)
+            XCTAssertEqual(error.code, NetworkingError.Code.invalidURLResponse.rawValue)
             XCTAssertEqual(error.localizedDescription, "An error occured due to an invalid HTTP response. Contact developer.paypal.com/support.")
         } catch {
             XCTFail("Unexpected error type")

--- a/v2_MIGRATION_GUIDE.md
+++ b/v2_MIGRATION_GUIDE.md
@@ -5,6 +5,10 @@ This guide helps you migrate your code from version 1.x or 2.0.0-beta1 to 2.0.0-
 ## Overview
 Version 2.0 of the SDK transitions from delgate-based flows to completion handler-based flows. This change simplifies the integration and provides better compatibility with modern async/await patterns.
 
+### Error Handling in the SDK
+This SDK uses `CoreSDKError` as its unified error type across all operations. All errors returned by the SDK, whether from card payments, PayPal flows, or networking operations, are instances of `CoreSDKError`.
+This allows for consistent error handling across different payment methods and operations.
+
 ### Key Changes
 
 ### Important Change: Cancellation Handling
@@ -45,15 +49,19 @@ Using Completion Handlers
 cardClient.vault(request) { result, error in
    if let error {
    // You can now use the public error enums directly
-   switch error {
-   case CardError.threeDSecureCanceledError:
-   // Handle 3DS cancellation
-   case NetworkingError.urlSessionError:
-   // Handle netowrk error
-   default:
-   // Handle other errors
-   }
- }
+      switch error {
+      case CardError.threeDSecureCanceledError:
+      // Handle 3DS cancellation
+      case NetworkingError.urlSessionError:
+      // Handle netowrk error
+      default:
+      // Handle other errors
+    }
+    return
+  }
+  if let result {
+    // Handle success
+  }
 }
 ```
 
@@ -95,7 +103,7 @@ do {
 ### Best Practices 
 - Take advantage of `Equatable` for simpler error comparisons
 - Use the public error enum properties for better code clarity and type safety
-- The helper methods CardError.isThreeDSecureCanceled(Error), PayPalError.isCheckoutCanceled(Error), PayPalError.isVaultCanceled(Error) are still available and are particularly useful if you only need to handle specific cases like cancellation and want to avoid casting to CoreSDKError in catch blocks:
+- The helper methods `CardError.isThreeDSecureCanceled(Error)`, `PayPalError.isCheckoutCanceled(Error)`, `PayPalError.isVaultCanceled(Error)` are still available and are particularly useful if you only need to handle specific cases like cancellation and want to avoid casting to CoreSDKError in catch blocks:
 
 ```swift
 // If you only care about handling cancellation, this might be simpler:

--- a/v2_MIGRATION_GUIDE.md
+++ b/v2_MIGRATION_GUIDE.md
@@ -43,8 +43,7 @@ Using Completion Handlers
 ```swift
 // Completion handlers return CoreSDKError, so no casting is needed in completion blocks
 cardClient.vault(request) { result, error in
-   guard let error = error else { return }
-   
+   if let error {
    // You can now use the public error enums directly
    switch error {
    case CardError.threeDSecureCanceledError:
@@ -54,6 +53,7 @@ cardClient.vault(request) { result, error in
    default:
    // Handle other errors
    }
+ }
 }
 ```
 

--- a/v2_MIGRATION_GUIDE.md
+++ b/v2_MIGRATION_GUIDE.md
@@ -1,4 +1,6 @@
-# Migrating from Delegates to Completion Handlers
+# Migrating Guide to 2.0.0-beta2
+
+This guide helps you migrade your code from version 1.x or 2.0.0-beta1 to 2.0.0-beta2.
 
 ## Overview
 Version 2.0 of the SDK transitions from delgate-based flows to completion handler-based flows. This change simplifies the integration and provides better compatibility with modern async/await patterns.
@@ -6,11 +8,109 @@ Version 2.0 of the SDK transitions from delgate-based flows to completion handle
 ### Key Changes
 
 ### Important Change: Cancellation Handling
-In v2.0, cancellations (e.g., 3DS cancellations, PayPal web flow cancellations) are now returned as errors rather than as separate delegate methods. There are new helper static functions, to help you discern threeDSecure cancellation errors and PayPal web flow cancellation errors. 
-- `CardError.threeDSecureCanceled(Error)` will return true for 3DS cancellation errors received during card payment or card vaulting flows. 
-- `PayPalError.isCheckoutCanceled(Error)` will return true for user cancellation during PayPalWebCheckout session.
-- `PayPalError.isVaultCanceled(Error)` will return true for user cancellation during PayPal vault session.
+In v2.0, cancellations (e.g., 3DS cancellations, PayPal web flow cancellations) are now returned as errors rather than as separate delegate methods. 
 
+### What's New in 2.0.0-beta2
+- The `CoreSDKError` is now equatable, enabling direct comparison of errors:
+```swift
+// Now possible in 2.0.0-beta2
+  if error == CardError.threeDSecureCanceledError {
+     // Handle 3DS Cancellation
+  }
+  
+// Instead of checking properties individually before and helper function in 2.0.0-beta1
+```
+
+- Public Access to Domain-Specific Error Enums: 
+Previously internal error enums like `CardError` and `NetworkingError` are now public, along with their static properties that return `CoreSDKError` instances. This provides better discoverability and type safety when working with specific error cases.
+```swift
+public enum CardError {
+  public static let threeDSecureCanceledError: CoreSDKError
+  public static let encodingError: CoreSDKError
+  //...other error constants
+}
+
+public enum NetworkingError {
+  public static let urlSessionError: CoreSDKError
+  public static let serverResponseError: (String) -> CoreSDKError
+  //...other error constants
+}
+```
+
+- Error Handling Examples
+
+Using Completion Handlers
+```swift
+// Completion handlers return CoreSDKError, so no casting is needed in completion blocks
+cardClient.vault(request) { result, error in
+   guard let error = error else { return }
+   
+   // You can now use the public error enums directly
+   switch error {
+   case CardError.threeDSecureCanceledError:
+   // Handle 3DS cancellation
+   case NetworkingError.urlSessionError:
+   // Handle netowrk error
+   default:
+   // Handle other errors
+   }
+}
+```
+
+Using Async/Await
+```swift
+do {
+      let result = cardClient.vault(request)
+      // handle success
+   } catch let error as CoreSDKError {
+      // Make sure to cast to CoreSDKError when using try-catch
+      switch error {
+      case CardError.threeDSecureCanceledError:
+      // Handle 3DS cancellation
+      case NetworkingError.urlSessionError:
+      // Handle netowrk error
+      default:
+      // Handle other errors
+      }
+  } catch {
+     // Handle unexpected errors
+  }  
+  
+  // Alternative approach using if-else
+  do {
+     let result = try await cardClient.vault(request)
+     // Handle success
+     } catch let error as CoreSDKError {
+        if error == CardError.threeDSecureCanceledError {
+         // Handle 3DS Cancellation
+        } else {
+         // Handle other CoreSDKErrors
+        }
+     } catch {
+       // Handle unexpected errors
+     }
+  }
+```
+
+### Best Practices 
+- Take advantage of `Equatable` for simpler error comparisons
+- Use the public error enum properties for better code clarity and type safety
+- The helper methods CardError.isThreeDSecureCanceled(Error), PayPalError.isCheckoutCanceled(Error), PayPalError.isVaultCanceled(Error) are still available and are particularly useful if you only need to handle specific cases like cancellation and want to avoid casting to CoreSDKError in catch blocks:
+
+```swift
+// If you only care about handling cancellation, this might be simpler:
+  do {
+     let result = try await cardClient.vault(request)
+     // Handle success
+    } catch {
+       if CardError.isThreeDSecureCanceled(error) {
+        // Handle cancellation
+       } else {
+        // Handle other errors
+       }
+    }
+```
+ 
 ### CardClient Changes
 
 ```swift
@@ -41,12 +141,7 @@ class MyViewController {
         let cardClient = CardClient(config: config)
         cardClient.approveOrder(request: cardRequest) { [weak self] result, error in
             if let error = error {
-                // if threeDSecure is canceled by user
-                if CardError.isThreeDSecureCanceled(error) {
-                // handle cancel error
-                } else {
-                // handle other errors
-                }
+                // handle errors
                 return
              }
             if let result = result {
@@ -87,12 +182,7 @@ class MyViewController {
         let payPalClient = PayPalWebCheckoutClient(config: config)
         payPalClient.start(request: paypalRequest) { [weak self] result, error in
             if let error = error {
-                // if PayPal webflow is canceled by user
-                if PayPalError.isCheckoutCanceled(error) {
-                // handle cancel error
-                } else {
-                // handle all other errors
-                }
+                // handle errors
                 return
             }
             if let result = result {

--- a/v2_MIGRATION_GUIDE.md
+++ b/v2_MIGRATION_GUIDE.md
@@ -1,6 +1,6 @@
 # Migrating Guide to 2.0.0-beta2
 
-This guide helps you migrade your code from version 1.x or 2.0.0-beta1 to 2.0.0-beta2.
+This guide helps you migrate your code from version 1.x or 2.0.0-beta1 to 2.0.0-beta2.
 
 ## Overview
 Version 2.0 of the SDK transitions from delgate-based flows to completion handler-based flows. This change simplifies the integration and provides better compatibility with modern async/await patterns.


### PR DESCRIPTION
### Summary of changes

- Make `CoreSDKError` Equatable and make static constants in `CardError` and `PayPalError` public so merchants can do this:
```
if let error {
  if error == CardError.threeDSecureCanceledError {
      // handle cancel case
   } else {
    // handle other errors 
 }

```
### Checklist

- [x] Added a changelog entry

### Authors
> List GitHub usernames for everyone who contributed to this pull request.

- @KunJeongPark 