### PR TITLE
CCO Updates for Card and PayPal Flows With Order ID

### DIFF
--- a/Sources/CorePayments/Networking/UpdateClientConfigAPI.swift
+++ b/Sources/CorePayments/Networking/UpdateClientConfigAPI.swift
@@ -62,16 +62,7 @@ public class UpdateClientConfigAPI {
         )
 
         let httpResponse = try await networkingClient.fetch(request: graphQLRequest, clientContext: token)
-        
-        #if DEBUG
-        print("HTTP Response Status: \(httpResponse.status)")
-        if let bodyData = httpResponse.body, let responseBody = String(data: bodyData, encoding: .utf8) {
-            print("HTTP Response Body: \(responseBody)")
-        } else {
-            print("HTTP Response Body: (error - could not parse)")
-        }
-        #endif
-        
+
         return try HTTPResponseParser().parseGraphQL(httpResponse, as: ClientConfigResponse.self)
     }
 }

--- a/Sources/CorePayments/Networking/UpdateClientConfigAPI.swift
+++ b/Sources/CorePayments/Networking/UpdateClientConfigAPI.swift
@@ -62,7 +62,16 @@ public class UpdateClientConfigAPI {
         )
 
         let httpResponse = try await networkingClient.fetch(request: graphQLRequest, clientContext: token)
-
+        
+        #if DEBUG
+        print("HTTP Response Status: \(httpResponse.status)")
+        if let bodyData = httpResponse.body, let responseBody = String(data: bodyData, encoding: .utf8) {
+            print("HTTP Response Body: \(responseBody)")
+        } else {
+            print("HTTP Response Body: (error - could not parse)")
+        }
+        #endif
+        
         return try HTTPResponseParser().parseGraphQL(httpResponse, as: ClientConfigResponse.self)
     }
 }

--- a/Sources/PayPalWebPayments/PayPalWebCheckoutClient.swift
+++ b/Sources/PayPalWebPayments/PayPalWebCheckoutClient.swift
@@ -65,8 +65,8 @@ public class PayPalWebCheckoutClient: NSObject {
             let baseURLString = config.environment.payPalBaseURL.absoluteString
             let payPalCheckoutURLString =
                 "\(baseURLString)/checkoutnow?token=\(request.orderID)" +
-                "&fundingSource=\(request.fundingSource.rawValue)"
-
+                "&fundingSource=\(request.fundingSource.rawValue)&integration_artifact=MOBILE_SDK"
+            
             guard let payPalCheckoutURL = URL(string: payPalCheckoutURLString),
                 let payPalCheckoutURLComponents = payPalCheckoutReturnURL(payPalCheckoutURL: payPalCheckoutURL)
             else {
@@ -160,8 +160,12 @@ public class PayPalWebCheckoutClient: NSObject {
         analyticsService = AnalyticsService(coreConfig: config, setupToken: vaultRequest.setupTokenID)
         analyticsService?.sendEvent("paypal-web-payments:vault-wo-purchase:started")
 
-        var vaultURLComponents = URLComponents(url: config.environment.paypalVaultCheckoutURL, resolvingAgainstBaseURL: false)
-        let queryItems = [URLQueryItem(name: "approval_session_id", value: vaultRequest.setupTokenID)]
+        let vaultURL = config.environment.paypalVaultCheckoutURL
+        var vaultURLComponents = URLComponents(url: vaultURL, resolvingAgainstBaseURL: false)
+        let queryItems = [
+            URLQueryItem(name: "approval_session_id", value: vaultRequest.setupTokenID),
+            URLQueryItem(name: "integration_artifact", value: "MOBILE_SDK")
+        ]
         vaultURLComponents?.queryItems = queryItems
 
         guard let vaultCheckoutURL = vaultURLComponents?.url else {

--- a/UnitTests/CardPaymentsTests/CardClient_Tests.swift
+++ b/UnitTests/CardPaymentsTests/CardClient_Tests.swift
@@ -25,6 +25,7 @@ class CardClient_Tests: XCTestCase {
     var mockNetworkingClient: MockNetworkingClient!
     var mockCheckoutOrdersAPI: MockCheckoutOrdersAPI!
     var mockVaultAPI: MockVaultPaymentTokensAPI!
+    var mockClientConfigAPI: MockClientConfigAPI!
 
     var sut: CardClient!
     
@@ -37,13 +38,14 @@ class CardClient_Tests: XCTestCase {
         cardVaultRequest = CardVaultRequest(card: card, setupTokenID: "testSetupTokenId")
 
         mockCheckoutOrdersAPI = MockCheckoutOrdersAPI(coreConfig: config, networkingClient: mockNetworkingClient)
-        
         mockVaultAPI = MockVaultPaymentTokensAPI(coreConfig: config, networkingClient: mockNetworkingClient)
+        mockClientConfigAPI = MockClientConfigAPI(coreConfig: config, networkingClient: mockNetworkingClient)
         
         sut = CardClient(
             config: config,
             checkoutOrdersAPI: mockCheckoutOrdersAPI,
             vaultAPI: mockVaultAPI,
+            clientConfigAPI: mockClientConfigAPI,
             webAuthenticationSession: mockWebAuthSession
         )
     }

--- a/UnitTests/PayPalWebPaymentsTests/PayPalWebCheckoutClient_Tests.swift
+++ b/UnitTests/PayPalWebPaymentsTests/PayPalWebCheckoutClient_Tests.swift
@@ -40,7 +40,7 @@ class PayPalClient_Tests: XCTestCase {
         payPalClient.vault(vaultRequest) { _ in }
         wait(for: [started], timeout: 1.0)
 
-        XCTAssertEqual(mockWebAuthenticationSession.lastLaunchedURL?.absoluteString, "https://sandbox.paypal.com/agreements/approve?approval_session_id=fake-token")
+        XCTAssertEqual(mockWebAuthenticationSession.lastLaunchedURL?.absoluteString, "https://sandbox.paypal.com/agreements/approve?approval_session_id=fake-token&integration_artifact=MOBILE_SDK")
     }
     
     func testVault_whenLive_launchesCorrectURLInWebSession() {
@@ -61,7 +61,7 @@ class PayPalClient_Tests: XCTestCase {
         payPalClient.vault(vaultRequest) { _ in }
         wait(for: [started], timeout: 1.0)
 
-        XCTAssertEqual(mockWebAuthenticationSession.lastLaunchedURL?.absoluteString, "https://paypal.com/agreements/approve?approval_session_id=fake-token")
+        XCTAssertEqual(mockWebAuthenticationSession.lastLaunchedURL?.absoluteString, "https://paypal.com/agreements/approve?approval_session_id=fake-token&integration_artifact=MOBILE_SDK")
     }
     
     func testVault_whenSuccessUrl_ReturnsVaultToken() {


### PR DESCRIPTION
### Summary of changes

- This PR removes CCO updates for vault flows since there is no associated order id, which makes CCO updates irrelevant.
- This PR adds a CCO update for `Card.approveOrder()` flows.

### Checklist

- [ ] ~Added a changelog entry~

### Authors
> List GitHub usernames for everyone who contributed to this pull request.

- @sshropshire