### PR TITLE
[DTPPMOBILE-143] Deprecate Delegation Methods in Paypal SDK

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -34,4 +34,5 @@ jobs:
         run: cd SampleApps/SPMTest && swift package resolve
       - name: Build & archive SPMTest
         run: xcodebuild -project 'SampleApps/SPMTest/SPMTest.xcodeproj' -scheme 'SPMTest' clean build archive CODE_SIGNING_ALLOWED=NO
+        run: pod lib lint --allow-warnings="deprecated"
 

--- a/.github/workflows/swiftlint.yml
+++ b/.github/workflows/swiftlint.yml
@@ -16,3 +16,5 @@ jobs:
         run: brew install swiftlint
       - name: Run SwiftLint
         run: swiftlint --strict
+disabled_rules:
+  - deprecated_syntax

--- a/Sources/CardPayments/CardClient.swift
+++ b/Sources/CardPayments/CardClient.swift
@@ -43,6 +43,7 @@ public class CardClient: NSObject {
     /// If `didAttempt3DSecureVerification` is `true`, check verification status with `/v3/vault/setup-token/{id}` in your server.
     /// - Parameters:
     ///   - vaultRequest: The request containing setupTokenID and card
+    @available(*, deprecated, message: "This method is deprecated and will be removed in a future release. Use the new completion handler-based approach instead.")
     public func vault(_ vaultRequest: CardVaultRequest) {
         analyticsService = AnalyticsService(coreConfig: config, setupToken: vaultRequest.setupTokenID)
         analyticsService?.sendEvent("card-payments:vault-wo-purchase:started")
@@ -75,6 +76,7 @@ public class CardClient: NSObject {
     /// - Parameters:
     ///   - orderId: Order id for approval
     ///   - request: The request containing the card
+    @available(*, deprecated, message: "This method is deprecated and will be removed in a future release. Use the new completion handler-based approach instead.")
     public func approveOrder(request: CardRequest) {
         analyticsService = AnalyticsService(coreConfig: config, orderID: request.orderID)
         analyticsService?.sendEvent("card-payments:3ds:started")

--- a/Sources/CardPayments/CardClient.swift
+++ b/Sources/CardPayments/CardClient.swift
@@ -43,7 +43,7 @@ public class CardClient: NSObject {
     /// If `didAttempt3DSecureVerification` is `true`, check verification status with `/v3/vault/setup-token/{id}` in your server.
     /// - Parameters:
     ///   - vaultRequest: The request containing setupTokenID and card
-    @available(*, deprecated, message: "This method is deprecated and will be removed in a future release. Use the new completion handler-based approach instead.")
+    @available(*, deprecated, message: "This method is deprecated and will be removed in version 2.0.0. Please use the new completion handler-based approach instead. For more details, visit the v2 migration guide: https://github.com/paypal/paypal-ios/")
     public func vault(_ vaultRequest: CardVaultRequest) {
         analyticsService = AnalyticsService(coreConfig: config, setupToken: vaultRequest.setupTokenID)
         analyticsService?.sendEvent("card-payments:vault-wo-purchase:started")

--- a/Sources/CardPayments/CardClient.swift
+++ b/Sources/CardPayments/CardClient.swift
@@ -76,7 +76,7 @@ public class CardClient: NSObject {
     /// - Parameters:
     ///   - orderId: Order id for approval
     ///   - request: The request containing the card
-    @available(*, deprecated, message: "This method is deprecated and will be removed in a future release. Use the new completion handler-based approach instead.")
+    @available(*, deprecated, message: "This method is deprecated and will be removed in version 2.0.0. Please use the new completion handler-based approach instead. For more details, visit the v2 migration guide: https://github.com/paypal/paypal-ios/")
     public func approveOrder(request: CardRequest) {
         analyticsService = AnalyticsService(coreConfig: config, orderID: request.orderID)
         analyticsService?.sendEvent("card-payments:3ds:started")

--- a/Sources/CardPayments/CardClientError.swift
+++ b/Sources/CardPayments/CardClientError.swift
@@ -3,6 +3,7 @@ import Foundation
 import CorePayments
 #endif
 
+@available(*, deprecated, renamed: "CardError")
 enum CardClientError {
 
     static let domain = "CardClientErrorDomain"

--- a/Sources/CardPayments/CardDelegate.swift
+++ b/Sources/CardPayments/CardDelegate.swift
@@ -4,6 +4,7 @@ import CorePayments
 #endif
 
 /// Card delegate to handle events from CardClient
+@available(*, deprecated, message: "This protocol is deprecated and will be removed in a future release. Use the new completion handler-based approach instead.")
 public protocol CardDelegate: AnyObject {
 
     /// Notify that the Card flow finished with a successful result

--- a/Sources/CardPayments/CardDelegate.swift
+++ b/Sources/CardPayments/CardDelegate.swift
@@ -4,7 +4,7 @@ import CorePayments
 #endif
 
 /// Card delegate to handle events from CardClient
-@available(*, deprecated, message: "This protocol is deprecated and will be removed in a future release. Use the new completion handler-based approach instead.")
+@available(*, deprecated, message: "This protocol is deprecated and will be removed in version 2.0.0. Please use the new completion handler-based approach instead. For more details, visit the v2 migration guide: https://github.com/paypal/paypal-ios/")
 public protocol CardDelegate: AnyObject {
 
     /// Notify that the Card flow finished with a successful result

--- a/Sources/CardPayments/CardVaultDelegate.swift
+++ b/Sources/CardPayments/CardVaultDelegate.swift
@@ -4,7 +4,7 @@ import CorePayments
 #endif
 
 /// CardVault delegate to handle events from CardClient
-@available(*, deprecated, message: "This protocol is deprecated and will be removed in a future release. Use the new completion handler-based approach instead.")
+@available(*, deprecated, message: "This protocol is deprecated and will be removed in version 2.0.0. Please use the new completion handler-based approach instead. For more details, visit the v2 migration guide: https://github.com/paypal/paypal-ios/")
 public protocol CardVaultDelegate: AnyObject {
     
     /// Notify that the Card vault flow finished with a successful result

--- a/Sources/CardPayments/CardVaultDelegate.swift
+++ b/Sources/CardPayments/CardVaultDelegate.swift
@@ -4,6 +4,7 @@ import CorePayments
 #endif
 
 /// CardVault delegate to handle events from CardClient
+@available(*, deprecated, message: "This protocol is deprecated and will be removed in a future release. Use the new completion handler-based approach instead.")
 public protocol CardVaultDelegate: AnyObject {
     
     /// Notify that the Card vault flow finished with a successful result

--- a/Sources/PayPalWebPayments/PayPalVaultDelegate.swift
+++ b/Sources/PayPalWebPayments/PayPalVaultDelegate.swift
@@ -4,7 +4,7 @@ import CorePayments
 #endif
 
 /// PayPalVault delegate to vault results from PayPalWebCheckoutClient
-@available(*, deprecated, message: "This protocol is deprecated and will be removed in a future release. Use the new completion handler-based approach instead.")
+@available(*, deprecated, message: "This protocol is deprecated and will be removed in version 2.0.0. Please use the new completion handler-based approach instead. For more details, visit the v2 migration guide: https://github.com/paypal/paypal-ios/")
 public protocol PayPalVaultDelegate: AnyObject {
 
     /// Notify that the PayPal vault flow finished with a successful result

--- a/Sources/PayPalWebPayments/PayPalVaultDelegate.swift
+++ b/Sources/PayPalWebPayments/PayPalVaultDelegate.swift
@@ -4,6 +4,7 @@ import CorePayments
 #endif
 
 /// PayPalVault delegate to vault results from PayPalWebCheckoutClient
+@available(*, deprecated, message: "This protocol is deprecated and will be removed in a future release. Use the new completion handler-based approach instead.")
 public protocol PayPalVaultDelegate: AnyObject {
 
     /// Notify that the PayPal vault flow finished with a successful result

--- a/Sources/PayPalWebPayments/PayPalWebCheckoutClient.swift
+++ b/Sources/PayPalWebPayments/PayPalWebCheckoutClient.swift
@@ -32,7 +32,7 @@ public class PayPalWebCheckoutClient: NSObject {
     /// Launch the PayPal web flow
     /// - Parameters:
     ///   - request: the PayPalRequest for the transaction
-    @available(*, deprecated, message: "This method is deprecated and will be removed in a future release. Use the new completion handler-based approach instead.")
+    @available(*, deprecated, message: "This method is deprecated and will be removed in version 2.0.0. Please use the new completion handler-based approach instead. For more details, visit the v2 migration guide: https://github.com/paypal/paypal-ios/")
     public func start(request: PayPalWebCheckoutRequest) {
         analyticsService = AnalyticsService(coreConfig: config, orderID: request.orderID)
         analyticsService?.sendEvent("paypal-web-payments:started")

--- a/Sources/PayPalWebPayments/PayPalWebCheckoutClient.swift
+++ b/Sources/PayPalWebPayments/PayPalWebCheckoutClient.swift
@@ -32,6 +32,7 @@ public class PayPalWebCheckoutClient: NSObject {
     /// Launch the PayPal web flow
     /// - Parameters:
     ///   - request: the PayPalRequest for the transaction
+    @available(*, deprecated, message: "This method is deprecated and will be removed in a future release. Use the new completion handler-based approach instead.")
     public func start(request: PayPalWebCheckoutRequest) {
         analyticsService = AnalyticsService(coreConfig: config, orderID: request.orderID)
         analyticsService?.sendEvent("paypal-web-payments:started")

--- a/Sources/PayPalWebPayments/PayPalWebCheckoutClientError.swift
+++ b/Sources/PayPalWebPayments/PayPalWebCheckoutClientError.swift
@@ -4,6 +4,7 @@ import Foundation
 import CorePayments
 #endif
 
+@available(*, deprecated, renamed: "PayPalError")
 enum PayPalWebCheckoutClientError {
 
     static let domain = "PayPalClientErrorDomain"

--- a/Sources/PayPalWebPayments/PayPalWebCheckoutDelegate.swift
+++ b/Sources/PayPalWebPayments/PayPalWebCheckoutDelegate.swift
@@ -4,7 +4,7 @@ import CorePayments
 #endif
 
 /// PayPal delegate to handle events from PayPalNativeCheckoutClient
-@available(*, deprecated, message: "This protocol is deprecated and will be removed in a future release. Use the new completion handler-based approach instead.")
+@available(*, deprecated, message: "This protocol is deprecated and will be removed in version 2.0.0. Please use the new completion handler-based approach instead. For more details, visit the v2 migration guide: https://github.com/paypal/paypal-ios/")
 public protocol PayPalWebCheckoutDelegate: AnyObject {
 
     /// Notify that the PayPal flow finished with a successful result

--- a/Sources/PayPalWebPayments/PayPalWebCheckoutDelegate.swift
+++ b/Sources/PayPalWebPayments/PayPalWebCheckoutDelegate.swift
@@ -4,6 +4,7 @@ import CorePayments
 #endif
 
 /// PayPal delegate to handle events from PayPalNativeCheckoutClient
+@available(*, deprecated, message: "This protocol is deprecated and will be removed in a future release. Use the new completion handler-based approach instead.")
 public protocol PayPalWebCheckoutDelegate: AnyObject {
 
     /// Notify that the PayPal flow finished with a successful result


### PR DESCRIPTION
### Reason for changes

The PayPal SDK is transitioned from the delegation pattern to the completion handler approach for handling asynchronous operation. We want to mark the existing delegation methods as deprecated in the 1.X to notify merchants about upcoming change. 

### Summary of changes
https://github.com/paypal/paypal-ios/pull/301
I used the migration-merged PR to deprecate all the methods and protocols that have been removed or renamed. 

### Checklist

- [ Deprecating Delegation]
- [ Deprecating Renamed methods] 

### Authors

- @GMALKHA 