### PR TITLE
Add Colors for Pressed Button State

### DIFF
--- a/Sources/PaymentButtons/PaymentButton.swift
+++ b/Sources/PaymentButtons/PaymentButton.swift
@@ -173,7 +173,7 @@ public class PaymentButton: UIButton {
 
     private func configureBackgroundColor() {
         backgroundColor = .clear
-        containerView.backgroundColor = color.color
+        containerView.backgroundColor = isHighlighted ? color.highlightedColor : color.color
     }
 
     private func configureLogo() -> UIImageView {
@@ -246,6 +246,12 @@ public class PaymentButton: UIButton {
         containerView.layer.cornerRadius = edges.cornerRadius(for: self)
     }
 
+    override public var isHighlighted: Bool {
+        didSet {
+            updateBackgroundColor()
+        }
+    }
+
     public override var intrinsicContentSize: CGSize {
         return CGSize(width: frame.size.width, height: buttonHeight)
     }
@@ -292,5 +298,9 @@ public class PaymentButton: UIButton {
             containerView.layer.borderWidth = 0
             containerView.layer.borderColor = UIColor.clear.cgColor
         }
+    }
+
+    private func updateBackgroundColor() {
+        containerView.backgroundColor = isHighlighted ? color.highlightedColor : color.color
     }
 }

--- a/Sources/PaymentButtons/PaymentButtonColor.swift
+++ b/Sources/PaymentButtons/PaymentButtonColor.swift
@@ -24,6 +24,17 @@ public enum PaymentButtonColor: String {
         }
     }
 
+    var highlightedColor: UIColor {
+        switch self {
+        case .blue:
+            return UIColor(hexString: "#3DB5FF")
+        case .black:
+            return UIColor(hexString: "#696969")
+        case .white:
+            return UIColor(hexString: "#E9E9E9")
+        }
+    }
+
     var fontColor: UIColor {
         switch self {
         case .white:

--- a/UnitTests/PaymentButtonsTests/PayPalButton_Tests.swift
+++ b/UnitTests/PaymentButtonsTests/PayPalButton_Tests.swift
@@ -42,6 +42,41 @@ class PayPalButton_Tests: XCTestCase {
         XCTAssertEqual(sut.containerView.layer.borderColor, expectedColor)
     }
 
+    func testHighlightState_whenHighlightedTrue_setsCorrectPressedColor() {
+        let sut = PayPalButton(color: .blue)
+        sut.isHighlighted = true
+
+        let expectedColor = PaymentButtonColor.blue.highlightedColor
+        XCTAssertEqual(sut.containerView.backgroundColor, expectedColor)
+    }
+
+    func testHighlightState_whenHighlightedFalse_restoresDefaultColor() {
+        let sut = PayPalButton(color: .blue)
+        sut.isHighlighted = true
+        sut.isHighlighted = false
+
+        let expectedColor = PaymentButtonColor.blue.color
+        XCTAssertEqual(sut.containerView.backgroundColor, expectedColor)
+    }
+
+    func testPressedState_whenWhite_setsE9E9E9() {
+        let sut = PayPalButton(color: .white)
+        sut.isHighlighted = true
+        XCTAssertEqual(sut.containerView.backgroundColor, UIColor(hexString: "#E9E9E9"))
+    }
+
+    func testPressedState_whenBlack_sets696969() {
+        let sut = PayPalButton(color: .black)
+        sut.isHighlighted = true
+        XCTAssertEqual(sut.containerView.backgroundColor, UIColor(hexString: "#696969"))
+    }
+
+    func testPressedState_whenBlue_sets696969() {
+        let sut = PayPalButton(color: .blue)
+        sut.isHighlighted = true
+        XCTAssertEqual(sut.containerView.backgroundColor, UIColor(hexString: "#3DB5FF"))
+    }
+
     // MARK: - PayPalButton.Representable for SwiftUI
     
     func testMakeCoordinator_whenOnActionIsCalled_executesActionPassedInInitializer() {

--- a/UnitTests/PaymentButtonsTests/PayPalCreditButton_Tests.swift
+++ b/UnitTests/PaymentButtonsTests/PayPalCreditButton_Tests.swift
@@ -42,6 +42,42 @@ class PayPalCreditButton_Tests: XCTestCase {
         XCTAssertEqual(sut.containerView.layer.borderColor, expectedColor)
     }
 
+    func testHighlightState_whenHighlightedTrue_setsCorrectPressedColor() {
+        let sut = PayPalCreditButton(color: .blue)
+        sut.isHighlighted = true
+
+        let expectedColor = PaymentButtonColor.blue.highlightedColor
+        XCTAssertEqual(sut.containerView.backgroundColor, expectedColor)
+    }
+
+    func testHighlightState_whenHighlightedFalse_restoresDefaultColor() {
+        let sut = PayPalCreditButton(color: .blue)
+        sut.isHighlighted = true
+        sut.isHighlighted = false
+
+        let expectedColor = PaymentButtonColor.blue.color
+        XCTAssertEqual(sut.containerView.backgroundColor, expectedColor)
+    }
+
+    func testPressedState_whenWhite_setsE9E9E9() {
+        let sut = PayPalCreditButton(color: .white)
+        sut.isHighlighted = true
+        XCTAssertEqual(sut.containerView.backgroundColor, UIColor(hexString: "#E9E9E9"))
+    }
+
+    func testPressedState_whenBlack_sets696969() {
+        let sut = PayPalCreditButton(color: .black)
+        sut.isHighlighted = true
+        XCTAssertEqual(sut.containerView.backgroundColor, UIColor(hexString: "#696969"))
+    }
+
+    func testPressedState_whenBlue_sets696969() {
+        let sut = PayPalCreditButton(color: .blue)
+        sut.isHighlighted = true
+        XCTAssertEqual(sut.containerView.backgroundColor, UIColor(hexString: "#3DB5FF"))
+    }
+
+
     // MARK: - PayPalPayCreditButton.Representable for SwiftUI
     
     func testMakeCoordinator_whenOnActionIsCalled_executesActionPassedInInitializer() {

--- a/UnitTests/PaymentButtonsTests/PayPalPayLaterButton_Tests.swift
+++ b/UnitTests/PaymentButtonsTests/PayPalPayLaterButton_Tests.swift
@@ -37,6 +37,41 @@ class PayPalPayLaterButton_Tests: XCTestCase {
         XCTAssertEqual(sut.containerView.layer.borderColor, expectedColor)
     }
 
+    func testHighlightState_whenHighlightedTrue_setsCorrectPressedColor() {
+        let sut = PayPalPayLaterButton(color: .blue)
+        sut.isHighlighted = true
+
+        let expectedColor = PaymentButtonColor.blue.highlightedColor
+        XCTAssertEqual(sut.containerView.backgroundColor, expectedColor)
+    }
+
+    func testHighlightState_whenHighlightedFalse_restoresDefaultColor() {
+        let sut = PayPalPayLaterButton(color: .blue)
+        sut.isHighlighted = true
+        sut.isHighlighted = false
+
+        let expectedColor = PaymentButtonColor.blue.color
+        XCTAssertEqual(sut.containerView.backgroundColor, expectedColor)
+    }
+
+    func testPressedState_whenWhite_setsE9E9E9() {
+        let sut = PayPalPayLaterButton(color: .white)
+        sut.isHighlighted = true
+        XCTAssertEqual(sut.containerView.backgroundColor, UIColor(hexString: "#E9E9E9"))
+    }
+
+    func testPressedState_whenBlack_sets696969() {
+        let sut = PayPalPayLaterButton(color: .black)
+        sut.isHighlighted = true
+        XCTAssertEqual(sut.containerView.backgroundColor, UIColor(hexString: "#696969"))
+    }
+
+    func testPressedState_whenBlue_sets696969() {
+        let sut = PayPalPayLaterButton(color: .blue)
+        sut.isHighlighted = true
+        XCTAssertEqual(sut.containerView.backgroundColor, UIColor(hexString: "#3DB5FF"))
+    }
+
     // MARK: - PayPalPayLaterButton.Representable for SwiftUI
     
     func testMakeCoordinator_whenOnActionIsCalled_executesActionPassedInInitializer() {


### PR DESCRIPTION
### Reason for changes

Add colors for pressed button state per requirements:

Blue button pressed color: #3DB5FF
Black button pressed color: #696969
White button pressed color: #E9E9E9


### Summary of changes

- override isHighlighted property to toggle button colors

### Checklist

- [ ] Added a changelog entry

### Authors
> List GitHub usernames for everyone who contributed to this pull request.

- @KunJeongPark 