### PR TITLE
Silence Font Registration Warning

### DIFF
--- a/Sources/PaymentButtons/PaymentButton.swift
+++ b/Sources/PaymentButtons/PaymentButton.swift
@@ -48,6 +48,7 @@ public class PaymentButton: UIButton {
         self.label = label
         self.analyticsService.sendEvent("payment-button:initialized", buttonType: fundingSource.rawValue)
         super.init(frame: .zero)
+        UIFont.registerFont()
         customizeAppearance()
         self.addTarget(self, action: #selector(onTap), for: .touchUpInside)
     }
@@ -180,7 +181,6 @@ public class PaymentButton: UIButton {
 
     private func configure() {
         translatesAutoresizingMaskIntoConstraints = false
-        UIFont.registerFont()
         configureStackView()
         configureBackgroundColor()
         configurePrefix()

--- a/Sources/PaymentButtons/PaymentButtonFont.swift
+++ b/Sources/PaymentButtons/PaymentButtonFont.swift
@@ -12,6 +12,10 @@ extension UIFont {
         var errorRef: Unmanaged<CFError>?
         let frameworkBundle = Bundle(for: PaymentButton.self)
 
+        guard UIFont(name: name, size: 10.0) == nil else {
+            return
+        }
+
         guard
             let pathForResourceString = frameworkBundle.path(forResource: name, ofType: fileExtension),
             let fontData = NSData(contentsOfFile: pathForResourceString),


### PR DESCRIPTION
### Summary of changes

- Move configure function with PayPal font registration to init function to silence failure to register
   already registered font
- Modify extension to UIFont to return on already registered font

### Checklist

- [ ] Added a changelog entry

### Authors
> List GitHub usernames for everyone who contributed to this pull request.

- @KunJeongPark 