### PR TITLE
Clean up Analytics Names

### DIFF
--- a/Sources/CardPayments/CardClient.swift
+++ b/Sources/CardPayments/CardClient.swift
@@ -99,7 +99,7 @@ public class CardClient: NSObject {
     ///   if it fails, `CardResult will be `nil` and `error` will describe the failure
     public func approveOrder(request: CardRequest, completion: @escaping (CardResult?, CoreSDKError?) -> Void) {
         analyticsService = AnalyticsService(coreConfig: config, orderID: request.orderID)
-        analyticsService?.sendEvent("card-payments:3ds:started")
+        analyticsService?.sendEvent("card-payments:approve-order:started")
         Task {
             do {
                 let result = try await checkoutOrdersAPI.confirmPaymentSource(cardRequest: request)
@@ -113,19 +113,19 @@ public class CardClient: NSObject {
                         return
                     }
                 
-                    analyticsService?.sendEvent("card-payments:3ds:confirm-payment-source:challenge-required")
+                    analyticsService?.sendEvent("card-payments:confirm-payment-source:challenge-required")
                     startThreeDSecureChallenge(url: url, orderId: result.id, completion: completion)
                 } else {
-                    analyticsService?.sendEvent("card-payments:3ds:confirm-payment-source:succeeded")
+                    analyticsService?.sendEvent("card-payments:confirm-payment-source:succeeded")
                     
                     let cardResult = CardResult(orderID: result.id, status: result.status, didAttemptThreeDSecureAuthentication: false)
                     notifyCheckoutSuccess(for: cardResult, completion: completion)
                 }
             } catch let error as CoreSDKError {
-                analyticsService?.sendEvent("card-payments:3ds:confirm-payment-source:failed")
+                analyticsService?.sendEvent("card-payments:confirm-payment-source:failed")
                 notifyCheckoutFailure(with: error, completion: completion)
             } catch {
-                analyticsService?.sendEvent("card-payments:3ds:confirm-payment-source:failed")
+                analyticsService?.sendEvent("card-payments:confirm-payment-source:failed")
                 notifyCheckoutFailure(with: CardError.unknownError, completion: completion)
             }
         }
@@ -225,17 +225,17 @@ public class CardClient: NSObject {
     }
 
     private func notifyCheckoutSuccess(for result: CardResult, completion: (CardResult?, CoreSDKError?) -> Void) {
-        analyticsService?.sendEvent("card-payments:3ds:succeeded")
+        analyticsService?.sendEvent("card-payments:approve-order:succeeded")
         completion(result, nil)
     }
 
     private func notifyCheckoutFailure(with error: CoreSDKError, completion: (CardResult?, CoreSDKError?) -> Void) {
-        analyticsService?.sendEvent("card-payments:3ds:failed")
+        analyticsService?.sendEvent("card-payments:approve-order:failed")
         completion(nil, error)
     }
 
     private func notifyCheckoutCancelWithError(with error: CoreSDKError, completion: (CardResult?, CoreSDKError?) -> Void) {
-        analyticsService?.sendEvent("card-payments:3ds:challenge:user-canceled")
+        analyticsService?.sendEvent("card-payments:approve-order:challenge:user-canceled")
         completion(nil, error)
     }
 

--- a/Sources/CardPayments/CardClient.swift
+++ b/Sources/CardPayments/CardClient.swift
@@ -226,7 +226,7 @@ public class CardClient: NSObject {
     }
 
     private func notify3dsCheckoutSuccess(for result: CardResult, completion: (CardResult?, CoreSDKError?) -> Void) {
-        analyticsService?.sendEvent("card-payments:approve-order:auth-challenge-succeeded")
+        analyticsService?.sendEvent("card-payments:approve-order:auth-challenge:succeeded")
         completion(result, nil)
     }
 
@@ -236,12 +236,12 @@ public class CardClient: NSObject {
     }
 
     private func notify3dsCheckoutFailure(with error: CoreSDKError, completion: (CardResult?, CoreSDKError?) -> Void) {
-        analyticsService?.sendEvent("card-payments:approve-order:auth-challenge-failed")
+        analyticsService?.sendEvent("card-payments:approve-order:auth-challenge:failed")
         completion(nil, error)
     }
 
     private func notify3dsCheckoutCancelWithError(with error: CoreSDKError, completion: (CardResult?, CoreSDKError?) -> Void) {
-        analyticsService?.sendEvent("card-payments:approve-order:auth-challenge-canceled")
+        analyticsService?.sendEvent("card-payments:approve-order:auth-challenge:canceled")
         completion(nil, error)
     }
 
@@ -251,7 +251,7 @@ public class CardClient: NSObject {
     }
 
     private func notify3dsVaultSuccess(for vaultResult: CardVaultResult, completion: (CardVaultResult?, CoreSDKError?) -> Void) {
-        analyticsService?.sendEvent("card-payments:vault-wo-purchase:auth-challenge-succeeded")
+        analyticsService?.sendEvent("card-payments:vault-wo-purchase:auth-challenge:succeeded")
         completion(vaultResult, nil)
     }
 
@@ -261,12 +261,12 @@ public class CardClient: NSObject {
     }
 
     private func notify3dsVaultFailure(with vaultError: CoreSDKError, completion: (CardVaultResult?, CoreSDKError?) -> Void) {
-        analyticsService?.sendEvent("card-payments:vault-wo-purchase:auth-challenge-failed")
+        analyticsService?.sendEvent("card-payments:vault-wo-purchase:auth-challenge:failed")
         completion(nil, vaultError)
     }
 
     private func notify3dsVaultCancelWithError(with vaultError: CoreSDKError, completion: (CardVaultResult?, CoreSDKError?) -> Void) {
-        analyticsService?.sendEvent("card-payments:vault-wo-purchase:auth-challenge-canceled")
+        analyticsService?.sendEvent("card-payments:vault-wo-purchase:auth-challenge:canceled")
         completion(nil, vaultError)
     }
 }

--- a/Sources/CardPayments/CardClient.swift
+++ b/Sources/CardPayments/CardClient.swift
@@ -56,7 +56,7 @@ public class CardClient: NSObject {
                         self.notify3dsVaultFailure(with: CardError.threeDSecureURLError, completion: completion)
                         return
                     }
-                    analyticsService?.sendEvent("card-payments:vault-wo-purchase:challenge-required")
+                    analyticsService?.sendEvent("card-payments:vault-wo-purchase:auth-challenge-required")
                     startVaultThreeDSecureChallenge(url: url, setupTokenID: vaultRequest.setupTokenID, completion: completion)
                 } else {
                     let vaultResult = CardVaultResult(setupTokenID: result.id, status: result.status, didAttemptThreeDSecureAuthentication: false)

--- a/Sources/CardPayments/CardClient.swift
+++ b/Sources/CardPayments/CardClient.swift
@@ -109,23 +109,19 @@ public class CardClient: NSObject {
                     guard getQueryStringParameter(url: url, param: "flow") == "3ds",
                         url.contains("helios"),
                         let url = URL(string: url) else {
-                        self.notifyCheckoutFailure(with: CardError.threeDSecureURLError, completion: completion)
+                        self.notify3dsCheckoutFailure(with: CardError.threeDSecureURLError, completion: completion)
                         return
                     }
                 
-                    analyticsService?.sendEvent("card-payments:confirm-payment-source:challenge-required")
+                    analyticsService?.sendEvent("card-payments:approve-order:auth-challenge-required")
                     startThreeDSecureChallenge(url: url, orderId: result.id, completion: completion)
                 } else {
-                    analyticsService?.sendEvent("card-payments:confirm-payment-source:succeeded")
-                    
                     let cardResult = CardResult(orderID: result.id, status: result.status, didAttemptThreeDSecureAuthentication: false)
                     notifyCheckoutSuccess(for: cardResult, completion: completion)
                 }
             } catch let error as CoreSDKError {
-                analyticsService?.sendEvent("card-payments:confirm-payment-source:failed")
                 notifyCheckoutFailure(with: error, completion: completion)
             } catch {
-                analyticsService?.sendEvent("card-payments:confirm-payment-source:failed")
                 notifyCheckoutFailure(with: CardError.unknownError, completion: completion)
             }
         }
@@ -161,25 +157,25 @@ public class CardClient: NSObject {
             context: self,
             sessionDidDisplay: { [weak self] didDisplay in
                 if didDisplay {
-                    self?.analyticsService?.sendEvent("card-payments:3ds:challenge-presentation:succeeded")
+                    self?.analyticsService?.sendEvent("card-payments:approve-order:challenge-presentation:succeeded")
                 } else {
-                    self?.analyticsService?.sendEvent("card-payments:3ds:challenge-presentation:failed")
+                    self?.analyticsService?.sendEvent("card-payments:approve-order:challenge-presentation:failed")
                 }
             },
             sessionDidComplete: { _, error in
                 if let error = error {
                     switch error {
                     case ASWebAuthenticationSessionError.canceledLogin:
-                        self.notifyCheckoutCancelWithError(with: CardError.threeDSecureCanceledError, completion: completion)
+                        self.notify3dsCheckoutCancelWithError(with: CardError.threeDSecureCanceledError, completion: completion)
                         return
                     default:
-                        self.notifyCheckoutFailure(with: CardError.threeDSecureError(error), completion: completion)
+                        self.notify3dsCheckoutFailure(with: CardError.threeDSecureError(error), completion: completion)
                         return
                     }
                 }
 
                 let cardResult = CardResult(orderID: orderId, status: nil, didAttemptThreeDSecureAuthentication: true)
-                self.notifyCheckoutSuccess(for: cardResult, completion: completion)
+                self.notify3dsCheckoutSuccess(for: cardResult, completion: completion)
             }
         )
     }
@@ -229,13 +225,23 @@ public class CardClient: NSObject {
         completion(result, nil)
     }
 
+    private func notify3dsCheckoutSuccess(for result: CardResult, completion: (CardResult?, CoreSDKError?) -> Void) {
+        analyticsService?.sendEvent("card-payments:approve-order:auth-challenge-succeeded")
+        completion(result, nil)
+    }
+
     private func notifyCheckoutFailure(with error: CoreSDKError, completion: (CardResult?, CoreSDKError?) -> Void) {
         analyticsService?.sendEvent("card-payments:approve-order:failed")
         completion(nil, error)
     }
 
-    private func notifyCheckoutCancelWithError(with error: CoreSDKError, completion: (CardResult?, CoreSDKError?) -> Void) {
-        analyticsService?.sendEvent("card-payments:approve-order:challenge:user-canceled")
+    private func notify3dsCheckoutFailure(with error: CoreSDKError, completion: (CardResult?, CoreSDKError?) -> Void) {
+        analyticsService?.sendEvent("card-payments:approve-order:auth-challenge-failed")
+        completion(nil, error)
+    }
+
+    private func notify3dsCheckoutCancelWithError(with error: CoreSDKError, completion: (CardResult?, CoreSDKError?) -> Void) {
+        analyticsService?.sendEvent("card-payments:approve-order:auth-challenge-canceled")
         completion(nil, error)
     }
 

--- a/Sources/PayPalWebPayments/PayPalWebCheckoutClient.swift
+++ b/Sources/PayPalWebPayments/PayPalWebCheckoutClient.swift
@@ -203,32 +203,32 @@ public class PayPalWebCheckoutClient: NSObject {
     }
 
     private func notifyCheckoutSuccess(for result: PayPalWebCheckoutResult, completion: (PayPalWebCheckoutResult?, CoreSDKError?) -> Void) {
-        self.analyticsService?.sendEvent("paypal-web-payments:checkout:auth-challenge-succeeded")
+        self.analyticsService?.sendEvent("paypal-web-payments:checkout:succeeded")
         completion(result, nil)
     }
 
     private func notifyCheckoutFailure(with error: CoreSDKError, completion: (PayPalWebCheckoutResult?, CoreSDKError?) -> Void) {
-        self.analyticsService?.sendEvent("paypal-web-payments:checkout:auth-challenge-failed")
+        self.analyticsService?.sendEvent("paypal-web-payments:checkout:failed")
         completion(nil, error)
     }
 
     private func notifyCheckoutCancelWithError(with error: CoreSDKError, completion: (PayPalWebCheckoutResult?, CoreSDKError?) -> Void) {
-        analyticsService?.sendEvent("paypal-web-payments:checkout:auth-challenge-canceled")
+        analyticsService?.sendEvent("paypal-web-payments:checkout:canceled")
         completion(nil, error)
     }
 
     private func notifyVaultSuccess(for result: PayPalVaultResult, completion: (PayPalVaultResult?, CoreSDKError?) -> Void) {
-        analyticsService?.sendEvent("paypal-web-payments:vault-wo-purchase:auth-challenge-succeeded")
+        analyticsService?.sendEvent("paypal-web-payments:vault-wo-purchase:succeeded")
         completion(result, nil)
     }
 
     private func notifyVaultFailure(with error: CoreSDKError, completion: (PayPalVaultResult?, CoreSDKError?) -> Void) {
-        analyticsService?.sendEvent("paypal-web-payments:vault-wo-purchase:auth-challenge-failed")
+        analyticsService?.sendEvent("paypal-web-payments:vault-wo-purchase:failed")
         completion(nil, error)
     }
 
     private func notifyVaultCancelWithError(with vaultError: CoreSDKError, completion: (PayPalVaultResult?, CoreSDKError?) -> Void) {
-        analyticsService?.sendEvent("paypal-web-payments:vault-wo-purchase:auth-challenge-canceled")
+        analyticsService?.sendEvent("paypal-web-payments:vault-wo-purchase:canceled")
         completion(nil, vaultError)
     }
 }

--- a/Sources/PayPalWebPayments/PayPalWebCheckoutClient.swift
+++ b/Sources/PayPalWebPayments/PayPalWebCheckoutClient.swift
@@ -143,9 +143,9 @@ public class PayPalWebCheckoutClient: NSObject {
             context: self,
             sessionDidDisplay: { [weak self] didDisplay in
                 if didDisplay {
-                    self?.analyticsService?.sendEvent("paypal-vault:browser-presentation:succeeded")
+                    self?.analyticsService?.sendEvent("paypal-web-payments:vault-wo-purchase:auth-challenge-presentation:succeeded")
                 } else {
-                    self?.analyticsService?.sendEvent("paypal-vault:browser-presentation:failed")
+                    self?.analyticsService?.sendEvent("paypal-web-payments:vault-wo-purchase:auth-challenge-presentation:failed")
                 }
             },
             sessionDidComplete: { url, error in
@@ -218,17 +218,17 @@ public class PayPalWebCheckoutClient: NSObject {
     }
 
     private func notifyVaultSuccess(for result: PayPalVaultResult, completion: (PayPalVaultResult?, CoreSDKError?) -> Void) {
-        analyticsService?.sendEvent("paypal-web-payments:vault-wo-purchase:succeeded")
+        analyticsService?.sendEvent("paypal-web-payments:vault-wo-purchase:auth-challenge-succeeded")
         completion(result, nil)
     }
 
     private func notifyVaultFailure(with error: CoreSDKError, completion: (PayPalVaultResult?, CoreSDKError?) -> Void) {
-        analyticsService?.sendEvent("paypal-web-payments:vault-wo-purchase:failed")
+        analyticsService?.sendEvent("paypal-web-payments:vault-wo-purchase:auth-challenge-failed")
         completion(nil, error)
     }
 
     private func notifyVaultCancelWithError(with vaultError: CoreSDKError, completion: (PayPalVaultResult?, CoreSDKError?) -> Void) {
-        analyticsService?.sendEvent("paypal-web-payments:vault-wo-purchase:canceled")
+        analyticsService?.sendEvent("paypal-web-payments:vault-wo-purchase:auth-challenge-canceled")
         completion(nil, vaultError)
     }
 }

--- a/Sources/PayPalWebPayments/PayPalWebCheckoutClient.swift
+++ b/Sources/PayPalWebPayments/PayPalWebCheckoutClient.swift
@@ -35,8 +35,8 @@ public class PayPalWebCheckoutClient: NSObject {
     ///   if it fails, `PayPalWebCheckoutResult will be `nil` and `error` will describe the failure
     public func start(request: PayPalWebCheckoutRequest, completion: @escaping (PayPalWebCheckoutResult?, CoreSDKError?) -> Void) {
         analyticsService = AnalyticsService(coreConfig: config, orderID: request.orderID)
-        analyticsService?.sendEvent("paypal-web-payments:started")
-        
+        analyticsService?.sendEvent("paypal-web-payments:checkout:started")
+
         let baseURLString = config.environment.payPalBaseURL.absoluteString
         let payPalCheckoutURLString =
             "\(baseURLString)/checkoutnow?token=\(request.orderID)" +
@@ -54,9 +54,9 @@ public class PayPalWebCheckoutClient: NSObject {
             context: self,
             sessionDidDisplay: { [weak self] didDisplay in
                 if didDisplay {
-                    self?.analyticsService?.sendEvent("paypal-web-payments:browser-presentation:succeeded")
+                    self?.analyticsService?.sendEvent("paypal-web-payments:checkout:auth-challenge-presentation:succeeded")
                 } else {
-                    self?.analyticsService?.sendEvent("paypal-web-payments:browser-presentation:failed")
+                    self?.analyticsService?.sendEvent("paypal-web-payments:checkout:auth-challenge-presentation:failed")
                 }
             },
             sessionDidComplete: { url, error in
@@ -203,17 +203,17 @@ public class PayPalWebCheckoutClient: NSObject {
     }
 
     private func notifyCheckoutSuccess(for result: PayPalWebCheckoutResult, completion: (PayPalWebCheckoutResult?, CoreSDKError?) -> Void) {
-        self.analyticsService?.sendEvent("paypal-web-payments:succeeded")
+        self.analyticsService?.sendEvent("paypal-web-payments:checkout:auth-challenge-succeeded")
         completion(result, nil)
     }
 
     private func notifyCheckoutFailure(with error: CoreSDKError, completion: (PayPalWebCheckoutResult?, CoreSDKError?) -> Void) {
-        self.analyticsService?.sendEvent("paypal-web-payments:failed")
+        self.analyticsService?.sendEvent("paypal-web-payments:checkout:auth-challenge-failed")
         completion(nil, error)
     }
 
     private func notifyCheckoutCancelWithError(with error: CoreSDKError, completion: (PayPalWebCheckoutResult?, CoreSDKError?) -> Void) {
-        analyticsService?.sendEvent("paypal-web-payments:browser-login:canceled")
+        analyticsService?.sendEvent("paypal-web-payments:checkout:auth-challenge-canceled")
         completion(nil, error)
     }
 


### PR DESCRIPTION
### Summary of changes

- Some card analytics events had "3ds" labels even when they may not have 3DS contingency
- Use format `<module>: <function>: <event> `
  - For vault function, we are opting for `vo-purchse` instead of just `vault` to distinguish it from vault with purchase flow
- Remove confirm-payment-source success/fail events
- Create separate end events for success/fail for 3ds and non-3ds flows in parity with Android

Changes:

**Card ApproveOrder**:

Removed:
1. remove `card-payments:3ds:confirm-payment-source:succeeded` (was sent for non-3ds flow along with general succeeded event)
2.  remove `card-payments:3ds:confirm-payment-source:failed` (was sent for non-3ds flow along with general failed event)

Added:
1.  Add `card-payments:approve-order:auth-challenge:succeeded` for card approval success with 3ds
2. Add `card-payments:approve-order:auth-challenge:failed` for card approval failure with 3ds

Renamed:
1. `card-payments:3ds:started` => `card-payments:approve-order:started`
2. `card-payments:3ds:confirm-payment-source:challenge-required` ->` card-payments:approve-order:auth-challenge-required`
3.  `card-payments:3ds:failed` (this was previously used for both 3ds and non-3ds final result) -> `card-payments:approve-order:failed`
4.  `card-payments:3ds:succeeded`(this was previously used for both 3ds and non-3ds final result) -> `card-payments:approve-order:succeeded`
5.  `card-payments:approve-order:challenge:user-canceled` =>`card-payments:approve-order:auth-challenge:canceled`
6. `card-payments:3ds:challenge-presentation:succeeded` => `card-payments:approve-order:auth-challenge-presentation:succeeded`
7. `card-payments:3ds:challenge-presentation:failed` => `card-payments:approve-order:auth-challenge-presentation:failed`

**Card Vault:**

Remains same for non-3ds flows:
1. `card-payments:vault-wo-purchase:succeeded`
2. `card-payments:vault-wo-purchase:failed`
3. `card-payments:vault-wo-purchase:started`

Added:
1. `card-payments:vault-wo-purchase:auth-challenge:succeeded` for card vault success with 3ds
2. `card-payments:vault-wo-purchase:auth-challenge:failed` for card vault failure with 3ds

Renamed:
1. `card-payments:3ds:challenge-presentation:challenge-required` => `card-payments:vault-wo-purchase:auth-challenge-required`
3. `card-payments:3ds:challenge-presentation:succeeded` => `card-payments:vault-wo-purchase:auth-challenge-presentation:succeeded`
5. `card-payments:3ds:challenge-presentation:failed` => `card-payments:vault-wo-purchase:auth-challenge-presentation:failed`
6. `card-payments:vault-wo-purchase:challenge:canceled` => `card-payments:vault-wo-purchase:auth-challenge:canceled`



**PayPal Checkout**:

Renamed:
1. `paypal-web-payments:started` => `paypal-web-payments:checkout:started`
2. `paypal-web-payments:browser-presentation:succeeded` => `paypal-web-payments:checkout:auth-challenge-presentation:succeeded`
3. `paypal-web-payments:browser-presentation:failed` => `paypal-web-payments:checkout:auth-challenge-presentation:failed`
4. `paypal-web-payments:succeeded` => `paypal-web-payments:checkout:succeeded`
5. `paypal-web-payments:failed` => `paypal-web-payments:checkout:failed`
7. `paypal-web-payments:browser-login:canceled` => `paypal-web-payments:checkout:canceled`

**PayPal Vault**:

Remains same:
1. `paypal-web-payments:vault-wo-purchase:started`

Renamed:
1. `paypal-vault:browser-presentation:succeeded` => `paypal-web-payments:vault-wo-purchase:auth-challenge-presentation:succeeded`
2. `paypal-web-payments:browser-presentation:failed` => `paypal-web-payments:vault-wo-purchase:auth-challenge-presentation:failed`
3. `paypal-web-payments:vault-wo-purchase:succeeded` => `paypal-web-payments:vault-wo-purchase:succeeded`
4. `paypal-web-payments:vault-wo-purchase:failed` => `paypal-web-payments:vault-wo-purchase:failed`
5. `paypal-web-payments:vault-wo-purchase:canceled` => `paypal-web-payments:vault-wo-purchase:canceled`

Main changes are having consistent analytic names across iOS and Android and separate success/fail end events for 3ds and non-3ds flows.

This is a draft as result of discussion with @sshropshire  on cleaning up and coordinating iOS and Android analytic events 

### Checklist

~- [ ] Added a changelog entry~

### Authors
> List GitHub usernames for everyone who contributed to this pull request.

- @KunJeongPark 