### PR TITLE
Add UpdateClientConfig to paypal vault

### DIFF
--- a/Sources/CorePayments/PayPalCoreConstants.swift
+++ b/Sources/CorePayments/PayPalCoreConstants.swift
@@ -1,9 +1,11 @@
-/// This class is exposed for internal PayPal use only. Do not use. It is not covered by Semantic Versioning and may change or be removed at any time.
+/// This class is exposed for internal PayPal use only. Do not use.
+/// It is not covered by Semantic Versioning and may change or be removed at any time.
 @_documentation(visibility: private)
 public enum PayPalCoreConstants {
     
     // TODO: - Update release script to update this version #
-    /// This property is exposed for internal PayPal use only. Do not use. It is not covered by Semantic Versioning and may change or be removed at any time.
+    /// This property is exposed for internal PayPal use only. Do not use.
+    /// It is not covered by Semantic Versioning and may change or be removed at any time.
     public static let payPalSDKVersion: String = "2.0.0"
     
     public static let callbackURLScheme: String = "sdk.ios.paypal"

--- a/Sources/PayPalWebPayments/PayPalWebCheckoutClient.swift
+++ b/Sources/PayPalWebPayments/PayPalWebCheckoutClient.swift
@@ -155,55 +155,66 @@ public class PayPalWebCheckoutClient: NSObject {
     public func vault(_ vaultRequest: PayPalVaultRequest, completion: @escaping (Result<PayPalVaultResult, CoreSDKError>) -> Void) {
         analyticsService = AnalyticsService(coreConfig: config, setupToken: vaultRequest.setupTokenID)
         analyticsService?.sendEvent("paypal-web-payments:vault-wo-purchase:started")
-        
-        var vaultURLComponents = URLComponents(url: config.environment.paypalVaultCheckoutURL, resolvingAgainstBaseURL: false)
-        let queryItems = [URLQueryItem(name: "approval_session_id", value: vaultRequest.setupTokenID)]
-        vaultURLComponents?.queryItems = queryItems
-        
-        guard let vaultCheckoutURL = vaultURLComponents?.url else {
-            notifyVaultFailure(with: PayPalError.payPalURLError, completion: completion)
-            return
-        }
-        
-        webAuthenticationSession.start(
-            url: vaultCheckoutURL,
-            context: self,
-            sessionDidDisplay: { [weak self] didDisplay in
-                if didDisplay {
-                    self?.analyticsService?.sendEvent("paypal-web-payments:vault-wo-purchase:auth-challenge-presentation:succeeded")
-                } else {
-                    self?.analyticsService?.sendEvent("paypal-web-payments:vault-wo-purchase:auth-challenge-presentation:failed")
-                }
-            },
-            sessionDidComplete: { url, error in
-                if let error = error {
-                    switch error {
-                    case ASWebAuthenticationSessionError.canceledLogin:
-                        self.notifyVaultCancelWithError(
-                            with: PayPalError.vaultCanceledError,
-                            completion: completion
-                        )
-                        return
-                    default:
-                        self.notifyVaultFailure(with: PayPalError.webSessionError(error), completion: completion)
-                        return
-                    }
-                }
 
-                if let url = url {
-                    guard let tokenID = self.getQueryStringParameter(url: url.absoluteString, param: "approval_token_id"),
-                        let approvalSessionID = self.getQueryStringParameter(url: url.absoluteString, param: "approval_session_id"),
-                        !tokenID.isEmpty, !approvalSessionID.isEmpty
-                    else {
-                        self.notifyVaultFailure(with: PayPalError.payPalVaultResponseError, completion: completion)
-                        return
-                    }
-
-                    let paypalVaultResult = PayPalVaultResult(tokenID: tokenID, approvalSessionID: approvalSessionID)
-                    self.notifyVaultSuccess(for: paypalVaultResult, completion: completion)
-                }
+        Task {
+            do {
+                _ = try await clientConfigAPI.updateClientConfig(
+                    token: vaultRequest.setupTokenID,
+                    fundingSource: PayPalWebCheckoutFundingSource.paypal.rawValue
+                )
+            } catch {
+                print("error in calling graphQL: \(error.localizedDescription)")
             }
-        )
+            
+            var vaultURLComponents = URLComponents(url: config.environment.paypalVaultCheckoutURL, resolvingAgainstBaseURL: false)
+            let queryItems = [URLQueryItem(name: "approval_session_id", value: vaultRequest.setupTokenID)]
+            vaultURLComponents?.queryItems = queryItems
+
+            guard let vaultCheckoutURL = vaultURLComponents?.url else {
+                notifyVaultFailure(with: PayPalError.payPalURLError, completion: completion)
+                return
+            }
+
+            webAuthenticationSession.start(
+                url: vaultCheckoutURL,
+                context: self,
+                sessionDidDisplay: { [weak self] didDisplay in
+                    if didDisplay {
+                        self?.analyticsService?.sendEvent("paypal-web-payments:vault-wo-purchase:auth-challenge-presentation:succeeded")
+                    } else {
+                        self?.analyticsService?.sendEvent("paypal-web-payments:vault-wo-purchase:auth-challenge-presentation:failed")
+                    }
+                },
+                sessionDidComplete: { url, error in
+                    if let error = error {
+                        switch error {
+                        case ASWebAuthenticationSessionError.canceledLogin:
+                            self.notifyVaultCancelWithError(
+                                with: PayPalError.vaultCanceledError,
+                                completion: completion
+                            )
+                            return
+                        default:
+                            self.notifyVaultFailure(with: PayPalError.webSessionError(error), completion: completion)
+                            return
+                        }
+                    }
+
+                    if let url = url {
+                        guard let tokenID = self.getQueryStringParameter(url: url.absoluteString, param: "approval_token_id"),
+                            let approvalSessionID = self.getQueryStringParameter(url: url.absoluteString, param: "approval_session_id"),
+                            !tokenID.isEmpty, !approvalSessionID.isEmpty
+                        else {
+                            self.notifyVaultFailure(with: PayPalError.payPalVaultResponseError, completion: completion)
+                            return
+                        }
+
+                        let paypalVaultResult = PayPalVaultResult(tokenID: tokenID, approvalSessionID: approvalSessionID)
+                        self.notifyVaultSuccess(for: paypalVaultResult, completion: completion)
+                    }
+                }
+            )
+        }
     }
 
     /// Starts a web session for vaulting PayPal Payment Method

--- a/UnitTests/PayPalWebPaymentsTests/PayPalWebCheckoutClient_Tests.swift
+++ b/UnitTests/PayPalWebPaymentsTests/PayPalWebCheckoutClient_Tests.swift
@@ -4,6 +4,7 @@ import AuthenticationServices
 @testable import PayPalWebPayments
 @testable import TestShared
 
+// swiftlint: disable type_body_length
 class PayPalClient_Tests: XCTestCase {
     
     var config: CoreConfig!
@@ -31,13 +32,24 @@ class PayPalClient_Tests: XCTestCase {
     
     func testVault_whenSandbox_launchesCorrectURLInWebSession() {
         let vaultRequest = PayPalVaultRequest(setupTokenID: "fake-token")
+        mockClientConfigAPI.stubUpdateClientConfigResponse = ClientConfigResponse(updateClientConfig: true)
+
+        let started = expectation(description: "ASWebAuthenticationSession Started")
+        mockWebAuthenticationSession.onStart = { started.fulfill() }
+
         payPalClient.vault(vaultRequest) { _ in }
+        wait(for: [started], timeout: 1.0)
 
         XCTAssertEqual(mockWebAuthenticationSession.lastLaunchedURL?.absoluteString, "https://sandbox.paypal.com/agreements/approve?approval_session_id=fake-token")
     }
     
     func testVault_whenLive_launchesCorrectURLInWebSession() {
         config = CoreConfig(clientID: "testClientID", environment: .live)
+        mockClientConfigAPI.stubUpdateClientConfigResponse = ClientConfigResponse(updateClientConfig: true)
+
+        let started = expectation(description: "ASWebAuthenticationSession Started")
+        mockWebAuthenticationSession.onStart = { started.fulfill() }
+
         let payPalClient = PayPalWebCheckoutClient(
             config: config,
             networkingClient: mockNetworkingClient,
@@ -47,6 +59,7 @@ class PayPalClient_Tests: XCTestCase {
         
         let vaultRequest = PayPalVaultRequest(setupTokenID: "fake-token")
         payPalClient.vault(vaultRequest) { _ in }
+        wait(for: [started], timeout: 1.0)
 
         XCTAssertEqual(mockWebAuthenticationSession.lastLaunchedURL?.absoluteString, "https://paypal.com/agreements/approve?approval_session_id=fake-token")
     }
@@ -314,3 +327,4 @@ class PayPalClient_Tests: XCTestCase {
         )
     }
 }
+// swiftlint:enable type_body_length

--- a/UnitTests/TestShared/MockWebAuthenticationSession.swift
+++ b/UnitTests/TestShared/MockWebAuthenticationSession.swift
@@ -9,6 +9,8 @@ class MockWebAuthenticationSession: WebAuthenticationSession {
     var cannedDidDisplayResult = true
     var lastLaunchedURL: URL?
 
+    var onStart: (() -> Void)?
+
     override func start(
         url: URL,
         context: ASWebAuthenticationPresentationContextProviding,
@@ -16,6 +18,8 @@ class MockWebAuthenticationSession: WebAuthenticationSession {
         sessionDidComplete: @escaping (URL?, Error?) -> Void
     ) {
         lastLaunchedURL = url
+        onStart?()
+        
         sessionDidDisplay(cannedDidDisplayResult)
         sessionDidComplete(cannedResponseURL, cannedErrorResponse)
     }


### PR DESCRIPTION
### Reason for changes
Call graphQL endpoint UpdateClientConfig for PayPalWebClient vault function
to propagate our CCO values


### Summary of changes

- call graphQL endpoint UpdateClientConfig for vault function

### Checklist

- [ ] Added a changelog entry

### Authors
> List GitHub usernames for everyone who contributed to this pull request.

- @KunJeongPark 