### PR TITLE
Remove Jira ticket references from workflow documentation

### DIFF
--- a/.github/workflows/publish-docs.yml
+++ b/.github/workflows/publish-docs.yml
@@ -4,7 +4,6 @@
 # All GitHub context variables are validated and isolated in environment variables before shell execution.
 #
 # Security References:
-# - Jira: LI-144104, LI-121611, LI-143136
 
 name: Publish Documentation
 on:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -13,7 +13,6 @@
 # - Validation enforced before any operations occur
 #
 # Security References:
-# - Jira: LI-144104, LI-121611, LI-143136
 # - GitHub Discussion: https://github.com/orgs/community/discussions/48373#discussioncomment-7543209
 # - SemVer Regex: https://semver.org/#is-there-a-suggested-regular-expression-regex-to-check-a-semver-string
 


### PR DESCRIPTION
## Summary

Removes internal Jira ticket references from GitHub Actions workflow documentation headers as requested by the security team during verification.

## Changes Made

- `.github/workflows/publish-docs.yml` - Removed Jira reference line
- `.github/workflows/release.yml` - Removed Jira reference line

All security documentation and hardening measures remain intact. Only internal ticket references have been removed to clean up the public documentation.

## Files Modified

- `.github/workflows/release.yml` - 1 deletion
- `.github/workflows/publish-docs.yml` - 1 deletion

---

🤖 Generated with [Claude Code](https://claude.com/claude-code)