### PR TITLE
Update CI to `macos-26`

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -6,28 +6,28 @@ concurrency:
 jobs:
   cocoapods:
     name: CocoaPods
-    runs-on: macOS-13
+    runs-on: macos-26
     steps:
       - name: Check out repository
         uses: actions/checkout@v3
         with:
           ref: ${{ github.event.pull_request.head.ref }}
           repository: ${{ github.event.pull_request.head.repo.full_name }}
-      - name: Use Xcode 15.1
-        run: sudo xcode-select -switch /Applications/Xcode_15.1.app
+      - name: Select Xcode Version
+        run: sudo xcode-select -switch /Applications/Xcode_26.0.1.app/Contents/Developer
       - name: Run pod lib lint
         run: pod lib lint
   spm:
     name: Swift Package Manager
-    runs-on: macOS-13
+    runs-on: macos-26
     steps:
       - name: Check out repository
         uses: actions/checkout@v3
         with:
           ref: ${{ github.event.pull_request.head.ref }}
           repository: ${{ github.event.pull_request.head.repo.full_name }}
-      - name: Use Xcode 15.1
-        run: sudo xcode-select -switch /Applications/Xcode_15.1.app
+      - name: Select Xcode Version
+        run: sudo xcode-select -switch /Applications/Xcode_26.0.1.app/Contents/Developer
       - name: Use current branch
         run: sed -i '' 's/branch = .*/branch = \"'"${GITHUB_HEAD_REF//\//\/}"'\";/' SampleApps/SPMTest/SPMTest.xcodeproj/project.pbxproj
       - name: Run swift package resolve

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -8,14 +8,14 @@ on:
 jobs:
   release:
     name: Release
-    runs-on: macOS-13
+    runs-on: macos-26
     steps:
       - name: Check out repository
         uses: actions/checkout@v3
         with:
           fetch-depth: 0
-      - name: Use Xcode 15.1
-        run: sudo xcode-select -switch /Applications/Xcode_15.1.app
+      - name: Select Xcode Version
+        run: sudo xcode-select -switch /Applications/Xcode_26.0.1.app/Contents/Developer
       - name: Check for unreleased section in changelog
         run: grep "## unreleased" CHANGELOG.md || (echo "::error::No unreleased section found in CHANGELOG" && exit 1)
       - name: Set git username and email

--- a/.github/workflows/swiftlint.yml
+++ b/.github/workflows/swiftlint.yml
@@ -6,12 +6,12 @@ concurrency:
 jobs:
   swiftlint:
     name: SwiftLint
-    runs-on: macOS-14
+    runs-on: macos-26
     steps:
       - name: Check out repository
         uses: actions/checkout@v2
-      - name: Use Xcode 15.1
-        run: sudo xcode-select -switch /Applications/Xcode_15.1.app
+      - name: Select Xcode Version
+        run: sudo xcode-select -switch /Applications/Xcode_26.0.1.app/Contents/Developer
       - name: Install SwiftLint
         run: brew install swiftlint
       - name: Run SwiftLint

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -6,14 +6,14 @@ concurrency:
 jobs:
   unit_test_job:
     name: Unit
-    runs-on: macOS-13
+    runs-on: macos-26
     steps:
       - name: Checkout repository
         uses: actions/checkout@v3
         with:
           ref: ${{ github.event.pull_request.head.ref }}
           repository: ${{ github.event.pull_request.head.repo.full_name }}
-      - name: Use Xcode 15.1
-        run: sudo xcode-select -switch /Applications/Xcode_15.1.app
+      - name: Select Xcode Version
+        run: sudo xcode-select -switch /Applications/Xcode_26.0.1.app/Contents/Developer
       - name: Run Unit Tests
-        run: set -o pipefail && xcodebuild -workspace 'PayPal.xcworkspace' -sdk 'iphonesimulator' -configuration 'Debug' -scheme 'UnitTests' -destination 'name=iPhone 14,platform=iOS Simulator' test | xcpretty
+        run: set -o pipefail && xcodebuild -workspace 'PayPal.xcworkspace' -sdk 'iphonesimulator' -configuration 'Debug' -scheme 'UnitTests' -destination 'platform=iOS Simulator,name=iPhone 17' test | xcpretty


### PR DESCRIPTION
### Reason for changes

This PR updates our CI to use macOS 26 since macOS 13 GitHub Actions runners [have been sunset](https://github.com/actions/runner-images/issues/13046).

### Summary of changes

- Change all GitHub Actions workflows in this repository to use `macos-26` runners. 

### Checklist

- [ ] ~Added a changelog entry~

### Authors
> List GitHub usernames for everyone who contributed to this pull request.

- @sshropshire