### PR TITLE
Add Manual DocC Documentation Publishing Workflow

### DIFF
--- a/.github/workflows/publish-docs.yml
+++ b/.github/workflows/publish-docs.yml
@@ -1,0 +1,243 @@
+name: Publish Documentation
+on:
+  workflow_dispatch:
+    inputs:
+      environment:
+        description: 'Deploy to production or preview'
+        required: true
+        type: choice
+        options:
+          - production
+          - preview
+jobs:
+  publish-docs:
+    name: Publish Documentation
+    runs-on: macos-26
+    steps:
+      - name: Check out repository
+        uses: actions/checkout@v3
+        with:
+          fetch-depth: 0
+      - name: Select Xcode Version
+        run: sudo xcode-select -switch /Applications/Xcode_26.0.1.app/Contents/Developer
+      - name: Set git username and email
+        run: |
+          git config user.name paypalsdks
+          git config user.email sdks@paypal.com
+      - name: Generate documentation
+        run: |
+          # Create output directories
+          mkdir -p docs archives
+          rm -rf ./DerivedData
+
+          # Modules to generate documentation for
+          MODULES=("CorePayments" "CardPayments" "PaymentButtons" "PayPalWebPayments" "FraudProtection")
+
+          # Build documentation archives for each module
+          echo ""
+          echo "Building documentation archives for each module..."
+          echo ""
+
+          for module in "${MODULES[@]}"; do
+            echo "================================================"
+            echo "Building documentation archive for $module..."
+            echo "================================================"
+
+            # Build documentation for this module
+            xcodebuild docbuild \
+              -scheme "$module" \
+              -destination 'platform=iOS Simulator,name=iPhone 17' \
+              -derivedDataPath ./DerivedData
+
+            # Find the .doccarchive for this module
+            ARCHIVE=$(find ./DerivedData -name "*.doccarchive" -type d | head -n 1)
+
+            if [ -z "$ARCHIVE" ]; then
+              echo "Error: No .doccarchive found for $module"
+              rm -rf ./DerivedData archives
+              exit 1
+            fi
+
+            # Save the archive
+            cp -R "$ARCHIVE" "archives/$module.doccarchive"
+            echo "$module archive saved"
+
+            # Clean up DerivedData for next module
+            rm -rf ./DerivedData
+            echo ""
+          done
+
+          # Merge all archives into a combined archive
+          echo "================================================"
+          echo "Merging all documentation archives..."
+          echo "================================================"
+
+          xcrun docc merge \
+            archives/CorePayments.doccarchive \
+            archives/CardPayments.doccarchive \
+            archives/PaymentButtons.doccarchive \
+            archives/PayPalWebPayments.doccarchive \
+            archives/FraudProtection.doccarchive \
+            --output-path archives/PayPal.doccarchive \
+            --synthesized-landing-page-name "PayPal iOS SDK"
+
+          if [ ! -d "archives/PayPal.doccarchive" ]; then
+            echo "Error: Failed to merge documentation archives"
+            rm -rf archives
+            exit 1
+          fi
+
+          echo "Documentation archives merged successfully"
+          echo ""
+
+          # Convert merged archive to static HTML
+          echo "================================================"
+          echo "Converting to static HTML..."
+          echo "================================================"
+
+          # Set hosting base path based on environment
+          if [ "${{ github.event.inputs.environment }}" == "preview" ]; then
+            BASE_PATH="paypal-ios/preview"
+          else
+            BASE_PATH="paypal-ios"
+          fi
+
+          xcrun docc process-archive transform-for-static-hosting \
+            archives/PayPal.doccarchive \
+            --output-path docs \
+            --hosting-base-path "$BASE_PATH"
+
+          # Clean up archives
+          rm -rf archives
+
+          # Add custom CSS to hide module icons
+          echo "================================================"
+          echo "Hiding module icons..."
+          echo "================================================"
+
+          cat > docs/css/custom-hide-icons.css << 'EOF'
+          /* Hide module icon containers completely */
+          .reference-card-grid-item__image,
+          .card-cover,
+          .TopicTypeIcon,
+          .reference-card-grid-item__icon {
+            display: none !important;
+          }
+          EOF
+
+          # Inject custom CSS into all HTML files
+          find docs -name "*.html" -type f -exec sed -i '' 's|</head>|<link rel="stylesheet" href="/css/custom-hide-icons.css"></head>|g' {} \;
+
+          echo "Module icons hidden"
+          echo ""
+
+          # Add environment badge to documentation
+          echo "================================================"
+          echo "Adding environment badge..."
+          echo "================================================"
+
+          COMMIT_SHA=$(git rev-parse --short HEAD)
+          TIMESTAMP=$(date -u +"%Y-%m-%d %H:%M:%S UTC")
+
+          if [ "${{ github.event.inputs.environment }}" == "preview" ]; then
+            BADGE_COLOR="#ff9800"
+            BADGE_TEXT="PREVIEW"
+            ENV_MESSAGE="Preview documentation generated from commit $COMMIT_SHA on $TIMESTAMP"
+          else
+            BADGE_COLOR="#4caf50"
+            BADGE_TEXT="PRODUCTION"
+            ENV_MESSAGE="Documentation generated from commit $COMMIT_SHA on $TIMESTAMP"
+          fi
+
+          # Add custom CSS for environment badge
+          cat >> docs/css/custom-hide-icons.css << EOF
+
+          /* Environment badge */
+          body::before {
+            content: "$BADGE_TEXT";
+            position: fixed;
+            top: 10px;
+            right: 10px;
+            background: $BADGE_COLOR;
+            color: white;
+            padding: 8px 16px;
+            border-radius: 4px;
+            font-weight: bold;
+            font-size: 12px;
+            z-index: 10000;
+            box-shadow: 0 2px 8px rgba(0,0,0,0.2);
+          }
+
+          /* Environment footer */
+          body::after {
+            content: "$ENV_MESSAGE";
+            position: fixed;
+            bottom: 10px;
+            left: 50%;
+            transform: translateX(-50%);
+            background: rgba(0,0,0,0.8);
+            color: white;
+            padding: 6px 12px;
+            border-radius: 4px;
+            font-size: 11px;
+            z-index: 10000;
+          }
+          EOF
+
+          echo "Environment badge added"
+          echo ""
+          echo "================================================"
+          echo "Documentation generated successfully!"
+          echo "================================================"
+          echo ""
+
+      - name: Publish to GitHub Pages
+        run: |
+          # Switch to gh-pages branch and publish
+          git fetch origin gh-pages:gh-pages || git checkout --orphan gh-pages
+          git checkout gh-pages
+
+          if [ "${{ github.event.inputs.environment }}" == "preview" ]; then
+            echo "Publishing to preview environment..."
+
+            # Create preview directory
+            mkdir -p preview
+
+            # Remove existing preview content
+            rm -rf preview/*
+
+            # Copy generated docs to preview directory
+            cp -R docs/* preview/
+
+            # Add and commit changes
+            git add preview
+            git commit -m "Publish preview documentation (commit: ${{ github.sha }})"
+
+            echo ""
+            echo "================================================"
+            echo "Preview documentation published!"
+            echo "================================================"
+            echo "URL: https://paypal.github.io/paypal-ios/preview/documentation/"
+            echo ""
+          else
+            echo "Publishing to production environment..."
+
+            # Remove all existing content except preview directory
+            find . -maxdepth 1 ! -name '.git' ! -name 'preview' ! -name '.' -exec rm -rf {} +
+
+            # Copy generated docs to root
+            cp -R docs/* .
+
+            # Add and commit changes
+            git add .
+            git commit -m "Publish production documentation (commit: ${{ github.sha }})"
+
+            echo ""
+            echo "================================================"
+            echo "Production documentation published!"
+            echo "================================================"
+            echo "URL: https://paypal.github.io/paypal-ios/documentation/"
+            echo ""
+          fi
+
+          git push origin gh-pages --force

--- a/.github/workflows/publish-docs.yml
+++ b/.github/workflows/publish-docs.yml
@@ -3,12 +3,13 @@ on:
   workflow_dispatch:
     inputs:
       environment:
-        description: 'Deploy to production or preview'
+        description: 'Deploy to production, preview, or cleanup preview'
         required: true
         type: choice
         options:
           - production
           - preview
+          - cleanup-preview
 jobs:
   publish-docs:
     name: Publish Documentation
@@ -25,76 +26,8 @@ jobs:
           git config user.name paypalsdks
           git config user.email sdks@paypal.com
       - name: Generate documentation
+        if: github.event.inputs.environment != 'cleanup-preview'
         run: |
-          # Create output directories
-          mkdir -p docs archives
-          rm -rf ./DerivedData
-
-          # Modules to generate documentation for
-          MODULES=("CorePayments" "CardPayments" "PaymentButtons" "PayPalWebPayments" "FraudProtection")
-
-          # Build documentation archives for each module
-          echo ""
-          echo "Building documentation archives for each module..."
-          echo ""
-
-          for module in "${MODULES[@]}"; do
-            echo "================================================"
-            echo "Building documentation archive for $module..."
-            echo "================================================"
-
-            # Build documentation for this module
-            xcodebuild docbuild \
-              -scheme "$module" \
-              -destination 'platform=iOS Simulator,name=iPhone 17' \
-              -derivedDataPath ./DerivedData
-
-            # Find the .doccarchive for this module
-            ARCHIVE=$(find ./DerivedData -name "*.doccarchive" -type d | head -n 1)
-
-            if [ -z "$ARCHIVE" ]; then
-              echo "Error: No .doccarchive found for $module"
-              rm -rf ./DerivedData archives
-              exit 1
-            fi
-
-            # Save the archive
-            cp -R "$ARCHIVE" "archives/$module.doccarchive"
-            echo "$module archive saved"
-
-            # Clean up DerivedData for next module
-            rm -rf ./DerivedData
-            echo ""
-          done
-
-          # Merge all archives into a combined archive
-          echo "================================================"
-          echo "Merging all documentation archives..."
-          echo "================================================"
-
-          xcrun docc merge \
-            archives/CorePayments.doccarchive \
-            archives/CardPayments.doccarchive \
-            archives/PaymentButtons.doccarchive \
-            archives/PayPalWebPayments.doccarchive \
-            archives/FraudProtection.doccarchive \
-            --output-path archives/PayPal.doccarchive \
-            --synthesized-landing-page-name "PayPal iOS SDK"
-
-          if [ ! -d "archives/PayPal.doccarchive" ]; then
-            echo "Error: Failed to merge documentation archives"
-            rm -rf archives
-            exit 1
-          fi
-
-          echo "Documentation archives merged successfully"
-          echo ""
-
-          # Convert merged archive to static HTML
-          echo "================================================"
-          echo "Converting to static HTML..."
-          echo "================================================"
-
           # Set hosting base path based on environment
           if [ "${{ github.event.inputs.environment }}" == "preview" ]; then
             BASE_PATH="paypal-ios/preview"
@@ -102,34 +35,8 @@ jobs:
             BASE_PATH="paypal-ios"
           fi
 
-          xcrun docc process-archive transform-for-static-hosting \
-            archives/PayPal.doccarchive \
-            --output-path docs \
-            --hosting-base-path "$BASE_PATH"
-
-          # Clean up archives
-          rm -rf archives
-
-          # Add custom CSS to hide module icons
-          echo "================================================"
-          echo "Hiding module icons..."
-          echo "================================================"
-
-          cat > docs/css/custom-hide-icons.css << 'EOF'
-          /* Hide module icon containers completely */
-          .reference-card-grid-item__image,
-          .card-cover,
-          .TopicTypeIcon,
-          .reference-card-grid-item__icon {
-            display: none !important;
-          }
-          EOF
-
-          # Inject custom CSS into all HTML files
-          find docs -name "*.html" -type f -exec sed -i '' 's|</head>|<link rel="stylesheet" href="/css/custom-hide-icons.css"></head>|g' {} \;
-
-          echo "Module icons hidden"
-          echo ""
+          # Generate documentation using shared script
+          ./ci generate_docs "$BASE_PATH"
 
           # Add environment badge to documentation
           echo "================================================"
@@ -197,7 +104,29 @@ jobs:
           git fetch origin gh-pages:gh-pages || git checkout --orphan gh-pages
           git checkout gh-pages
 
-          if [ "${{ github.event.inputs.environment }}" == "preview" ]; then
+          if [ "${{ github.event.inputs.environment }}" == "cleanup-preview" ]; then
+            echo "Cleaning up preview documentation..."
+
+            # Remove preview directory if it exists
+            if [ -d "preview" ]; then
+              rm -rf preview
+              git add preview
+              git commit -m "Remove preview documentation" || echo "No preview directory to remove"
+
+              echo ""
+              echo "================================================"
+              echo "Preview documentation removed!"
+              echo "================================================"
+              echo ""
+            else
+              echo ""
+              echo "================================================"
+              echo "No preview documentation found to remove"
+              echo "================================================"
+              echo ""
+            fi
+
+          elif [ "${{ github.event.inputs.environment }}" == "preview" ]; then
             echo "Publishing to preview environment..."
 
             # Create preview directory
@@ -219,6 +148,7 @@ jobs:
             echo "================================================"
             echo "URL: https://paypal.github.io/paypal-ios/preview/documentation/"
             echo ""
+
           else
             echo "Publishing to production environment..."
 

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -52,3 +52,33 @@ jobs:
         env:
           COCOAPODS_TRUNK_TOKEN: ${{ secrets.COCOAPODS_TRUNK_TOKEN }}
         run: pod trunk push PayPal.podspec
+      - name: Clean up preview documentation
+        run: |
+          git config user.name paypalsdks
+          git config user.email sdks@paypal.com
+
+          # Switch to gh-pages branch
+          git fetch origin gh-pages:gh-pages || git checkout --orphan gh-pages
+          git checkout gh-pages
+
+          echo "Cleaning up preview documentation..."
+
+          # Remove preview directory if it exists
+          if [ -d "preview" ]; then
+            rm -rf preview
+            git add preview
+            git commit -m "Remove preview documentation (automated cleanup during release ${{ github.event.inputs.version }})" || echo "No preview directory to remove"
+            git push origin gh-pages
+
+            echo ""
+            echo "================================================"
+            echo "Preview documentation removed!"
+            echo "================================================"
+            echo ""
+          else
+            echo ""
+            echo "================================================"
+            echo "No preview documentation found to remove"
+            echo "================================================"
+            echo ""
+          fi

--- a/.gitignore
+++ b/.gitignore
@@ -38,3 +38,6 @@ Carthage/
 .build
 SampleApps/SPMTest/SPMTest.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
 
+# DocC Documentation
+docs/
+*.doccarchive

--- a/Sources/CardPayments/Models/PaymentSource.swift
+++ b/Sources/CardPayments/Models/PaymentSource.swift
@@ -3,6 +3,7 @@ import Foundation
 import CorePayments
 #endif
 
+@_documentation(visibility: private)
 public struct PaymentSource: Decodable {
 
     /// The card used as payment
@@ -26,12 +27,14 @@ public struct PaymentSource: Decodable {
     }
 }
 
+@_documentation(visibility: private)
 public struct AuthenticationResult: Decodable {
 
     public let liabilityShift: String?
     public let threeDSecure: ThreeDSecure?
 }
 
+@_documentation(visibility: private)
 public struct ThreeDSecure: Decodable {
 
     public let enrollmentStatus, authenticationStatus: String?

--- a/Sources/CorePayments/CorePaymentsError.swift
+++ b/Sources/CorePayments/CorePaymentsError.swift
@@ -1,3 +1,4 @@
+@_documentation(visibility: private)
 public enum CorePaymentsError {
 
     static let domain = "CorePaymentsErrorDomain"

--- a/Sources/CorePayments/Networking/Enums/HTTPHeader.swift
+++ b/Sources/CorePayments/Networking/Enums/HTTPHeader.swift
@@ -1,5 +1,6 @@
 import Foundation
 
+@_documentation(visibility: private)
 public enum HTTPHeader: String {
     case accept = "Accept"
     case acceptLanguage = "Accept-Language"

--- a/Sources/CorePayments/Networking/Enums/HTTPMethod.swift
+++ b/Sources/CorePayments/Networking/Enums/HTTPMethod.swift
@@ -4,6 +4,7 @@ import Foundation
 /// Request method associated with a URL request
 /// For more information, see https://developer.mozilla.org/en-US/docs/Web/HTTP/Methods
 /// Methods can be added here as they are needed
+@_documentation(visibility: private)
 public enum HTTPMethod: String {
     case get = "GET"
     case post = "POST"

--- a/Sources/CorePayments/Networking/NetworkingError.swift
+++ b/Sources/CorePayments/Networking/NetworkingError.swift
@@ -1,5 +1,6 @@
 import Foundation
 
+@_documentation(visibility: private)
 public enum NetworkingError {
 
     static let domain = "NetworkingClientErrorDomain"

--- a/Sources/CorePayments/WebAuthenticationSession.swift
+++ b/Sources/CorePayments/WebAuthenticationSession.swift
@@ -1,6 +1,7 @@
 import Foundation
 import AuthenticationServices
 
+@_documentation(visibility: private)
 public class WebAuthenticationSession: NSObject {
 
     public func start(

--- a/Sources/PaymentButtons/Coordinator.swift
+++ b/Sources/PaymentButtons/Coordinator.swift
@@ -1,6 +1,7 @@
 import Foundation
 
 /// Coordinator class for passing actions to our UIKit buttons in SwiftUI
+@_documentation(visibility: private)
 public class Coordinator {
 
     var action: () -> Void

--- a/ci
+++ b/ci
@@ -4,6 +4,9 @@ command_name="$1"
 
 case $command_name in
   generate_docs)
+    # Optional parameter for hosting base path (used by CI)
+    HOSTING_BASE_PATH="${2:-}"
+
     echo "Generating combined DocC documentation for PayPal iOS SDK..."
 
     # Create output directory
@@ -75,9 +78,13 @@ case $command_name in
     echo "Converting to static HTML..."
     echo "================================================"
 
-    xcrun docc process-archive transform-for-static-hosting \
-      archives/PayPal.doccarchive \
-      --output-path docs
+    # Build transform command with optional hosting base path
+    TRANSFORM_CMD="xcrun docc process-archive transform-for-static-hosting archives/PayPal.doccarchive --output-path docs"
+    if [ -n "$HOSTING_BASE_PATH" ]; then
+      TRANSFORM_CMD="$TRANSFORM_CMD --hosting-base-path $HOSTING_BASE_PATH"
+    fi
+
+    eval $TRANSFORM_CMD
 
     # Clean up archives
     rm -rf archives

--- a/ci
+++ b/ci
@@ -1,0 +1,134 @@
+#!/usr/bin/env bash
+
+command_name="$1"
+
+case $command_name in
+  generate_docs)
+    echo "Generating combined DocC documentation for PayPal iOS SDK..."
+
+    # Create output directory
+    mkdir -p docs archives
+    rm -rf ./DerivedData
+
+    # Modules to generate documentation for
+    MODULES=("CorePayments" "CardPayments" "PaymentButtons" "PayPalWebPayments" "FraudProtection")
+
+    # Build documentation archives for each module
+    echo ""
+    echo "Building documentation archives for each module..."
+    echo ""
+
+    for module in "${MODULES[@]}"; do
+      echo "================================================"
+      echo "Building documentation archive for $module..."
+      echo "================================================"
+
+      # Build documentation for this module
+      xcodebuild docbuild \
+        -scheme "$module" \
+        -destination 'platform=iOS Simulator,name=iPhone 17' \
+        -derivedDataPath ./DerivedData
+
+      # Find the .doccarchive for this module
+      ARCHIVE=$(find ./DerivedData -name "*.doccarchive" -type d | head -n 1)
+
+      if [ -z "$ARCHIVE" ]; then
+        echo "❌ Error: No .doccarchive found for $module"
+        rm -rf ./DerivedData archives
+        exit 1
+      fi
+
+      # Save the archive
+      cp -R "$ARCHIVE" "archives/$module.doccarchive"
+      echo "✅ $module archive saved"
+
+      # Clean up DerivedData for next module
+      rm -rf ./DerivedData
+      echo ""
+    done
+
+    # Merge all archives into a combined archive
+    echo "================================================"
+    echo "Merging all documentation archives..."
+    echo "================================================"
+
+    xcrun docc merge \
+      archives/CorePayments.doccarchive \
+      archives/CardPayments.doccarchive \
+      archives/PaymentButtons.doccarchive \
+      archives/PayPalWebPayments.doccarchive \
+      archives/FraudProtection.doccarchive \
+      --output-path archives/PayPal.doccarchive \
+      --synthesized-landing-page-name "PayPal iOS SDK"
+
+    if [ ! -d "archives/PayPal.doccarchive" ]; then
+      echo "❌ Error: Failed to merge documentation archives"
+      rm -rf archives
+      exit 1
+    fi
+
+    echo "✅ Documentation archives merged successfully"
+    echo ""
+
+    # Convert merged archive to static HTML
+    echo "================================================"
+    echo "Converting to static HTML..."
+    echo "================================================"
+
+    xcrun docc process-archive transform-for-static-hosting \
+      archives/PayPal.doccarchive \
+      --output-path docs
+
+    # Clean up archives
+    rm -rf archives
+
+    # Add custom CSS to hide module icons
+    echo "================================================"
+    echo "Hiding module icons..."
+    echo "================================================"
+
+    cat > docs/css/custom-hide-icons.css << 'EOF'
+/* Hide module icon containers completely */
+.reference-card-grid-item__image,
+.card-cover,
+.TopicTypeIcon,
+.reference-card-grid-item__icon {
+  display: none !important;
+}
+EOF
+
+    # Inject custom CSS into all HTML files
+    find docs -name "*.html" -type f -exec sed -i '' 's|</head>|<link rel="stylesheet" href="/css/custom-hide-icons.css"></head>|g' {} \;
+
+    echo "✅ Module icons hidden"
+    echo ""
+    echo "================================================"
+    echo "✅ Documentation generated successfully!"
+    echo "================================================"
+    echo ""
+    echo "Documentation landing page: ./docs/documentation/index.html"
+    echo ""
+    echo "To view documentation:"
+    echo "  1. Run: ./ci serve_docs"
+    echo "  2. Open: http://localhost:8000/documentation/"
+    ;;
+
+  serve_docs)
+    echo "Starting local web server to view documentation..."
+    echo ""
+    echo "Documentation will be available at:"
+    echo "  http://localhost:8000/index.html"
+    echo ""
+    echo "Press Ctrl+C to stop the server"
+    echo ""
+    cd docs && python3 -m http.server 8000
+    ;;
+
+  *)
+    echo "Usage: ./ci <command>"
+    echo ""
+    echo "Available commands:"
+    echo "  generate_docs    Generate DocC reference documentation locally"
+    echo "  serve_docs       Start a local web server to view the documentation"
+    ;;
+esac


### PR DESCRIPTION
## Summary
  Adds comprehensive DocC documentation generation with both local development and
  automated publishing workflows.

  ## Changes
  1. **Local Documentation Generation**
     - New `ci` script for generating and serving docs locally
     - Commands: `./ci generate_docs` and `./ci serve_docs`
     - Updated .gitignore to exclude generated docs and archives

  2. **DocC Visibility Control**
     - Mark internal implementation types as private in documentation
     - Improves clarity by hiding types developers shouldn't directly use
     - Affects CorePayments, CardPayments, and PaymentButtons modules

  3. **Manual Publishing Workflow**
     - New `publish-docs.yml` workflow with three modes:
       - `preview`: Publishes docs to `/preview` path with preview badge
       - `production`: Publishes docs to main path
       - `cleanup-preview`: Removes preview documentation
     - Manually triggered via GitHub Actions UI

  ## Usage
  **Local Development:**
  ```bash
  ./ci generate_docs  # Generate documentation
  ./ci serve_docs     # View at http://localhost:8000/documentation/
```

  Publishing (after merge):
  - Go to Actions → "Publish Documentation" → Run workflow → Select environment

### Checklist

- [ ] Added a changelog entry

### Authors
> List GitHub usernames for everyone who contributed to this pull request.

-  @MikeThorntonPayPal 