### PR TITLE
Fix PayPal Explicit Vault and Cancel False Positives

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 
 # PayPal iOS SDK Release Notes
+
+## unreleased
+
+* PayPalWebPayments
+  * Update `PayPalWebCheckoutClient.start()` to recognize `cancel` opType in the deep link urls (fixes #361)
+  * Update `PayPalWebCheckoutClient.vault()` to recognize `cancel` path in deep link urls (fixes #361)
   
 ## 2.0.0 (2025-03-18)
 * Breaking Changes

--- a/Sources/PayPalWebPayments/PayPalWebCheckoutClient.swift
+++ b/Sources/PayPalWebPayments/PayPalWebCheckoutClient.swift
@@ -45,7 +45,10 @@ public class PayPalWebCheckoutClient: NSObject {
     ///                   - `orderID`: The ID of the approved order.
     ///                   - `payerID`: Payer ID (or user id) associated with the transaction
     ///                 - `.failure(CoreSDKError)`: Describes the reason for failure.
-    public func start(request: PayPalWebCheckoutRequest, completion: @escaping (Result<PayPalWebCheckoutResult, CoreSDKError>) -> Void) {
+    public func start(
+        request: PayPalWebCheckoutRequest,
+        completion: @escaping (Result<PayPalWebCheckoutResult, CoreSDKError>) -> Void
+    ) {
         analyticsService = AnalyticsService(coreConfig: config, orderID: request.orderID)
         analyticsService?.sendEvent("paypal-web-payments:checkout:started")
 
@@ -83,17 +86,14 @@ public class PayPalWebCheckoutClient: NSObject {
                 },
                 sessionDidComplete: { url, error in
                     if let error = error {
+                        let sdkError: CoreSDKError
                         switch error {
                         case ASWebAuthenticationSessionError.canceledLogin:
-                            self.notifyCheckoutCancelWithError(
-                                with: PayPalError.checkoutCanceledError,
-                                completion: completion
-                            )
-                            return
+                            sdkError = PayPalError.checkoutCanceledError
                         default:
-                            self.notifyCheckoutFailure(with: PayPalError.webSessionError(error), completion: completion)
-                            return
+                            sdkError = PayPalError.webSessionError(error)
                         }
+                        self.notifyCheckoutFailure(with: sdkError, completion: completion)
                     }
                     
                     if let url = url {
@@ -191,17 +191,14 @@ public class PayPalWebCheckoutClient: NSObject {
                 },
                 sessionDidComplete: { url, error in
                     if let error = error {
+                        let sdkError: CoreSDKError
                         switch error {
                         case ASWebAuthenticationSessionError.canceledLogin:
-                            self.notifyVaultCancelWithError(
-                                with: PayPalError.vaultCanceledError,
-                                completion: completion
-                            )
-                            return
+                            sdkError = PayPalError.vaultCanceledError
                         default:
-                            self.notifyVaultFailure(with: PayPalError.webSessionError(error), completion: completion)
-                            return
+                            sdkError = PayPalError.webSessionError(error)
                         }
+                        self.notifyVaultCancelWithError(with: sdkError, completion: completion)
                     }
 
                     if let url = url {

--- a/UnitTests/PayPalWebPaymentsTests/PayPalWebCheckoutClient_Tests.swift
+++ b/UnitTests/PayPalWebPaymentsTests/PayPalWebCheckoutClient_Tests.swift
@@ -329,12 +329,12 @@ class PayPalClient_Tests: XCTestCase {
         let expectation = self.expectation(description: "Call back invoked with error")
         payPalClient.start(request: request) { result in
             switch result {
-            case .success(let result):
+            case .success:
                 XCTFail("Expected failure with error")
             case .failure(let error):
                 XCTAssertEqual(error.domain, PayPalError.domain)
-                XCTAssertEqual(error.code, PayPalError.Code.vaultCanceledError.rawValue)
-                XCTAssertEqual(error.localizedDescription, "PayPal vault has been canceled by the user")
+                XCTAssertEqual(error.code, PayPalError.Code.checkoutCanceledError.rawValue)
+                XCTAssertEqual(error.localizedDescription, "PayPal checkout has been canceled by the user")
             }
             expectation.fulfill()
         }


### PR DESCRIPTION
### Reason for changes

This PR contains fixes for #361

### Summary of changes

- Update `PayPalWebCheckoutClient.start()` to recognize `cancel` opType in the deep link urls
- Update `PayPalWebCheckoutClient.vault()` to recognize `cancel` path in deep link urls

### Checklist

- [x] Added a changelog entry

### Authors
> List GitHub usernames for everyone who contributed to this pull request.

- @sshropshire