### PR TITLE
Patch CCO for CardClient approveOrder() and vault() Methods

### DIFF
--- a/Sources/PayPalWebPayments/PayPalWebCheckoutClient.swift
+++ b/Sources/PayPalWebPayments/PayPalWebCheckoutClient.swift
@@ -56,7 +56,8 @@ public class PayPalWebCheckoutClient: NSObject {
                     fundingSource: request.fundingSource.rawValue
                 )
             } catch {
-                print("error in calling graphQL: \(error.localizedDescription)")
+                // fail silently; we don't want CCO updates to prevent web authentication session
+                // from starting
             }
             
             let baseURLString = config.environment.payPalBaseURL.absoluteString


### PR DESCRIPTION
### Reason for changes

This PR adds CCO updates for `CardClient.approveOrder()` and `CardClient.vault()` 

### Summary of changes

- WIP

### Checklist

- [ ] ~Added a changelog entry~

### Authors
> List GitHub usernames for everyone who contributed to this pull request.

- @sshropshire