### PR TITLE
Return Result type instead of tuple of optionals

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,17 @@
 
 # PayPal iOS SDK Release Notes
 
+## Unreleased
+* Breaking Changes
+  * PayPalWebPayments
+    * Update completion handler types to use `Result` instead of optional tuples
+      * Change `start` completion from `(PayPalWebCheckoutResult?, CoreSDKError?)` to `Result<PayPalWebCheckoutResult, CoreSDKError>`
+      * Change `vault` completion from `(PayPalVaultResult?, CoreSDKError?)` to `Result<PayPalVaultResult, CoreSDKError>`
+  * CardPayments
+    * Update completion handler types to use `Result` instead of optional tuples
+      * Change `approveOrder` completion from `(CardResult?, CoreSDKError?)` to `Result<CardResult, CoreSDKError>`
+      * Change `vault` completion from `(CardVaultResult?, CoreSDKError?)` to `Result<CardVaultResult, CoreSDKError>`
+      
 ## 2.0.0-beta2 (2024-12-11)
 * CorePayments
   * Make `CoreSDKError` conform to Equatable

--- a/Demo/Demo/CardPayments/CardPaymentViewModel/CardPaymentViewModel.swift
+++ b/Demo/Demo/CardPayments/CardPaymentViewModel/CardPaymentViewModel.swift
@@ -118,21 +118,22 @@ class CardPaymentViewModel: ObservableObject {
             cardClient = CardClient(config: config)
             payPalDataCollector = PayPalDataCollector(config: config)
             let cardRequest = CardRequest(orderID: orderID, card: card, sca: sca)
-            cardClient?.approveOrder(request: cardRequest) { result, error in
-                if let error {
+            cardClient?.approveOrder(request: cardRequest) { result in
+                switch result {
+                case .success(let cardResult):
+                    self.setApprovalSuccessResult(
+                        approveResult: CardPaymentState.CardResult(
+                            id: cardResult.orderID,
+                            status: cardResult.status,
+                            didAttemptThreeDSecureAuthentication: cardResult.didAttemptThreeDSecureAuthentication
+                        )
+                    )
+                case .failure(let error):
                     if error == CardError.threeDSecureCanceledError {
                         self.setApprovalCancelResult()
                     } else {
                         self.setApprovalFailureResult(error: error)
                     }
-                } else if let result {
-                    self.setApprovalSuccessResult(
-                        approveResult: CardPaymentState.CardResult(
-                            id: result.orderID,
-                            status: result.status,
-                            didAttemptThreeDSecureAuthentication: result.didAttemptThreeDSecureAuthentication
-                        )
-                    )
                 }
             }
         } catch {

--- a/Demo/Demo/CardVault/CardVaultViewModel/CardVaultViewModel.swift
+++ b/Demo/Demo/CardVault/CardVaultViewModel/CardVaultViewModel.swift
@@ -14,10 +14,11 @@ class CardVaultViewModel: VaultViewModel {
             let config = try await configManager.getCoreConfig()
             let cardClient = CardClient(config: config)
             let cardVaultRequest = CardVaultRequest(card: card, setupTokenID: setupToken)
-            cardClient.vault(cardVaultRequest) { result, error in
-                if let result {
-                    self.setUpdateSetupTokenResult(vaultResult: result, vaultError: nil)
-                } else if let error {
+            cardClient.vault(cardVaultRequest) { result in
+                switch result {
+                case .success(let cardVaultResult):
+                    self.setUpdateSetupTokenResult(vaultResult: cardVaultResult, vaultError: nil)
+                case .failure(let error):
                     self.setUpdateSetupTokenResult(vaultResult: nil, vaultError: error)
                 }
             }

--- a/Demo/Demo/PayPalVault/PayPalVaultViewModel/PayPalVaultViewModel.swift
+++ b/Demo/Demo/PayPalVault/PayPalVaultViewModel/PayPalVaultViewModel.swift
@@ -14,8 +14,13 @@ class PayPalVaultViewModel: VaultViewModel {
             let config = try await configManager.getCoreConfig()
             let paypalClient = PayPalWebCheckoutClient(config: config)
             let vaultRequest = PayPalVaultRequest(setupTokenID: setupTokenID)
-            paypalClient.vault(vaultRequest) { result, error in
-                if let error {
+            paypalClient.vault(vaultRequest) { result in
+                switch result {
+                case .success(let cardVaultResult):
+                    DispatchQueue.main.async {
+                        self.state.paypalVaultTokenResponse = .loaded(cardVaultResult)
+                    }
+                case .failure(let error):
                     if error == PayPalError.vaultCanceledError {
                         DispatchQueue.main.async {
                             print("Canceled")
@@ -25,10 +30,6 @@ class PayPalVaultViewModel: VaultViewModel {
                         DispatchQueue.main.async {
                             self.state.paypalVaultTokenResponse = .error(message: error.localizedDescription)
                         }
-                    }
-                } else if let result {
-                    DispatchQueue.main.async {
-                        self.state.paypalVaultTokenResponse = .loaded(result)
                     }
                 }
             }

--- a/Sources/CardPayments/CardClient.swift
+++ b/Sources/CardPayments/CardClient.swift
@@ -41,8 +41,12 @@ public class CardClient: NSObject {
     /// - Parameters:
     ///   - vaultRequest: The request containing setupTokenID and card
     ///   - completion: A completion block that is invoked when the request is completed. If the request succeeds,
-    ///   a  `Result` type with `.success(CardVaultResult)` with `setupTokenID` and `status` are returned;
-    ///   if it fails, `Result` type with `.failure(CoreSDKError)` that describes the failure will be returned
+    ///                 The closure returns a `Result`:
+    ///                 - `.success(CardVaultResult)` containing:
+    ///                   - `setupTokenID`: The ID of the token that was updated.
+    ///                   - `status`: The setup token status.
+    ///                   - `didAttemptThreeDSecureAuthentication`: A flag indicating if 3D Secure authentication was attempted.
+    ///                 - `.failure(CoreSDKError)`: Describes the reason for failure.
     public func vault(_ vaultRequest: CardVaultRequest, completion: @escaping (Result<CardVaultResult, CoreSDKError>) -> Void) {
         analyticsService = AnalyticsService(coreConfig: config, setupToken: vaultRequest.setupTokenID)
         analyticsService?.sendEvent("card-payments:vault-wo-purchase:started")
@@ -95,9 +99,13 @@ public class CardClient: NSObject {
     /// - Parameters:
     ///   - orderId: Order id for approval
     ///   - request: The request containing the card
-    ///   - completion: A completion block that is invoked when the request is completed. If the request succeeds,
-    ///   a  `Result` type will be returned with `.success(CardResult)` with `orderID` , `status` and `didAttemptThreeDSecureAuthentication`;
-    ///   if it fails, `Result` type with `.failure(CoreSDKError)` that describes the failure will be returned
+    ///   - completion: A completion block that is invoked when the request is completed.
+    ///                 The closure returns a `Result`:
+    ///                 - `.success(CardResult)` containing:
+    ///                   - `orderID`: The ID of the approved order.
+    ///                   - `status`: The approval status.
+    ///                   - `didAttemptThreeDSecureAuthentication`: A flag indicating if 3D Secure authentication was attempted.
+    ///                 - `.failure(CoreSDKError)`: Describes the reason for failure.
     public func approveOrder(request: CardRequest, completion: @escaping (Result<CardResult, CoreSDKError>) -> Void) {
         analyticsService = AnalyticsService(coreConfig: config, orderID: request.orderID)
         analyticsService?.sendEvent("card-payments:approve-order:started")

--- a/Sources/PayPalWebPayments/PayPalWebCheckoutClient.swift
+++ b/Sources/PayPalWebPayments/PayPalWebCheckoutClient.swift
@@ -34,7 +34,7 @@ public class PayPalWebCheckoutClient: NSObject {
     ///                 The closure returns a `Result`:
     ///                 - `.success(PayPalCheckoutResult)` containing:
     ///                   - `orderID`: The ID of the approved order.
-    ///                   - `payerID`: Payer ID (or user id associated with the transaction
+    ///                   - `payerID`: Payer ID (or user id) associated with the transaction
     ///                 - `.failure(CoreSDKError)`: Describes the reason for failure.
     public func start(request: PayPalWebCheckoutRequest, completion: @escaping (Result<PayPalWebCheckoutResult, CoreSDKError>) -> Void) {
         analyticsService = AnalyticsService(coreConfig: config, orderID: request.orderID)

--- a/Sources/PayPalWebPayments/PayPalWebCheckoutClient.swift
+++ b/Sources/PayPalWebPayments/PayPalWebCheckoutClient.swift
@@ -30,10 +30,13 @@ public class PayPalWebCheckoutClient: NSObject {
     /// Launch the PayPal web flow
     /// - Parameters:
     ///   - request: the PayPalRequest for the transaction
-    ///   - completion: A completion block that is invoked when the request is completed. If the request succeeds,
-    ///   a `PayPalWebCheckoutResult` with `orderID` and `payerID` are returned and `error` will be `nil`;
-    ///   if it fails, `PayPalWebCheckoutResult will be `nil` and `error` will describe the failure
-    public func start(request: PayPalWebCheckoutRequest, completion: @escaping (PayPalWebCheckoutResult?, CoreSDKError?) -> Void) {
+    ///   - completion: A completion block that is invoked when the request is completed.
+    ///                 The closure returns a `Result`:
+    ///                 - `.success(CardResult)` containing:
+    ///                   - `orderID`: The ID of the approved order.
+    ///                   - `payerID`: Payer ID (or user id associated with the transaction
+    ///                 - `.failure(CoreSDKError)`: Describes the reason for failure.
+    public func start(request: PayPalWebCheckoutRequest, completion: @escaping (Result<PayPalWebCheckoutResult, CoreSDKError>) -> Void) {
         analyticsService = AnalyticsService(coreConfig: config, orderID: request.orderID)
         analyticsService?.sendEvent("paypal-web-payments:checkout:started")
 
@@ -95,11 +98,12 @@ public class PayPalWebCheckoutClient: NSObject {
     /// - Throws: A `CoreSDKError` describing the failure
     public func start(request: PayPalWebCheckoutRequest) async throws -> PayPalWebCheckoutResult {
         try await withCheckedThrowingContinuation { continuation in
-            start(request: request) { result, error in
-                if let error {
-                    continuation.resume(throwing: error)
-                } else if let result {
+            start(request: request) { result in
+                switch result {
+                case .success(let result):
                     continuation.resume(returning: result)
+                case .failure(let error):
+                    continuation.resume(throwing: error)
                 }
             }
         }
@@ -202,19 +206,28 @@ public class PayPalWebCheckoutClient: NSObject {
         return url.queryItems?.first { $0.name == param }?.value
     }
 
-    private func notifyCheckoutSuccess(for result: PayPalWebCheckoutResult, completion: (PayPalWebCheckoutResult?, CoreSDKError?) -> Void) {
+    private func notifyCheckoutSuccess(
+        for result: PayPalWebCheckoutResult,
+        completion: (Result<PayPalWebCheckoutResult, CoreSDKError>) -> Void
+    ) {
         self.analyticsService?.sendEvent("paypal-web-payments:checkout:succeeded")
-        completion(result, nil)
+        completion(.success(result))
     }
 
-    private func notifyCheckoutFailure(with error: CoreSDKError, completion: (PayPalWebCheckoutResult?, CoreSDKError?) -> Void) {
+    private func notifyCheckoutFailure(
+        with error: CoreSDKError,
+        completion: (Result<PayPalWebCheckoutResult, CoreSDKError>) -> Void
+    ) {
         self.analyticsService?.sendEvent("paypal-web-payments:checkout:failed")
-        completion(nil, error)
+        completion(.failure(error))
     }
 
-    private func notifyCheckoutCancelWithError(with error: CoreSDKError, completion: (PayPalWebCheckoutResult?, CoreSDKError?) -> Void) {
+    private func notifyCheckoutCancelWithError(
+        with error: CoreSDKError,
+        completion: (Result<PayPalWebCheckoutResult, CoreSDKError>) -> Void
+    ) {
         analyticsService?.sendEvent("paypal-web-payments:checkout:canceled")
-        completion(nil, error)
+        completion(.failure(error))
     }
 
     private func notifyVaultSuccess(for result: PayPalVaultResult, completion: (PayPalVaultResult?, CoreSDKError?) -> Void) {

--- a/Sources/PayPalWebPayments/PayPalWebCheckoutClient.swift
+++ b/Sources/PayPalWebPayments/PayPalWebCheckoutClient.swift
@@ -32,7 +32,7 @@ public class PayPalWebCheckoutClient: NSObject {
     ///   - request: the PayPalRequest for the transaction
     ///   - completion: A completion block that is invoked when the request is completed.
     ///                 The closure returns a `Result`:
-    ///                 - `.success(CardResult)` containing:
+    ///                 - `.success(PayPalCheckoutResult)` containing:
     ///                   - `orderID`: The ID of the approved order.
     ///                   - `payerID`: Payer ID (or user id associated with the transaction
     ///                 - `.failure(CoreSDKError)`: Describes the reason for failure.

--- a/UnitTests/CardPaymentsTests/CardClient_Tests.swift
+++ b/UnitTests/CardPaymentsTests/CardClient_Tests.swift
@@ -248,14 +248,14 @@ class CardClient_Tests: XCTestCase {
         
         let expectation = expectation(description: "approveOrder() completed")
 
-        sut.approveOrder(request: cardRequest) { result, error in
-            XCTAssertNil(result)
-            if let error {
+        sut.approveOrder(request: cardRequest) { result in
+            switch result {
+            case .success:
+                XCTFail("Expected failure with error")
+            case .failure(let error):
                 XCTAssertEqual(error.code, 3)
                 XCTAssertEqual(error.domain, "CardClientErrorDomain")
                 XCTAssertEqual(error.errorDescription, "An invalid 3DS URL was returned. Contact developer.paypal.com/support.")
-            } else {
-                XCTFail("Expected error not to be nil")
             }
             expectation.fulfill()
         }
@@ -265,19 +265,17 @@ class CardClient_Tests: XCTestCase {
 
     func testApproveOrder_withNoThreeDSecure_returnsOrderData() {
         mockCheckoutOrdersAPI.stubConfirmResponse = FakeConfirmPaymentResponse.without3DS
-        
         let expectation = expectation(description: "approveOrder() completed")
 
-        sut.approveOrder(request: cardRequest) { result, error in
-            if let result {
-                XCTAssertEqual(result.orderID, "testOrderId")
-                XCTAssertEqual(result.status, "APPROVED")
-                XCTAssertFalse(result.didAttemptThreeDSecureAuthentication)
-            } else {
-                XCTFail("expected result not to be nil")
+        sut.approveOrder(request: cardRequest) { result in
+            switch result {
+            case .success(let cardResult):
+                XCTAssertEqual(cardResult.orderID, "testOrderId")
+                XCTAssertEqual(cardResult.status, "APPROVED")
+                XCTAssertFalse(cardResult.didAttemptThreeDSecureAuthentication)
+            case .failure:
+                XCTFail("Expected success with CardResult")
             }
-
-            XCTAssertNil(error)
             expectation.fulfill()
         }
 
@@ -289,18 +287,17 @@ class CardClient_Tests: XCTestCase {
 
         let expectation = expectation(description: "approveOrder() completed")
 
-        sut.approveOrder(request: cardRequest) { result, error in
-            XCTAssertNil(result)
-            if let error {
+        sut.approveOrder(request: cardRequest) { result in
+            switch result {
+            case .success:
+                XCTFail("Expected failure with error")
+            case .failure(let error):
                 XCTAssertEqual(error.code, 123)
                 XCTAssertEqual(error.domain, "sdk-domain")
                 XCTAssertEqual(error.errorDescription, "sdk-error-desc")
-            } else {
-                XCTFail("Expected error not to be nil")
             }
             expectation.fulfill()
         }
-
         waitForExpectations(timeout: 2, handler: nil)
     }
     
@@ -313,16 +310,16 @@ class CardClient_Tests: XCTestCase {
 
         let expectation = expectation(description: "approveOrder() completed")
 
-        sut.approveOrder(request: cardRequest) { result, error in
-            XCTAssertNil(result)
-            if let error = error {
+        sut.approveOrder(request: cardRequest) { result in
+            switch result {
+            case .success:
+                XCTFail("Expected failure with error")
+            case .failure(let error):
                 XCTAssertEqual(error.domain, CardError.domain)
                 XCTAssertEqual(error.code, CardError.Code.unknown.rawValue)
                 XCTAssertNotNil(error.localizedDescription)
-                expectation.fulfill()
-            } else {
-                XCTFail("Expected error not to be nil")
             }
+            expectation.fulfill()
         }
 
         waitForExpectations(timeout: 2, handler: nil)
@@ -332,17 +329,16 @@ class CardClient_Tests: XCTestCase {
         mockCheckoutOrdersAPI.stubConfirmResponse = FakeConfirmPaymentResponse.withValid3DSURL
 
         mockWebAuthSession.cannedResponseURL = .init(string: "sdk.ios.paypal://card/success?state=undefined&code=undefined&liability_shift=POSSIBLE")
-        
         let expectation = expectation(description: "approveOrder() completed")
 
-        sut.approveOrder(request: cardRequest) { result, error in
-            XCTAssertNil(error)
-            if let result {
-                XCTAssertEqual(result.orderID, "testOrderId")
-                XCTAssertNil(result.status)
-                XCTAssertTrue(result.didAttemptThreeDSecureAuthentication)
-            } else {
-                XCTFail("Expected non-nil result")
+        sut.approveOrder(request: cardRequest) { result in
+            switch result {
+            case .success(let cardResult):
+                XCTAssertEqual(cardResult.orderID, "testOrderId")
+                XCTAssertNil(cardResult.status)
+                XCTAssertTrue(cardResult.didAttemptThreeDSecureAuthentication)
+            case .failure:
+                XCTFail("Expected success with CardResult")
             }
             expectation.fulfill()
         }
@@ -360,14 +356,14 @@ class CardClient_Tests: XCTestCase {
 
         let expectation = expectation(description: "approveOrder() completed")
 
-        sut.approveOrder(request: cardRequest) { result, error in
-            XCTAssertNil(result)
-            if let error = error {
+        sut.approveOrder(request: cardRequest) { result in
+            switch result {
+            case .success:
+                XCTFail("Expected failure with error")
+            case .failure(let error):
                 XCTAssertEqual(error.domain, CardError.domain)
                 XCTAssertEqual(error.code, CardError.threeDSecureCanceledError.code)
                 XCTAssertEqual(error.localizedDescription, CardError.threeDSecureCanceledError.localizedDescription)
-            } else {
-                XCTFail("Expected error")
             }
             expectation.fulfill()
         }
@@ -386,14 +382,14 @@ class CardClient_Tests: XCTestCase {
 
         let expectation = expectation(description: "approveOrder() completed")
 
-        sut.approveOrder(request: cardRequest) { result, error in
-            XCTAssertNil(result)
-            if let error = error {
+        sut.approveOrder(request: cardRequest) { result in
+            switch result {
+            case .success:
+                XCTFail("Expected failure with error")
+            case .failure(let error):
                 XCTAssertEqual(error.domain, CardError.domain)
                 XCTAssertEqual(error.code, CardError.Code.threeDSecureError.rawValue)
                 XCTAssertEqual(error.localizedDescription, "Mock web session error description.")
-            } else {
-                XCTFail("Expected error")
             }
             expectation.fulfill()
         }
@@ -412,12 +408,12 @@ class CardClient_Tests: XCTestCase {
 
         let expectation = expectation(description: "approveOrder() completed")
 
-        sut.approveOrder(request: cardRequest) { result, error in
-            XCTAssertNil(result)
-            if let error = error {
+        sut.approveOrder(request: cardRequest) { result in
+            switch result {
+            case .success:
+                XCTFail("Expected failure with cancellation error")
+            case .failure(let error):
                 XCTAssertTrue(CardError.isThreeDSecureCanceled(error))
-            } else {
-                XCTFail("Expected error due to user cancellation")
             }
             expectation.fulfill()
         }

--- a/UnitTests/PayPalWebPaymentsTests/PayPalWebCheckoutClient_Tests.swift
+++ b/UnitTests/PayPalWebPaymentsTests/PayPalWebCheckoutClient_Tests.swift
@@ -178,14 +178,14 @@ class PayPalClient_Tests: XCTestCase {
         )
 
         let expectation = self.expectation(description: "Call back invoked with error")
-        payPalClient.start(request: request) { result, error in
-            XCTAssertNil(result)
-            if let error {
+        payPalClient.start(request: request) { result in
+            switch result {
+            case .success:
+                XCTFail("Expected failure with error")
+            case .failure(let error):
                 XCTAssertEqual(error.domain, PayPalError.domain)
                 XCTAssertEqual(error.code, PayPalError.checkoutCanceledError.code)
                 XCTAssertEqual(error.localizedDescription, PayPalError.checkoutCanceledError.localizedDescription)
-            } else {
-                XCTFail("Expected error not to be nil")
             }
             expectation.fulfill()
         }
@@ -206,19 +206,18 @@ class PayPalClient_Tests: XCTestCase {
         )
 
         let expectation = self.expectation(description: "Call back invoked with error")
-        payPalClient.start(request: request) { result, error in
-            XCTAssertNil(result)
-            if let error {
+        payPalClient.start(request: request) { result in
+            switch result {
+            case .success:
+                XCTFail("Expected failure with error")
+            case .failure(let error):
                 XCTAssertTrue(PayPalError.isCheckoutCanceled(error))
-            } else {
-                XCTFail("Expected error from PayPal checkout cancellation.")
             }
             expectation.fulfill()
         }
 
         waitForExpectations(timeout: 2, handler: nil)
     }
-
 
     func testStart_whenWebAuthenticationSessions_returnsWebSessionError() {
         let request = PayPalWebCheckoutRequest(orderID: "1234")
@@ -230,17 +229,19 @@ class PayPalClient_Tests: XCTestCase {
         )
 
         let expectation = self.expectation(description: "Call back invoked with error")
-        payPalClient.start(request: request) { result, error in
-            XCTAssertNil(result)
-            if let error {
+
+        payPalClient.start(request: request) { result in
+            switch result {
+            case .success:
+                XCTFail("Expected failure with error")
+            case .failure(let error):
                 XCTAssertEqual(error.domain, PayPalError.domain)
                 XCTAssertEqual(error.code, PayPalError.Code.webSessionError.rawValue)
                 XCTAssertEqual(error.localizedDescription, "Mock web session error description.")
-            } else {
-                XCTFail("Expected error not to be nil")
             }
             expectation.fulfill()
         }
+
         waitForExpectations(timeout: 2, handler: nil)
     }
 
@@ -249,17 +250,18 @@ class PayPalClient_Tests: XCTestCase {
 
         mockWebAuthenticationSession.cannedResponseURL = URL(string: "https://fakeURL?PayerID=98765")
         let expectation = self.expectation(description: "Call back invoked with error")
-        payPalClient.start(request: request) { result, error in
-            XCTAssertNil(result)
-            if let error {
+        payPalClient.start(request: request) { result in
+            switch result {
+            case .success:
+                XCTFail("Expected failure with error")
+            case .failure(let error):
                 XCTAssertEqual(error.domain, PayPalError.domain)
                 XCTAssertEqual(error.code, PayPalError.Code.malformedResultError.rawValue)
                 XCTAssertEqual(error.localizedDescription, "Result did not contain the expected data.")
-            } else {
-                XCTFail("Expected error not to be nil")
             }
             expectation.fulfill()
         }
+
         waitForExpectations(timeout: 2, handler: nil)
     }
 
@@ -268,12 +270,17 @@ class PayPalClient_Tests: XCTestCase {
 
         mockWebAuthenticationSession.cannedResponseURL = URL(string: "https://fakeURL?token=1234&PayerID=98765")
         let expectation = self.expectation(description: "Call back invoked with error")
-        payPalClient.start(request: request) { result, error in
-            XCTAssertEqual(result?.orderID, "1234")
-            XCTAssertEqual(result?.payerID, "98765")
-            XCTAssertNil(error)
+        payPalClient.start(request: request) { result in
+            switch result {
+            case .success(let result):
+                XCTAssertEqual(result.orderID, "1234")
+                XCTAssertEqual(result.payerID, "98765")
+            case .failure:
+                XCTFail("Expected success with PayPalCheckoutResult")
+            }
             expectation.fulfill()
         }
+
         waitForExpectations(timeout: 2, handler: nil)
     }
 


### PR DESCRIPTION
### Summary of changes

- Return result type with .success and .failure rather than optional of result and errors.

### Checklist

- [x] Added a changelog entry

### Authors
> List GitHub usernames for everyone who contributed to this pull request.

- @KunJeongPark 