### PR TITLE
Changes for toggling app switch for checkout

### DIFF
--- a/Demo/Demo/Models/CreateOrderParams.swift
+++ b/Demo/Demo/Models/CreateOrderParams.swift
@@ -1,70 +1,81 @@
 struct CreateOrderParams: Encodable {
 
-    let applicationContext: ApplicationContext?
-    let intent: String
-    var purchaseUnits: [PurchaseUnit]?
-    var paymentSource: VaultPaymentSource?
+    var applicationContext: ApplicationContext?
+    var intent: String
+    var purchaseUnits: [PurchaseUnit]
+    var paymentSource: OrderPaymentSource?
 }
 
 struct ApplicationContext: Codable {
 
     let userAction: String
     let shippingPreference: String
-
-    enum CodingKeys: String, CodingKey {
-        case userAction
-        case shippingPreference
-    }
 }
 
-enum VaultPaymentSource: Encodable {
-    case card(VaultCardPaymentSource)
-    case paypal(VaultPayPalPaymentSource)
+// MARK: - Payment source (general, for both vault, and non-vault)
+
+enum OrderPaymentSource: Encodable {
+
+    case paypal(OrderPayPalPaymentSource)
+    case card(OrderCardPaymentSource)
 
     func encode(to encoder: Encoder) throws {
         var container = encoder.singleValueContainer()
         switch self {
-        case .card(let cardSource):
-            try container.encode(cardSource)
-        case .paypal(let paypalSource):
-            try container.encode(paypalSource)
+        case .paypal(let source): try container.encode(source)
+        case .card(let source):   try container.encode(source)
         }
     }
 }
 
-struct VaultPayPalPaymentSource: Encodable {
+struct OrderPayPalPaymentSource: Encodable {
 
-    let paypal: VaultPayPal
+    let paypal: PayPalSource
 }
 
-struct VaultPayPal: Encodable {
+struct OrderCardPaymentSource: Encodable {
 
-    let attributes: Attributes
-    let experienceContext: ExperienceContext
+    let card: CardSource
 }
 
-struct ExperienceContext: Encodable {
+// Attributes are only for vault now
+struct PayPalSource: Encodable {
 
-    // these fields are not encoded for our SDK but are required for create order with PayPal vault option
+    var attributes: Attributes?
+    var experienceContext: PayPalExperienceContext?
+}
+
+struct CardSource: Encodable {
+
+    var attributes: Attributes?
+}
+
+// MARK: - PayPal experience context
+
+struct PayPalExperienceContext: Encodable {
+
     let returnUrl: String
     let cancelUrl: String
+    var appSwitchContext: AppSwitchContext?
 }
 
-struct VaultCardPaymentSource: Encodable {
+struct AppSwitchContext: Encodable {
 
-    let card: VaultCard
+    let nativeApp: NativeApp
 }
 
-struct VaultCard: Encodable {
+struct NativeApp: Encodable {
 
-    let attributes: Attributes
+    let osType: String
+    let appUrl: String
 }
+
+// MARK: - Vault attributes
 
 struct Attributes: Encodable {
 
     let vault: Vault
     let customer: Customer?
-
     init(vault: Vault, customer: Customer? = nil) {
         self.vault = vault
         self.customer = customer
@@ -76,7 +87,6 @@ struct Vault: Encodable {
     let storeInVault: String
     let usageType: String?
     let customerType: String?
-
     init(storeInVault: String, usageType: String? = nil, customerType: String? = nil) {
         self.storeInVault = storeInVault
         self.usageType = usageType
@@ -132,7 +142,7 @@ struct Amount: Encodable {
     let currencyCode: String
     let value: String
     var breakdown: Breakdown?
-    
+
     struct Breakdown: Encodable {
 
         let shipping: ItemTotal

--- a/PayPal.xcodeproj/project.pbxproj
+++ b/PayPal.xcodeproj/project.pbxproj
@@ -19,6 +19,9 @@
 		3B783DC32B7A69C2004623DB /* FakeUpdateSetupTokenResponse.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3B783DC22B7A69C2004623DB /* FakeUpdateSetupTokenResponse.swift */; };
 		3B79E4F72A8503CA00C01D06 /* UpdateVaultVariables.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3B79E4F62A8503C900C01D06 /* UpdateVaultVariables.swift */; };
 		3B80D50C2A27979000D2EAC4 /* FailingJSONEncoder.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3B80D50B2A27979000D2EAC4 /* FailingJSONEncoder.swift */; };
+		3B857B172E69E9D8006F3CBC /* AuthenticationTokenServiceAPI.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3B857B162E69E99E006F3CBC /* AuthenticationTokenServiceAPI.swift */; };
+		3B857B192E69FACA006F3CBC /* AuthenticationSecureTokenServiceAPI_Tests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3B857B182E69FAB9006F3CBC /* AuthenticationSecureTokenServiceAPI_Tests.swift */; };
+		3B857B1B2E6A02F5006F3CBC /* AuthenticationTokenResponse.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3B857B1A2E6A02ED006F3CBC /* AuthenticationTokenResponse.swift */; };
 		3B8F848C2D93380B00A151AC /* TestShared.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 80E743F8270E40CE00BACECA /* TestShared.framework */; };
 		3BD82DBB2A835AF900CBE764 /* UpdateSetupTokenResponse.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3BD82DBA2A835AF900CBE764 /* UpdateSetupTokenResponse.swift */; };
 		3BDB34942A80CE6E008100D7 /* CardVaultRequest.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3BDB34932A80CE6E008100D7 /* CardVaultRequest.swift */; };
@@ -199,6 +202,9 @@
 		3B783DC22B7A69C2004623DB /* FakeUpdateSetupTokenResponse.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FakeUpdateSetupTokenResponse.swift; sourceTree = "<group>"; };
 		3B79E4F62A8503C900C01D06 /* UpdateVaultVariables.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = UpdateVaultVariables.swift; sourceTree = "<group>"; };
 		3B80D50B2A27979000D2EAC4 /* FailingJSONEncoder.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FailingJSONEncoder.swift; sourceTree = "<group>"; };
+		3B857B162E69E99E006F3CBC /* AuthenticationTokenServiceAPI.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AuthenticationTokenServiceAPI.swift; sourceTree = "<group>"; };
+		3B857B182E69FAB9006F3CBC /* AuthenticationSecureTokenServiceAPI_Tests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AuthenticationSecureTokenServiceAPI_Tests.swift; sourceTree = "<group>"; };
+		3B857B1A2E6A02ED006F3CBC /* AuthenticationTokenResponse.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AuthenticationTokenResponse.swift; sourceTree = "<group>"; };
 		3B8F84852D93318D00A151AC /* UpdateClientConfigAP_Tests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = UpdateClientConfigAP_Tests.swift; sourceTree = "<group>"; };
 		3B8F84912D933FAE00A151AC /* MockUpdateClientConfigAPI.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MockUpdateClientConfigAPI.swift; sourceTree = "<group>"; };
 		3BD82DBA2A835AF900CBE764 /* UpdateSetupTokenResponse.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = UpdateSetupTokenResponse.swift; sourceTree = "<group>"; };
@@ -467,6 +473,7 @@
 		3BF06F422E16477D002CA7B4 /* CorePaymentTests */ = {
 			isa = PBXGroup;
 			children = (
+				3B857B182E69FAB9006F3CBC /* AuthenticationSecureTokenServiceAPI_Tests.swift */,
 				3B8F84852D93318D00A151AC /* UpdateClientConfigAP_Tests.swift */,
 			);
 			path = CorePaymentTests;
@@ -675,6 +682,8 @@
 		BEA100E526EF9EDA0036A6A5 /* Networking */ = {
 			isa = PBXGroup;
 			children = (
+				3B857B1A2E6A02ED006F3CBC /* AuthenticationTokenResponse.swift */,
+				3B857B162E69E99E006F3CBC /* AuthenticationTokenServiceAPI.swift */,
 				E646231928369B71008AC8E1 /* GraphQL */,
 				BEA100E626EF9EDA0036A6A5 /* NetworkingClient.swift */,
 				804E628529380B04004B9FEF /* AnalyticsService.swift */,
@@ -1163,6 +1172,7 @@
 			buildActionMask = 2147483647;
 			files = (
 				808EEA81291321FE001B6765 /* AnalyticsEventData_Tests.swift in Sources */,
+				3B857B192E69FACA006F3CBC /* AuthenticationSecureTokenServiceAPI_Tests.swift in Sources */,
 				8036C1E5270F9BE700C0F091 /* Environment_Tests.swift in Sources */,
 				80B96AAE2A980F6B00C62916 /* MockTrackingEventsAPI.swift in Sources */,
 				80FC261D29847AC7008EC841 /* HTTP_Tests.swift in Sources */,
@@ -1180,6 +1190,7 @@
 			files = (
 				E6022E802857C6BE008B0E27 /* GraphQLHTTPResponse.swift in Sources */,
 				80E643832A1EBBD2008FD705 /* HTTPResponse.swift in Sources */,
+				3B857B1B2E6A02F5006F3CBC /* AuthenticationTokenResponse.swift in Sources */,
 				807C5E6929102D9800ECECD8 /* AnalyticsEventData.swift in Sources */,
 				3BF06F3D2E15CAB4002CA7B4 /* UpdateClientConfigAPI.swift in Sources */,
 				80E237DF2A84434B00FF18CA /* HTTPRequest.swift in Sources */,
@@ -1187,6 +1198,7 @@
 				8021B69029144E6D000FBC54 /* PayPalCoreConstants.swift in Sources */,
 				807D56B02A869F97009E591D /* GraphQLErrorResponse.swift in Sources */,
 				80DB2F762980795D00CFB86A /* CorePaymentsError.swift in Sources */,
+				3B857B172E69E9D8006F3CBC /* AuthenticationTokenServiceAPI.swift in Sources */,
 				06CE009926F3D1660000CC46 /* CoreConfig.swift in Sources */,
 				BEA100EC26EFA7790036A6A5 /* HTTPMethod.swift in Sources */,
 				BEA100EE26EFA7990036A6A5 /* HTTPHeader.swift in Sources */,

--- a/PayPal.xcodeproj/project.pbxproj
+++ b/PayPal.xcodeproj/project.pbxproj
@@ -22,7 +22,12 @@
 		3B857B172E69E9D8006F3CBC /* AuthenticationTokenServiceAPI.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3B857B162E69E99E006F3CBC /* AuthenticationTokenServiceAPI.swift */; };
 		3B857B192E69FACA006F3CBC /* AuthenticationSecureTokenServiceAPI_Tests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3B857B182E69FAB9006F3CBC /* AuthenticationSecureTokenServiceAPI_Tests.swift */; };
 		3B857B1B2E6A02F5006F3CBC /* AuthenticationTokenResponse.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3B857B1A2E6A02ED006F3CBC /* AuthenticationTokenResponse.swift */; };
+		3B857B1D2E6B6661006F3CBC /* PatchCCOWithAppSwitchEligibility.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3B857B1C2E6B663F006F3CBC /* PatchCCOWithAppSwitchEligibility.swift */; };
+		3B857B1F2E6B7A76006F3CBC /* PatchCcoWithAppSwitchEligibilityVariables.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3B857B1E2E6B7A64006F3CBC /* PatchCcoWithAppSwitchEligibilityVariables.swift */; };
 		3B8F848C2D93380B00A151AC /* TestShared.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 80E743F8270E40CE00BACECA /* TestShared.framework */; };
+		3B95C9832E6B9B77004C6F65 /* PatchCcoWithAppSwitchEligibilityResponse.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3B95C9822E6B9B77004C6F65 /* PatchCcoWithAppSwitchEligibilityResponse.swift */; };
+		3B95C9852E6BA139004C6F65 /* MockAuthenticationSecureTokenServiceAPI.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3B95C9842E6BA124004C6F65 /* MockAuthenticationSecureTokenServiceAPI.swift */; };
+		3B95C9872E6BA266004C6F65 /* PatchCCOWithAppSwitchEligibility.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3B95C9862E6BA266004C6F65 /* PatchCCOWithAppSwitchEligibility.swift */; };
 		3BD82DBB2A835AF900CBE764 /* UpdateSetupTokenResponse.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3BD82DBA2A835AF900CBE764 /* UpdateSetupTokenResponse.swift */; };
 		3BDB34942A80CE6E008100D7 /* CardVaultRequest.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3BDB34932A80CE6E008100D7 /* CardVaultRequest.swift */; };
 		3BE738682B9A66D800598F05 /* PrivacyInfo.xcprivacy in Resources */ = {isa = PBXBuildFile; fileRef = 3BE738622B9A482800598F05 /* PrivacyInfo.xcprivacy */; };
@@ -205,8 +210,13 @@
 		3B857B162E69E99E006F3CBC /* AuthenticationTokenServiceAPI.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AuthenticationTokenServiceAPI.swift; sourceTree = "<group>"; };
 		3B857B182E69FAB9006F3CBC /* AuthenticationSecureTokenServiceAPI_Tests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AuthenticationSecureTokenServiceAPI_Tests.swift; sourceTree = "<group>"; };
 		3B857B1A2E6A02ED006F3CBC /* AuthenticationTokenResponse.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AuthenticationTokenResponse.swift; sourceTree = "<group>"; };
+		3B857B1C2E6B663F006F3CBC /* PatchCCOWithAppSwitchEligibility.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PatchCCOWithAppSwitchEligibility.swift; sourceTree = "<group>"; };
+		3B857B1E2E6B7A64006F3CBC /* PatchCcoWithAppSwitchEligibilityVariables.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PatchCcoWithAppSwitchEligibilityVariables.swift; sourceTree = "<group>"; };
 		3B8F84852D93318D00A151AC /* UpdateClientConfigAP_Tests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = UpdateClientConfigAP_Tests.swift; sourceTree = "<group>"; };
 		3B8F84912D933FAE00A151AC /* MockUpdateClientConfigAPI.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MockUpdateClientConfigAPI.swift; sourceTree = "<group>"; };
+		3B95C9822E6B9B77004C6F65 /* PatchCcoWithAppSwitchEligibilityResponse.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PatchCcoWithAppSwitchEligibilityResponse.swift; sourceTree = "<group>"; };
+		3B95C9842E6BA124004C6F65 /* MockAuthenticationSecureTokenServiceAPI.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MockAuthenticationSecureTokenServiceAPI.swift; sourceTree = "<group>"; };
+		3B95C9862E6BA266004C6F65 /* PatchCCOWithAppSwitchEligibility.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PatchCCOWithAppSwitchEligibility.swift; sourceTree = "<group>"; };
 		3BD82DBA2A835AF900CBE764 /* UpdateSetupTokenResponse.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = UpdateSetupTokenResponse.swift; sourceTree = "<group>"; };
 		3BDB34932A80CE6E008100D7 /* CardVaultRequest.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CardVaultRequest.swift; sourceTree = "<group>"; };
 		3BE738622B9A482800598F05 /* PrivacyInfo.xcprivacy */ = {isa = PBXFileReference; lastKnownFileType = text.xml; path = PrivacyInfo.xcprivacy; sourceTree = "<group>"; };
@@ -473,6 +483,7 @@
 		3BF06F422E16477D002CA7B4 /* CorePaymentTests */ = {
 			isa = PBXGroup;
 			children = (
+				3B95C9862E6BA266004C6F65 /* PatchCCOWithAppSwitchEligibility.swift */,
 				3B857B182E69FAB9006F3CBC /* AuthenticationSecureTokenServiceAPI_Tests.swift */,
 				3B8F84852D93318D00A151AC /* UpdateClientConfigAP_Tests.swift */,
 			);
@@ -525,6 +536,9 @@
 		80B9F85226B8750000D67843 /* CorePayments */ = {
 			isa = PBXGroup;
 			children = (
+				3B95C9822E6B9B77004C6F65 /* PatchCcoWithAppSwitchEligibilityResponse.swift */,
+				3B857B1E2E6B7A64006F3CBC /* PatchCcoWithAppSwitchEligibilityVariables.swift */,
+				3B857B1C2E6B663F006F3CBC /* PatchCCOWithAppSwitchEligibility.swift */,
 				BE4F784827EB629100FF4C0E /* WebAuthenticationSession.swift */,
 				06CE009826F3D1660000CC46 /* CoreConfig.swift */,
 				065A4DBB26FCD8080007014A /* CoreSDKError.swift */,
@@ -554,6 +568,7 @@
 		80E743F9270E40CE00BACECA /* TestShared */ = {
 			isa = PBXGroup;
 			children = (
+				3B95C9842E6BA124004C6F65 /* MockAuthenticationSecureTokenServiceAPI.swift */,
 				3B80D50B2A27979000D2EAC4 /* FailingJSONEncoder.swift */,
 				80E743FF270E40F300BACECA /* FakeRequests.swift */,
 				E64763702899B60C00074113 /* MockNetworkingClient.swift */,
@@ -1180,6 +1195,7 @@
 				802C4A762945676E00896A5D /* AnalyticsService_Tests.swift in Sources */,
 				3BF06F412E1633D7002CA7B4 /* UpdateClientConfigAP_Tests.swift in Sources */,
 				807BF5912A2A5D48002F32B3 /* HTTPResponseParser_Tests.swift in Sources */,
+				3B95C9872E6BA266004C6F65 /* PatchCCOWithAppSwitchEligibility.swift in Sources */,
 				8036C1E4270F9BE700C0F091 /* NetworkingClient_Tests.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
@@ -1202,6 +1218,7 @@
 				06CE009926F3D1660000CC46 /* CoreConfig.swift in Sources */,
 				BEA100EC26EFA7790036A6A5 /* HTTPMethod.swift in Sources */,
 				BEA100EE26EFA7990036A6A5 /* HTTPHeader.swift in Sources */,
+				3B857B1F2E6B7A76006F3CBC /* PatchCcoWithAppSwitchEligibilityVariables.swift in Sources */,
 				CB4BE27E2847EA7D00EA2DD1 /* WebAuthenticationSession.swift in Sources */,
 				80E2FDC12A83535A0045593D /* TrackingEventsAPI.swift in Sources */,
 				BEA100F226EFA7DE0036A6A5 /* Environment.swift in Sources */,
@@ -1209,6 +1226,7 @@
 				BEA100F026EFA7C20036A6A5 /* NetworkingError.swift in Sources */,
 				804E628629380B04004B9FEF /* AnalyticsService.swift in Sources */,
 				BC04837427B2FC7300FA7B46 /* URLSession+URLSessionProtocol.swift in Sources */,
+				3B95C9832E6B9B77004C6F65 /* PatchCcoWithAppSwitchEligibilityResponse.swift in Sources */,
 				80E2FDC32A8354AD0045593D /* RESTRequest.swift in Sources */,
 				3DC42BA927187E8300B71645 /* ErrorResponse.swift in Sources */,
 				807D56AC2A869044009E591D /* GraphQLHTTPPostBody.swift in Sources */,
@@ -1217,6 +1235,7 @@
 				065A4DBC26FCD8090007014A /* CoreSDKError.swift in Sources */,
 				BEA100E726EF9EDA0036A6A5 /* NetworkingClient.swift in Sources */,
 				807BF58F2A2A5D19002F32B3 /* HTTPResponseParser.swift in Sources */,
+				3B857B1D2E6B6661006F3CBC /* PatchCCOWithAppSwitchEligibility.swift in Sources */,
 				807D56AE2A869064009E591D /* GraphQLRequest.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
@@ -1232,6 +1251,7 @@
 				CB4BE28A28512A9800EA2DD1 /* MockQuededURLSession.swift in Sources */,
 				3BF06F432E16480F002CA7B4 /* MockUpdateClientConfigAPI.swift in Sources */,
 				80E74400270E40F300BACECA /* FakeRequests.swift in Sources */,
+				3B95C9852E6BA139004C6F65 /* MockAuthenticationSecureTokenServiceAPI.swift in Sources */,
 				E64763712899B60C00074113 /* MockNetworkingClient.swift in Sources */,
 				3B80D50C2A27979000D2EAC4 /* FailingJSONEncoder.swift in Sources */,
 			);

--- a/Sources/CorePayments/Networking/AuthenticationTokenResponse.swift
+++ b/Sources/CorePayments/Networking/AuthenticationTokenResponse.swift
@@ -1,0 +1,8 @@
+import Foundation
+
+@_documentation(visibility: private)
+public struct AuthTokenResponse: Decodable {
+
+    let accessToken: String
+    let tokenType: String
+}

--- a/Sources/CorePayments/Networking/AuthenticationTokenServiceAPI.swift
+++ b/Sources/CorePayments/Networking/AuthenticationTokenServiceAPI.swift
@@ -1,0 +1,37 @@
+import Foundation
+
+@_documentation(visibility: private)
+public class AuthenticationSecureTokenServiceAPI {
+
+    // MARK: - Private Properties
+
+    private var coreConfig: CoreConfig
+    private var networkingClient: NetworkingClient
+
+    // MARK: - Initializer
+
+    public init(coreConfig: CoreConfig) {
+        self.coreConfig = coreConfig
+        self.networkingClient = NetworkingClient(coreConfig: coreConfig)
+    }
+
+    /// Exposed for injecting MockNetworkingClient in tests
+    init(coreConfig: CoreConfig, networkingClient: NetworkingClient) {
+        self.coreConfig = coreConfig
+        self.networkingClient = networkingClient
+    }
+
+    // MARK: - Internal Methods
+
+    public func createLowScopedAccessToken() async throws -> AuthTokenResponse {
+        let restRequest = RESTRequest(
+            path: "v1/oauth2/token",
+            method: .post,
+            postParameters: "grant_type=client_credentials&response_type=token",
+            contentType: .formURLEncoded
+        )
+
+        let httpResponse = try await networkingClient.fetch(request: restRequest)
+        return try HTTPResponseParser().parseREST(httpResponse, as: AuthTokenResponse.self)
+    }
+}

--- a/Sources/CorePayments/Networking/NetworkingClient.swift
+++ b/Sources/CorePayments/Networking/NetworkingClient.swift
@@ -65,7 +65,8 @@ public class NetworkingClient {
     @_documentation(visibility: private)
     public func fetch(
         request: GraphQLRequest,
-        clientContext: String? = nil
+        clientContext: String? = nil,
+        additionalHeaders: [HTTPHeader: String] = [:]
     ) async throws -> HTTPResponse {
         let url = try constructGraphQLURL(queryName: request.queryNameForURL)
                 
@@ -84,6 +85,9 @@ public class NetworkingClient {
         if let clientContext {
             headers[.payPalClientContext] = clientContext
         }
+
+        additionalHeaders.forEach { headers[$0.key] = $0.value }
+
         let httpRequest = HTTPRequest(
             headers: headers,
             method: .post,

--- a/Sources/CorePayments/Networking/NetworkingClient.swift
+++ b/Sources/CorePayments/Networking/NetworkingClient.swift
@@ -39,15 +39,19 @@ public class NetworkingClient {
             .authorization: "Basic \(base64EncodedCredentials)"
         ]
         if request.method == .post {
-            headers[.contentType] = "application/json"
+            headers[.contentType] = request.contentType.headerValue
         }
         
         // TODO: - Move JSON encoding into custom class, similar to HTTPResponseParser
         var data: Data?
         if let postBody = request.postParameters {
-            let encoder = JSONEncoder()
-            encoder.keyEncodingStrategy = .convertToSnakeCase
-            data = try encoder.encode(postBody)
+            if request.contentType == .formURLEncoded, let formString = postBody as? String {
+                data = formString.data(using: .utf8)
+            } else {
+                let encoder = JSONEncoder()
+                encoder.keyEncodingStrategy = .convertToSnakeCase
+                data = try encoder.encode(postBody)
+            }
         }
         
         let httpRequest = HTTPRequest(headers: headers, method: request.method, url: url, body: data)

--- a/Sources/CorePayments/Networking/RESTRequest.swift
+++ b/Sources/CorePayments/Networking/RESTRequest.swift
@@ -1,22 +1,40 @@
 import Foundation
 
 @_documentation(visibility: private)
+public enum ContentType {
+    case json
+    case formURLEncoded
+    
+    var headerValue: String {
+        switch self {
+        case .json:
+            return "application/json"
+        case .formURLEncoded:
+            return "application/x-www-form-urlencoded"
+        }
+    }
+}
+
+@_documentation(visibility: private)
 public struct RESTRequest {
     
     var path: String
     var method: HTTPMethod
     var queryParameters: [String: String]?
     var postParameters: Encodable?
+    var contentType: ContentType
     
     public init(
         path: String,
         method: HTTPMethod,
         queryParameters: [String: String]? = nil,
-        postParameters: Encodable? = nil
+        postParameters: Encodable? = nil,
+        contentType: ContentType = .json
     ) {
         self.path = path
         self.method = method
         self.queryParameters = queryParameters
         self.postParameters = postParameters
+        self.contentType = contentType
     }
 }

--- a/Sources/CorePayments/PatchCCOWithAppSwitchEligibility.swift
+++ b/Sources/CorePayments/PatchCCOWithAppSwitchEligibility.swift
@@ -1,0 +1,114 @@
+import Foundation
+
+/// This class coordinates networking logic for communicating with the /graphql API for patching CCO with app switch eligibility.
+@_documentation(visibility: private)
+public class PatchCCOWithAppSwitchEligibility {
+
+    // MARK: - Private Properties
+
+    private let coreConfig: CoreConfig
+    private let networkingClient: NetworkingClient
+    private let authenticationSecureTokenServiceAPI: AuthenticationSecureTokenServiceAPI
+
+    private let patchCCOQuery = """
+        mutation PatchCcoWithAppSwitchEligibility(
+            $contextId: String!,
+            $experimentationContext: externalExperimentationContextInput,
+            $osType: externalOSType!,
+            $merchantOptInForAppSwitch: Boolean!,
+            $token: externalToken!,
+            $tokenType: externalTokenType!,
+            $integrationArtifact: externalIntegrationArtifactType!
+        ) {
+            external {
+                patchCcoWithAppSwitchEligibility(
+                    appSwitchEligibilityInput: {
+                        contextId: $contextId,
+                        experimentationContext: $experimentationContext,
+                        merchantOptInForAppSwitch: $merchantOptInForAppSwitch,
+                        osType: $osType,
+                        token: $token,
+                        tokenType: $tokenType
+                    },
+                    patchCcoInput: {
+                        token: $token,
+                        clientConfig: {
+                            integrationArtifact: $integrationArtifact
+                        }
+                    }
+                ) {
+                    appSwitchEligibility {
+                        appSwitchEligible
+                        redirectURL
+                        ineligibleReason
+                    }
+                }
+            }
+        }
+        """
+
+    // MARK: - Initializer
+
+    public init(coreConfig: CoreConfig) {
+        self.coreConfig = coreConfig
+        self.networkingClient = NetworkingClient(coreConfig: coreConfig)
+        self.authenticationSecureTokenServiceAPI = AuthenticationSecureTokenServiceAPI(coreConfig: coreConfig)
+    }
+
+    /// Exposed for injecting MockNetworkingClient in tests
+    init(
+        coreConfig: CoreConfig,
+        networkingClient: NetworkingClient,
+        authenticationSecureTokenServiceAPI: AuthenticationSecureTokenServiceAPI
+    ) {
+        self.coreConfig = coreConfig
+        self.networkingClient = networkingClient
+        self.authenticationSecureTokenServiceAPI = authenticationSecureTokenServiceAPI
+    }
+
+    // MARK: - Internal Methods
+
+    public func patchCCOWithAppSwitchEligibility(
+        token: String,
+        tokenType: String
+    ) async throws -> AppSwitchEligibility {
+
+        let lsat = try await authenticationSecureTokenServiceAPI.createLowScopedAccessToken().accessToken
+
+        let variables = PatchCcoWithAppSwitchEligibilityVariables(
+            contextId: token,
+            experimentationContext: ExperimentationContext(integrationChannel: "PPCP_NATIVE_SDK"),
+            osType: "IOS",
+            merchantOptInForAppSwitch: true,
+            token: token,
+            tokenType: tokenType,
+            integrationArtifact: "MOBILE_SDK",
+            paypalNativeAppInstalled: true
+        )
+
+        let graphQLRequest = GraphQLRequest(
+            query: patchCCOQuery,
+            variables: variables,
+            queryNameForURL: nil
+        )
+
+        let httpResponse = try await networkingClient.fetch(
+            request: graphQLRequest,
+            clientContext: token,
+            additionalHeaders: [.authorization: "Bearer \(lsat)"]
+        )
+
+        let parsed: PatchCcoWithAppSwitchEligibilityResponse =
+        try HTTPResponseParser().parseGraphQL(httpResponse, as: PatchCcoWithAppSwitchEligibilityResponse.self)
+
+        guard
+            let eligibility = parsed.external?
+                .patchCcoWithAppSwitchEligibility?
+                .appSwitchEligibility
+        else {
+            throw NetworkingError.noGraphQLDataKey
+        }
+
+        return eligibility
+    }
+}

--- a/Sources/CorePayments/PatchCcoWithAppSwitchEligibilityResponse.swift
+++ b/Sources/CorePayments/PatchCcoWithAppSwitchEligibilityResponse.swift
@@ -1,0 +1,25 @@
+import Foundation
+
+@_documentation(visibility: private)
+public struct PatchCcoWithAppSwitchEligibilityResponse: Decodable {
+
+    let external: ExternalNode?
+
+    struct ExternalNode: Decodable {
+
+        let patchCcoWithAppSwitchEligibility: PatchNode?
+    }
+
+    struct PatchNode: Decodable {
+
+        let appSwitchEligibility: AppSwitchEligibility?
+    }
+}
+
+@_documentation(visibility: private)
+public struct AppSwitchEligibility: Decodable {
+    
+    public let appSwitchEligible: Bool?
+    public let redirectURL: String?
+    public let ineligibleReason: String?
+}

--- a/Sources/CorePayments/PatchCcoWithAppSwitchEligibilityVariables.swift
+++ b/Sources/CorePayments/PatchCcoWithAppSwitchEligibilityVariables.swift
@@ -1,0 +1,21 @@
+import Foundation
+
+struct ExperimentationContext: Encodable {
+
+    let integrationChannel: String?
+    init(integrationChannel: String? = "PPCP_NATIVE_SDK") {
+        self.integrationChannel = integrationChannel
+    }
+}
+
+struct PatchCcoWithAppSwitchEligibilityVariables: Encodable {
+
+    let contextId: String
+    let experimentationContext: ExperimentationContext?
+    let osType: String
+    let merchantOptInForAppSwitch: Bool
+    let token: String
+    let tokenType: String
+    let integrationArtifact: String
+    let paypalNativeAppInstalled: Bool?
+}

--- a/Sources/PayPalWebPayments/PayPalWebCheckoutClient.swift
+++ b/Sources/PayPalWebPayments/PayPalWebCheckoutClient.swift
@@ -73,6 +73,7 @@ public class PayPalWebCheckoutClient: NSObject {
 
                 case .fallback(let reason):
                     // TODO: analytics
+                    _ = reason
                     startWebCheckoutFlow(request: request, completion: completionOnce)
                 }
             } else {

--- a/Sources/PayPalWebPayments/PayPalWebCheckoutClient.swift
+++ b/Sources/PayPalWebPayments/PayPalWebCheckoutClient.swift
@@ -8,6 +8,8 @@ public class PayPalWebCheckoutClient: NSObject {
 
     let config: CoreConfig
 
+    var appSwitchCompletion: ((Result<PayPalWebCheckoutResult, CoreSDKError>) -> Void)?
+
     private let clientConfigAPI: UpdateClientConfigAPI
     private let webAuthenticationSession: WebAuthenticationSession
     private let networkingClient: NetworkingClient
@@ -234,6 +236,42 @@ public class PayPalWebCheckoutClient: NSObject {
                 }
             }
         }
+    }
+
+    // MARK: - App Switch Method
+
+    public func handleReturnURL(_ url: URL) {
+
+        guard let completion = appSwitchCompletion else { return }
+        defer { appSwitchCompletion = nil }
+
+        let components = URLComponents(url: url, resolvingAgainstBaseURL: false)
+        let items = components?.queryItems ?? []
+        func queryValue(_ name: String) -> String? {
+            items.first { $0.name.compare(name) == .orderedSame }?.value
+        }
+
+        let path = url.path.lowercased()
+
+        if path.contains("/cancel") {
+            notifyCheckoutCancelWithError(with: PayPalError.checkoutCanceledError, completion: completion)
+            return
+        }
+
+        if path.contains("/success"),
+        let orderID = queryValue("token"), !orderID.isEmpty,
+        let payerID = queryValue("PayerID") ?? queryValue("payer_id") ?? queryValue("payerId"), !payerID.isEmpty {
+            notifyCheckoutSuccess(for: PayPalWebCheckoutResult(orderID: orderID, payerID: payerID), completion: completion)
+            return
+        }
+
+        // TODO: Check for error in app switch returnURL, return PayPalError.webSessionError(Error)
+        if path.contains("/fail") {
+            notifyCheckoutFailure(with: PayPalError.malformedResultError, completion: completion)
+            return
+        }
+
+        notifyCheckoutFailure(with: PayPalError.malformedResultError, completion: completion)
     }
 
     private func getQueryStringParameter(url: String, param: String) -> String? {

--- a/Sources/PayPalWebPayments/PayPalWebCheckoutRequest.swift
+++ b/Sources/PayPalWebPayments/PayPalWebCheckoutRequest.swift
@@ -7,12 +7,14 @@ public struct PayPalWebCheckoutRequest {
     public let orderID: String
     /// The funding for the order: credit, paylater or default
     public let fundingSource: PayPalWebCheckoutFundingSource
+    public let appSwitchIfEligible: Bool
 
     /// Creates an instance of a PayPalRequest.
     /// - Parameter orderID: The ID of the order to be approved.
     /// - Parameter fundingSource: The funding source for and order. Default value is .paypal
-    public init(orderID: String, fundingSource: PayPalWebCheckoutFundingSource = .paypal) {
+    public init(orderID: String, fundingSource: PayPalWebCheckoutFundingSource = .paypal, appSwitchIfEligible: Bool = false) {
         self.orderID = orderID
         self.fundingSource = fundingSource
+        self.appSwitchIfEligible = appSwitchIfEligible
     }
 }

--- a/UnitTests/CorePaymentTests/AuthenticationSecureTokenServiceAPI_Tests.swift
+++ b/UnitTests/CorePaymentTests/AuthenticationSecureTokenServiceAPI_Tests.swift
@@ -1,0 +1,53 @@
+import XCTest
+@testable import CorePayments
+@testable import TestShared
+
+class AuthenticationSecureTokenServiceAPI_Tests: XCTestCase {
+
+    // MARK: - Helper Properties
+
+    var sut: AuthenticationSecureTokenServiceAPI!
+    var mockNetworkingClient: MockNetworkingClient!
+    var coreConfig = CoreConfig(clientID: "fake-client-id", environment: .sandbox)
+
+    // MARK: - Test lifecycle
+
+    override func setUp() {
+        super.setUp()
+
+        mockNetworkingClient = MockNetworkingClient(coreConfig: coreConfig)
+        sut = AuthenticationSecureTokenServiceAPI(coreConfig: coreConfig, networkingClient: mockNetworkingClient)
+    }
+
+    // MARK: - Tests
+
+    func testCreateLowScopedAccessToken_UsesFormURLEncodedContentType() async throws {
+
+        let responseBodyString = """
+        {
+            "access_token": "mock-token",
+            "token_type": "Bearer"
+        }
+        """
+
+        let responseBody = responseBodyString.data(using: .utf8)
+
+        mockNetworkingClient.stubHTTPResponse = HTTPResponse(status: 200, body: responseBody)
+
+        _ = try await sut.createLowScopedAccessToken()
+
+        guard let capturedRequest = mockNetworkingClient.capturedRESTRequest else {
+            XCTFail("No REST request was captured")
+            return
+        }
+
+        XCTAssertEqual(capturedRequest.path, "v1/oauth2/token")
+        XCTAssertEqual(capturedRequest.method, .post)
+        XCTAssertEqual(capturedRequest.contentType, .formURLEncoded)
+        if let postParams = capturedRequest.postParameters as? String {
+            XCTAssertEqual(postParams, "grant_type=client_credentials&response_type=token")
+        } else {
+            XCTFail("Post parameters should be a String for form-urlencoded requests")
+        }
+    }
+}

--- a/UnitTests/CorePaymentTests/PatchCCOWithAppSwitchEligibility.swift
+++ b/UnitTests/CorePaymentTests/PatchCCOWithAppSwitchEligibility.swift
@@ -1,0 +1,222 @@
+// swiftlint:disable indentation_width
+
+import Foundation
+import XCTest
+@testable import CorePayments
+@testable import TestShared
+
+final class PatchCCOWithAppSwitchEligibility_Tests: XCTestCase {
+
+    private var sut: PatchCCOWithAppSwitchEligibility!
+    private var mockNetworkingClient: MockNetworkingClient!
+    private var mockAuthSTS: MockAuthenticationSecureTokenServiceAPI!
+    private let coreConfig = CoreConfig(clientID: "fake-client-id", environment: .sandbox)
+    private let expectedQueryString = """
+        mutation PatchCcoWithAppSwitchEligibility(
+            $contextId: String!,
+            $experimentationContext: externalExperimentationContextInput,
+            $osType: externalOSType!,
+            $merchantOptInForAppSwitch: Boolean!,
+            $token: externalToken!,
+            $tokenType: externalTokenType!,
+            $integrationArtifact: externalIntegrationArtifactType!
+        ) {
+            external {
+                patchCcoWithAppSwitchEligibility(
+                    appSwitchEligibilityInput: {
+                        contextId: $contextId,
+                        experimentationContext: $experimentationContext,
+                        merchantOptInForAppSwitch: $merchantOptInForAppSwitch,
+                        osType: $osType,
+                        token: $token,
+                        tokenType: $tokenType
+                    },
+                    patchCcoInput: {
+                        token: $token,
+                        clientConfig: {
+                            integrationArtifact: $integrationArtifact
+                        }
+                    }
+                ) {
+                    appSwitchEligibility {
+                        appSwitchEligible
+                        redirectURL
+                        ineligibleReason
+                    }
+                }
+            }
+        }
+        """
+
+    override func setUp() {
+        super.setUp()
+        let mockHTTP = MockHTTP(coreConfig: coreConfig)
+        mockNetworkingClient = MockNetworkingClient(http: mockHTTP)
+        mockAuthSTS = MockAuthenticationSecureTokenServiceAPI(coreConfig: coreConfig)
+        sut = PatchCCOWithAppSwitchEligibility(
+            coreConfig: coreConfig,
+            networkingClient: mockNetworkingClient,
+            authenticationSecureTokenServiceAPI: mockAuthSTS
+        )
+    }
+
+    override func tearDown() {
+        sut = nil
+        mockNetworkingClient = nil
+        mockAuthSTS = nil
+        super.tearDown()
+    }
+
+    // MARK: - Tests
+
+    func test_patchCCO_constructsGraphQLRequest_variables_headers_and_clientContext() async throws {
+
+        let token = "ctx_abc123"
+        let tokenType = "CLIENT_TOKEN"
+        let lsat = "lsat_test_value"
+        mockAuthSTS.stubbedAccessToken = lsat
+
+        let successJSON = """
+        {
+        "data": {
+            "external": {
+              "patchCcoWithAppSwitchEligibility": {
+                "appSwitchEligibility": {
+                  "appSwitchEligible": true,
+                  "redirectURL": "paypal://app-switch",
+                  "ineligibleReason": null
+                }
+              }
+            }
+          }
+        }
+        """
+
+        mockNetworkingClient.stubHTTPResponse = HTTPResponse(status: 200, body: successJSON.data(using: .utf8))
+        let result = try await sut.patchCCOWithAppSwitchEligibility(token: token, tokenType: tokenType)
+        XCTAssertEqual(result.appSwitchEligible, true)
+        XCTAssertEqual(result.redirectURL, "paypal://app-switch")
+        XCTAssertNil(result.ineligibleReason)
+
+        XCTAssertNotNil(mockNetworkingClient.capturedGraphQLRequest?.query)
+        if let query = mockNetworkingClient.capturedGraphQLRequest?.query {
+            let normalizedQuery = normalizeGraphQLString(query)
+            let normalizedExpected = normalizeGraphQLString(expectedQueryString)
+            XCTAssertEqual(normalizedQuery, normalizedExpected)
+        }
+
+        XCTAssertNil(mockNetworkingClient.capturedGraphQLRequest?.queryNameForURL)
+
+        let vars = try XCTUnwrap(
+            mockNetworkingClient.capturedGraphQLRequest?.variables as? PatchCcoWithAppSwitchEligibilityVariables
+        )
+        XCTAssertEqual(vars.contextId, token)
+        XCTAssertEqual(vars.experimentationContext?.integrationChannel, "PPCP_NATIVE_SDK")
+        XCTAssertEqual(vars.osType, "IOS")
+        XCTAssertTrue(vars.merchantOptInForAppSwitch)
+        XCTAssertEqual(vars.token, token)
+        XCTAssertEqual(vars.tokenType, tokenType)
+        XCTAssertEqual(vars.integrationArtifact, "MOBILE_SDK")
+        XCTAssertEqual(vars.paypalNativeAppInstalled, true)
+
+        XCTAssertEqual(mockNetworkingClient.capturedClientContext, token)
+        XCTAssertEqual(mockNetworkingClient.capturedAdditionalHeaders?[.authorization], "Bearer \(lsat)")
+    }
+
+    func test_patchCCO_bubblesNetworkingError() async {
+        mockAuthSTS.stubbedAccessToken = "lsat_ok"
+        mockNetworkingClient.stubHTTPError = CoreSDKError(code: 999, domain: "networking", errorDescription: "boom")
+
+        do {
+            _ = try await sut.patchCCOWithAppSwitchEligibility(token: "t", tokenType: "CLIENT_TOKEN")
+            XCTFail("Expected error")
+        } catch let error as CoreSDKError {
+            XCTAssertEqual(error.domain, "networking")
+            XCTAssertEqual(error.code, 999)
+            XCTAssertEqual(error.localizedDescription, "boom")
+        } catch {
+            XCTAssert(false, "Expected CoreSDKError: \(error)")
+        }
+    }
+
+    func test_patchCCO_bubblesAuthError() async {
+        mockAuthSTS.stubbedError = CoreSDKError(code: 401, domain: "auth", errorDescription: "unauthorized")
+
+        do {
+            _ = try await sut.patchCCOWithAppSwitchEligibility(token: "t", tokenType: "CLIENT_TOKEN")
+            XCTFail("Expected auth error")
+        } catch let error as CoreSDKError {
+            XCTAssertEqual(error.domain, "auth")
+            XCTAssertEqual(error.code, 401)
+            XCTAssertEqual(error.localizedDescription, "unauthorized")
+        } catch {
+            XCTAssert(false, "Expected CoreSDKError: \(error)")
+        }
+    }
+
+    func test_patchCCO_whenMissingEligibility_throwsNoGraphQLDataKey() async {
+        mockAuthSTS.stubbedAccessToken = "lsat_ok"
+
+        let missingEligibilityJSON = """
+        {
+          "data": {
+            "external": {
+              "patchCcoWithAppSwitchEligibility": {
+              }
+            }
+          }
+        }
+        """
+        mockNetworkingClient.stubHTTPResponse = HTTPResponse(status: 200, body: missingEligibilityJSON.data(using: .utf8))
+
+        do {
+            _ = try await sut.patchCCOWithAppSwitchEligibility(token: "t", tokenType: "CLIENT_TOKEN")
+            XCTFail("Expected NetworkingError.noGraphQLDataKey")
+        } catch let error as CoreSDKError {
+            guard NetworkingError.noGraphQLDataKey == error else {
+                return XCTFail("Expected NetworkingError.noGraphQLDataKey, got \(error)")
+            }
+        } catch {
+            return XCTFail("Expected NetworkingError.noGraphQLDataKey, got \(error)")
+        }
+    }
+
+    func test_patchCCO_success_returnsParsedEligibility_falseReasoned() async throws {
+        mockAuthSTS.stubbedAccessToken = "lsat_ok"
+
+        let body = """
+        {
+          "data": {
+            "external": {
+              "patchCcoWithAppSwitchEligibility": {
+                "appSwitchEligibility": {
+                  "appSwitchEligible": false,
+                  "redirectURL": null,
+                  "ineligibleReason": "NO_INSTALLED_APP"
+                }
+              }
+            }
+          }
+        }
+        """
+        mockNetworkingClient.stubHTTPResponse = HTTPResponse(status: 200, body: body.data(using: .utf8))
+
+        let response = try await sut.patchCCOWithAppSwitchEligibility(token: "tok", tokenType: "CLIENT_TOKEN")
+
+        XCTAssertEqual(response.appSwitchEligible, false)
+        XCTAssertNil(response.redirectURL)
+        XCTAssertEqual(response.ineligibleReason, "NO_INSTALLED_APP")
+    }
+
+    // MARK: - Helper Methods
+
+    private func normalizeGraphQLString(_ string: String) -> String {
+        return string
+            .trimmingCharacters(in: .whitespacesAndNewlines)
+            .replacingOccurrences(of: "\\s+", with: " ", options: .regularExpression)
+            .replacingOccurrences(of: "\\s*\\{\\s*", with: "{", options: .regularExpression)
+            .replacingOccurrences(of: "\\s*\\}\\s*", with: "}", options: .regularExpression)
+            .replacingOccurrences(of: "\\s*\\(\\s*", with: "(", options: .regularExpression)
+            .replacingOccurrences(of: "\\s*\\)\\s*", with: ")", options: .regularExpression)
+    }
+}

--- a/UnitTests/TestShared/MockAuthenticationSecureTokenServiceAPI.swift
+++ b/UnitTests/TestShared/MockAuthenticationSecureTokenServiceAPI.swift
@@ -1,0 +1,20 @@
+import Foundation
+@testable import CorePayments
+
+class MockAuthenticationSecureTokenServiceAPI: AuthenticationSecureTokenServiceAPI {
+
+    var stubbedAccessToken: String = "lsat_stubbed"
+    var stubbedError: Error?
+
+    override init(coreConfig: CoreConfig) {
+        super.init(coreConfig: coreConfig)
+    }
+
+    override func createLowScopedAccessToken() async throws -> AuthTokenResponse {
+        if let err = stubbedError { throw err }
+        return AuthTokenResponse(
+            accessToken: stubbedAccessToken,
+            tokenType: "Bearer"
+        )
+    }
+}

--- a/UnitTests/TestShared/MockNetworkingClient.swift
+++ b/UnitTests/TestShared/MockNetworkingClient.swift
@@ -8,6 +8,8 @@ class MockNetworkingClient: NetworkingClient {
     
     var capturedRESTRequest: RESTRequest?
     var capturedGraphQLRequest: GraphQLRequest?
+    var capturedClientContext: String?
+    var capturedAdditionalHeaders: [HTTPHeader: String]?
     
     override func fetch(request: RESTRequest) async throws -> HTTPResponse {
         capturedRESTRequest = request
@@ -23,8 +25,14 @@ class MockNetworkingClient: NetworkingClient {
         throw CoreSDKError(code: 0, domain: "", errorDescription: "Stubbed responses not implemented for this mock.")
     }
     
-    override func fetch(request: GraphQLRequest, clientContext: String? = nil) async throws -> HTTPResponse {
+    override func fetch(
+        request: GraphQLRequest,
+        clientContext: String? = nil,
+        additionalHeaders: [HTTPHeader: String] = [:]
+    ) async throws -> HTTPResponse {
         capturedGraphQLRequest = request
+        capturedClientContext = clientContext
+        capturedAdditionalHeaders = additionalHeaders
         
         if let stubHTTPError {
             throw stubHTTPError


### PR DESCRIPTION
### Reason for changes

- Implement app switch if opted in, eligible or no errors in app launch

### Summary of changes

- Create appSwitchIfEligible property in PayPalWebCheckoutRequest
- Toggle existing paypal web checkout with app switch if eligible flow
- If not app switch launched, fallback to web checkout flow

TODO: unit tests

### Checklist

- [ ] Added a changelog entry

### Authors
> List GitHub usernames for everyone who contributed to this pull request.

- @KunJeongPark 