### PR TITLE
Remove Venmo Reference in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # PayPal iOS SDK
 
-Welcome to PayPal's iOS SDK. This library will help you accept card, PayPal, Venmo, and alternative payment methods in your iOS app.
+Welcome to PayPal's iOS SDK. This library will help you accept card and PayPal payment methods in your iOS app.
 
 ## FAQ
 ### Contribution


### PR DESCRIPTION
### Reason for changes

Our README incorrectly states that we have Venmo Integrations

### Summary of changes

- Remove Venmo ref in README

### Checklist

- [ ] Added a changelog entry

### Authors
> List GitHub usernames for everyone who contributed to this pull request.
@KunJeongPark 

- 