### PR TITLE
HTTP and Networking Protocol Oriented Programming

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -14,7 +14,7 @@ jobs:
           ref: ${{ github.event.pull_request.head.ref }}
           repository: ${{ github.event.pull_request.head.repo.full_name }}
       - name: Select Xcode Version
-        run: sudo xcode-select -switch /Applications/Xcode_26.0.1.app/Contents/Developer
+        run: sudo xcode-select -switch /Applications/Xcode_26.4.0.app/Contents/Developer
       - name: Run pod lib lint
         run: pod lib lint
   spm:
@@ -27,7 +27,7 @@ jobs:
           ref: ${{ github.event.pull_request.head.ref }}
           repository: ${{ github.event.pull_request.head.repo.full_name }}
       - name: Select Xcode Version
-        run: sudo xcode-select -switch /Applications/Xcode_26.0.1.app/Contents/Developer
+        run: sudo xcode-select -switch /Applications/Xcode_26.4.0.app/Contents/Developer
       - name: Use current branch
         run: sed -i '' 's/branch = .*/branch = \"'"${GITHUB_HEAD_REF//\//\/}"'\";/' SampleApps/SPMTest/SPMTest.xcodeproj/project.pbxproj
       - name: Run swift package resolve

--- a/.github/workflows/publish-docs.yml
+++ b/.github/workflows/publish-docs.yml
@@ -18,7 +18,7 @@ jobs:
         with:
           fetch-depth: 0
       - name: Select Xcode Version
-        run: sudo xcode-select -switch /Applications/Xcode_26.0.1.app/Contents/Developer
+        run: sudo xcode-select -switch /Applications/Xcode_26.4.0.app/Contents/Developer
       - name: Set git username and email
         run: |
           git config user.name paypalsdks

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -33,7 +33,7 @@ jobs:
         with:
           fetch-depth: 0
       - name: Select Xcode Version
-        run: sudo xcode-select -switch /Applications/Xcode_26.0.1.app/Contents/Developer
+        run: sudo xcode-select -switch /Applications/Xcode_26.4.0.app/Contents/Developer
       - name: Check for unreleased section in changelog
         run: grep "## unreleased" CHANGELOG.md || (echo "::error::No unreleased section found in CHANGELOG" && exit 1)
       - name: Set git username and email

--- a/.github/workflows/swiftlint.yml
+++ b/.github/workflows/swiftlint.yml
@@ -11,7 +11,7 @@ jobs:
       - name: Check out repository
         uses: actions/checkout@v2
       - name: Select Xcode Version
-        run: sudo xcode-select -switch /Applications/Xcode_26.0.1.app/Contents/Developer
+        run: sudo xcode-select -switch /Applications/Xcode_26.4.0.app/Contents/Developer
       - name: Install SwiftLint
         run: brew install swiftlint
       - name: Run SwiftLint

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -14,6 +14,6 @@ jobs:
           ref: ${{ github.event.pull_request.head.ref }}
           repository: ${{ github.event.pull_request.head.repo.full_name }}
       - name: Select Xcode Version
-        run: sudo xcode-select -switch /Applications/Xcode_26.0.1.app/Contents/Developer
+        run: sudo xcode-select -switch /Applications/Xcode_26.4.0.app/Contents/Developer
       - name: Run Unit Tests
         run: set -o pipefail && xcodebuild -workspace 'PayPal.xcworkspace' -sdk 'iphonesimulator' -configuration 'Debug' -scheme 'UnitTests' -destination 'platform=iOS Simulator,name=iPhone 17,OS=26.2' test | xcpretty

--- a/PayPal.xcodeproj/project.pbxproj
+++ b/PayPal.xcodeproj/project.pbxproj
@@ -114,7 +114,7 @@
 		BE4F785527EB656400FF4C0E /* PayPalError.swift in Sources */ = {isa = PBXBuildFile; fileRef = BE4F784427EB629100FF4C0E /* PayPalError.swift */; };
 		BE4F785727EB656400FF4C0E /* PayPalWebCheckoutRequest.swift in Sources */ = {isa = PBXBuildFile; fileRef = BE4F784527EB629100FF4C0E /* PayPalWebCheckoutRequest.swift */; };
 		BE4F785827EB656400FF4C0E /* PayPalWebCheckoutResult.swift in Sources */ = {isa = PBXBuildFile; fileRef = BE4F784727EB629100FF4C0E /* PayPalWebCheckoutResult.swift */; };
-		BEA100E726EF9EDA0036A6A5 /* NetworkingClient.swift in Sources */ = {isa = PBXBuildFile; fileRef = BEA100E626EF9EDA0036A6A5 /* NetworkingClient.swift */; };
+		BEA100E726EF9EDA0036A6A5 /* HTTPNetworkingClient.swift in Sources */ = {isa = PBXBuildFile; fileRef = BEA100E626EF9EDA0036A6A5 /* HTTPNetworkingClient.swift */; };
 		BEA100EC26EFA7790036A6A5 /* HTTPMethod.swift in Sources */ = {isa = PBXBuildFile; fileRef = BEA100EB26EFA7790036A6A5 /* HTTPMethod.swift */; };
 		BEA100EE26EFA7990036A6A5 /* HTTPHeader.swift in Sources */ = {isa = PBXBuildFile; fileRef = BEA100ED26EFA7990036A6A5 /* HTTPHeader.swift */; };
 		BEA100F026EFA7C20036A6A5 /* NetworkingError.swift in Sources */ = {isa = PBXBuildFile; fileRef = BEA100EF26EFA7C20036A6A5 /* NetworkingError.swift */; };
@@ -136,7 +136,7 @@
 		CB51FF7227FCB947001A97F5 /* PayPalWebCheckoutFundingSource.swift in Sources */ = {isa = PBXBuildFile; fileRef = CB51FF7127FCB947001A97F5 /* PayPalWebCheckoutFundingSource.swift */; };
 		CBC16DD529E99B4600307117 /* PaymentSource.swift in Sources */ = {isa = PBXBuildFile; fileRef = CB4BE285284802C200EA2DD1 /* PaymentSource.swift */; };
 		E6022E802857C6BE008B0E27 /* GraphQLHTTPResponse.swift in Sources */ = {isa = PBXBuildFile; fileRef = E64623222836A69E008AC8E1 /* GraphQLHTTPResponse.swift */; };
-		E64763712899B60C00074113 /* MockNetworkingClient.swift in Sources */ = {isa = PBXBuildFile; fileRef = E64763702899B60C00074113 /* MockNetworkingClient.swift */; };
+		E64763712899B60C00074113 /* MockHTTPNetworkingClient.swift in Sources */ = {isa = PBXBuildFile; fileRef = E64763702899B60C00074113 /* MockHTTPNetworkingClient.swift */; };
 /* End PBXBuildFile section */
 
 /* Begin PBXContainerItemProxy section */
@@ -292,7 +292,7 @@
 		BE4F784827EB629100FF4C0E /* WebAuthenticationSession.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = WebAuthenticationSession.swift; sourceTree = "<group>"; };
 		BE9F36DE274859A000AFC7DA /* PaymentButtonColor.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PaymentButtonColor.swift; sourceTree = "<group>"; };
 		BE9F36E3275520E700AFC7DA /* PayPalCreditButton_Tests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PayPalCreditButton_Tests.swift; sourceTree = "<group>"; };
-		BEA100E626EF9EDA0036A6A5 /* NetworkingClient.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = NetworkingClient.swift; sourceTree = "<group>"; };
+		BEA100E626EF9EDA0036A6A5 /* HTTPNetworkingClient.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = HTTPNetworkingClient.swift; sourceTree = "<group>"; };
 		BEA100EB26EFA7790036A6A5 /* HTTPMethod.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = HTTPMethod.swift; sourceTree = "<group>"; };
 		BEA100ED26EFA7990036A6A5 /* HTTPHeader.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = HTTPHeader.swift; sourceTree = "<group>"; };
 		BEA100EF26EFA7C20036A6A5 /* NetworkingError.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NetworkingError.swift; sourceTree = "<group>"; };
@@ -313,7 +313,7 @@
 		CB4BE28928512A9800EA2DD1 /* MockQuededURLSession.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MockQuededURLSession.swift; sourceTree = "<group>"; };
 		CB51FF7127FCB947001A97F5 /* PayPalWebCheckoutFundingSource.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PayPalWebCheckoutFundingSource.swift; sourceTree = "<group>"; };
 		E64623222836A69E008AC8E1 /* GraphQLHTTPResponse.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = GraphQLHTTPResponse.swift; sourceTree = "<group>"; };
-		E64763702899B60C00074113 /* MockNetworkingClient.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MockNetworkingClient.swift; sourceTree = "<group>"; };
+		E64763702899B60C00074113 /* MockHTTPNetworkingClient.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MockHTTPNetworkingClient.swift; sourceTree = "<group>"; };
 		OBJ_16 /* README.md */ = {isa = PBXFileReference; lastKnownFileType = net.daringfireball.markdown; path = README.md; sourceTree = "<group>"; };
 		OBJ_6 /* Package.swift */ = {isa = PBXFileReference; explicitFileType = sourcecode.swift; path = Package.swift; sourceTree = "<group>"; };
 /* End PBXFileReference section */
@@ -551,7 +551,7 @@
 			children = (
 				3B80D50B2A27979000D2EAC4 /* FailingJSONEncoder.swift */,
 				80E743FF270E40F300BACECA /* FakeRequests.swift */,
-				E64763702899B60C00074113 /* MockNetworkingClient.swift */,
+				E64763702899B60C00074113 /* MockHTTPNetworkingClient.swift */,
 				802C4A732945670400896A5D /* MockHTTP.swift */,
 				CB4BE28928512A9800EA2DD1 /* MockQuededURLSession.swift */,
 				3B8F84912D933FAE00A151AC /* MockUpdateClientConfigAPI.swift */,
@@ -678,7 +678,7 @@
 			isa = PBXGroup;
 			children = (
 				E646231928369B71008AC8E1 /* GraphQL */,
-				BEA100E626EF9EDA0036A6A5 /* NetworkingClient.swift */,
+				BEA100E626EF9EDA0036A6A5 /* HTTPNetworkingClient.swift */,
 				804E628529380B04004B9FEF /* AnalyticsService.swift */,
 				3BF06F3E2E15CC35002CA7B4 /* ClientConfigResponse.swift */,
 				80E2FDBF2A8353550045593D /* TrackingEventsAPI.swift */,
@@ -1207,7 +1207,7 @@
 					BE0000012E1A000000000001 /* HTTPClient.swift in Sources */,
 				BC04836F27B2FB3600FA7B46 /* URLSessionProtocol.swift in Sources */,
 				065A4DBC26FCD8090007014A /* CoreSDKError.swift in Sources */,
-				BEA100E726EF9EDA0036A6A5 /* NetworkingClient.swift in Sources */,
+				BEA100E726EF9EDA0036A6A5 /* HTTPNetworkingClient.swift in Sources */,
 				807BF58F2A2A5D19002F32B3 /* HTTPResponseParser.swift in Sources */,
 				807D56AE2A869064009E591D /* GraphQLRequest.swift in Sources */,
 			);
@@ -1224,7 +1224,7 @@
 				CB4BE28A28512A9800EA2DD1 /* MockQuededURLSession.swift in Sources */,
 				3BF06F432E16480F002CA7B4 /* MockUpdateClientConfigAPI.swift in Sources */,
 				80E74400270E40F300BACECA /* FakeRequests.swift in Sources */,
-				E64763712899B60C00074113 /* MockNetworkingClient.swift in Sources */,
+				E64763712899B60C00074113 /* MockHTTPNetworkingClient.swift in Sources */,
 				3B80D50C2A27979000D2EAC4 /* FailingJSONEncoder.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;

--- a/PayPal.xcodeproj/project.pbxproj
+++ b/PayPal.xcodeproj/project.pbxproj
@@ -47,7 +47,7 @@
 		803C31B5270E46EB0067D36E /* CorePayments.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 80B9F85126B8750000D67843 /* CorePayments.framework */; };
 		803C31B9270E4C560067D36E /* MockURLSession.swift in Sources */ = {isa = PBXBuildFile; fileRef = 803C31B8270E4C560067D36E /* MockURLSession.swift */; };
 		8048D28C270B9DE00072214A /* ConfirmPaymentSourceResponse.swift in Sources */ = {isa = PBXBuildFile; fileRef = 06CE00A226F3E32A0000CC46 /* ConfirmPaymentSourceResponse.swift */; };
-		804E62822937EBCE004B9FEF /* HTTP.swift in Sources */ = {isa = PBXBuildFile; fileRef = 804E62812937EBCE004B9FEF /* HTTP.swift */; };
+		804E62822937EBCE004B9FEF /* URLSessionHTTPClient.swift in Sources */ = {isa = PBXBuildFile; fileRef = 804E62812937EBCE004B9FEF /* URLSessionHTTPClient.swift */; };
 		804E628629380B04004B9FEF /* AnalyticsService.swift in Sources */ = {isa = PBXBuildFile; fileRef = 804E628529380B04004B9FEF /* AnalyticsService.swift */; };
 		805AB85926B88882003BEE0D /* CorePayments.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 80B9F85126B8750000D67843 /* CorePayments.framework */; platformFilter = ios; };
 		807BF58F2A2A5D19002F32B3 /* HTTPResponseParser.swift in Sources */ = {isa = PBXBuildFile; fileRef = 807BF58E2A2A5D19002F32B3 /* HTTPResponseParser.swift */; };
@@ -226,7 +226,7 @@
 		8036C1E1270F9BE700C0F091 /* Environment_Tests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; name = Environment_Tests.swift; path = UnitTests/PaymentsCoreTests/Environment_Tests.swift; sourceTree = SOURCE_ROOT; };
 		8036F87F2A30E492005B6186 /* HTTPResponse_Tests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = HTTPResponse_Tests.swift; sourceTree = "<group>"; };
 		803C31B8270E4C560067D36E /* MockURLSession.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MockURLSession.swift; sourceTree = "<group>"; };
-		804E62812937EBCE004B9FEF /* HTTP.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = HTTP.swift; sourceTree = "<group>"; };
+		804E62812937EBCE004B9FEF /* URLSessionHTTPClient.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = URLSessionHTTPClient.swift; sourceTree = "<group>"; };
 		804E628529380B04004B9FEF /* AnalyticsService.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AnalyticsService.swift; sourceTree = "<group>"; };
 		807BF58E2A2A5D19002F32B3 /* HTTPResponseParser.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = HTTPResponseParser.swift; sourceTree = "<group>"; };
 		807BF5902A2A5D48002F32B3 /* HTTPResponseParser_Tests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = HTTPResponseParser_Tests.swift; sourceTree = "<group>"; };
@@ -685,7 +685,7 @@
 				804E628529380B04004B9FEF /* AnalyticsService.swift */,
 				3BF06F3E2E15CC35002CA7B4 /* ClientConfigResponse.swift */,
 				80E2FDBF2A8353550045593D /* TrackingEventsAPI.swift */,
-				804E62812937EBCE004B9FEF /* HTTP.swift */,
+				804E62812937EBCE004B9FEF /* URLSessionHTTPClient.swift */,
 				BE0000002E1A000000000001 /* HTTPClient.swift */,
 				80E237DE2A84434B00FF18CA /* HTTPRequest.swift */,
 				80E643822A1EBBD2008FD705 /* HTTPResponse.swift */,
@@ -1206,7 +1206,7 @@
 				80E2FDC32A8354AD0045593D /* RESTRequest.swift in Sources */,
 				3DC42BA927187E8300B71645 /* ErrorResponse.swift in Sources */,
 				807D56AC2A869044009E591D /* GraphQLHTTPPostBody.swift in Sources */,
-				804E62822937EBCE004B9FEF /* HTTP.swift in Sources */,
+				804E62822937EBCE004B9FEF /* URLSessionHTTPClient.swift in Sources */,
 				BE0000012E1A000000000001 /* HTTPClient.swift in Sources */,
 				BC04836F27B2FB3600FA7B46 /* URLSessionProtocol.swift in Sources */,
 				065A4DBC26FCD8090007014A /* CoreSDKError.swift in Sources */,

--- a/PayPal.xcodeproj/project.pbxproj
+++ b/PayPal.xcodeproj/project.pbxproj
@@ -48,6 +48,7 @@
 		803C31B9270E4C560067D36E /* MockURLSession.swift in Sources */ = {isa = PBXBuildFile; fileRef = 803C31B8270E4C560067D36E /* MockURLSession.swift */; };
 		8048D28C270B9DE00072214A /* ConfirmPaymentSourceResponse.swift in Sources */ = {isa = PBXBuildFile; fileRef = 06CE00A226F3E32A0000CC46 /* ConfirmPaymentSourceResponse.swift */; };
 		804E62822937EBCE004B9FEF /* HTTP.swift in Sources */ = {isa = PBXBuildFile; fileRef = 804E62812937EBCE004B9FEF /* HTTP.swift */; };
+		BE0000012E1A000000000001 /* HTTPClient.swift in Sources */ = {isa = PBXBuildFile; fileRef = BE0000002E1A000000000001 /* HTTPClient.swift */; };
 		804E628629380B04004B9FEF /* AnalyticsService.swift in Sources */ = {isa = PBXBuildFile; fileRef = 804E628529380B04004B9FEF /* AnalyticsService.swift */; };
 		805AB85926B88882003BEE0D /* CorePayments.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 80B9F85126B8750000D67843 /* CorePayments.framework */; platformFilter = ios; };
 		807BF58F2A2A5D19002F32B3 /* HTTPResponseParser.swift in Sources */ = {isa = PBXBuildFile; fileRef = 807BF58E2A2A5D19002F32B3 /* HTTPResponseParser.swift */; };
@@ -225,6 +226,7 @@
 		8036F87F2A30E492005B6186 /* HTTPResponse_Tests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = HTTPResponse_Tests.swift; sourceTree = "<group>"; };
 		803C31B8270E4C560067D36E /* MockURLSession.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MockURLSession.swift; sourceTree = "<group>"; };
 		804E62812937EBCE004B9FEF /* HTTP.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = HTTP.swift; sourceTree = "<group>"; };
+		BE0000002E1A000000000001 /* HTTPClient.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = HTTPClient.swift; sourceTree = "<group>"; };
 		804E628529380B04004B9FEF /* AnalyticsService.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AnalyticsService.swift; sourceTree = "<group>"; };
 		807BF58E2A2A5D19002F32B3 /* HTTPResponseParser.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = HTTPResponseParser.swift; sourceTree = "<group>"; };
 		807BF5902A2A5D48002F32B3 /* HTTPResponseParser_Tests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = HTTPResponseParser_Tests.swift; sourceTree = "<group>"; };
@@ -681,6 +683,7 @@
 				3BF06F3E2E15CC35002CA7B4 /* ClientConfigResponse.swift */,
 				80E2FDBF2A8353550045593D /* TrackingEventsAPI.swift */,
 				804E62812937EBCE004B9FEF /* HTTP.swift */,
+				BE0000002E1A000000000001 /* HTTPClient.swift */,
 				80E237DE2A84434B00FF18CA /* HTTPRequest.swift */,
 				80E643822A1EBBD2008FD705 /* HTTPResponse.swift */,
 				80E2FDC22A8354AD0045593D /* RESTRequest.swift */,
@@ -1201,6 +1204,7 @@
 				3DC42BA927187E8300B71645 /* ErrorResponse.swift in Sources */,
 				807D56AC2A869044009E591D /* GraphQLHTTPPostBody.swift in Sources */,
 				804E62822937EBCE004B9FEF /* HTTP.swift in Sources */,
+					BE0000012E1A000000000001 /* HTTPClient.swift in Sources */,
 				BC04836F27B2FB3600FA7B46 /* URLSessionProtocol.swift in Sources */,
 				065A4DBC26FCD8090007014A /* CoreSDKError.swift in Sources */,
 				BEA100E726EF9EDA0036A6A5 /* NetworkingClient.swift in Sources */,

--- a/PayPal.xcodeproj/project.pbxproj
+++ b/PayPal.xcodeproj/project.pbxproj
@@ -48,7 +48,6 @@
 		803C31B9270E4C560067D36E /* MockURLSession.swift in Sources */ = {isa = PBXBuildFile; fileRef = 803C31B8270E4C560067D36E /* MockURLSession.swift */; };
 		8048D28C270B9DE00072214A /* ConfirmPaymentSourceResponse.swift in Sources */ = {isa = PBXBuildFile; fileRef = 06CE00A226F3E32A0000CC46 /* ConfirmPaymentSourceResponse.swift */; };
 		804E62822937EBCE004B9FEF /* HTTP.swift in Sources */ = {isa = PBXBuildFile; fileRef = 804E62812937EBCE004B9FEF /* HTTP.swift */; };
-		BE0000012E1A000000000001 /* HTTPClient.swift in Sources */ = {isa = PBXBuildFile; fileRef = BE0000002E1A000000000001 /* HTTPClient.swift */; };
 		804E628629380B04004B9FEF /* AnalyticsService.swift in Sources */ = {isa = PBXBuildFile; fileRef = 804E628529380B04004B9FEF /* AnalyticsService.swift */; };
 		805AB85926B88882003BEE0D /* CorePayments.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 80B9F85126B8750000D67843 /* CorePayments.framework */; platformFilter = ios; };
 		807BF58F2A2A5D19002F32B3 /* HTTPResponseParser.swift in Sources */ = {isa = PBXBuildFile; fileRef = 807BF58E2A2A5D19002F32B3 /* HTTPResponseParser.swift */; };
@@ -80,6 +79,7 @@
 		BC0A82A6270B9954006E9A21 /* ConfirmPaymentSourceRequest_Tests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 065A4DC226FCE1D20007014A /* ConfirmPaymentSourceRequest_Tests.swift */; };
 		BC171FB12A8C156300B26DCB /* CoreConfig+MagnesSDK.swift in Sources */ = {isa = PBXBuildFile; fileRef = BC171FB02A8C156300B26DCB /* CoreConfig+MagnesSDK.swift */; };
 		BC171FB22A8D6FE500B26DCB /* CorePayments.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 80B9F85126B8750000D67843 /* CorePayments.framework */; };
+		BC55C0822F7C6DA900631E5F /* MockNetworkingClient.swift in Sources */ = {isa = PBXBuildFile; fileRef = BC55C0812F7C6DA900631E5F /* MockNetworkingClient.swift */; };
 		BC7F8123275FC1350011EDC8 /* CardRequest.swift in Sources */ = {isa = PBXBuildFile; fileRef = BC7F8122275FC1350011EDC8 /* CardRequest.swift */; };
 		BC9C18D427D2775A0019B541 /* MockDeviceInspector.swift in Sources */ = {isa = PBXBuildFile; fileRef = BC9C18D327D2775A0019B541 /* MockDeviceInspector.swift */; };
 		BC9C18D827D279C70019B541 /* MagnesSDKResult.swift in Sources */ = {isa = PBXBuildFile; fileRef = BC9C18D727D279C70019B541 /* MagnesSDKResult.swift */; };
@@ -109,12 +109,14 @@
 		BCFAC71D27ED04C300C3AF00 /* PayPalButton.swift in Sources */ = {isa = PBXBuildFile; fileRef = BE00B79B2742F96200758C63 /* PayPalButton.swift */; };
 		BCFAC71E27ED04C500C3AF00 /* PayPalCreditButton.swift in Sources */ = {isa = PBXBuildFile; fileRef = BE00B7A82743F6AF00758C63 /* PayPalCreditButton.swift */; };
 		BCFAC71F27ED04C800C3AF00 /* Coordinator.swift in Sources */ = {isa = PBXBuildFile; fileRef = BEDB7FE32788AB8E00CEA554 /* Coordinator.swift */; };
+		BE0000012E1A000000000001 /* HTTPClient.swift in Sources */ = {isa = PBXBuildFile; fileRef = BE0000002E1A000000000001 /* HTTPClient.swift */; };
 		BE4F785327EB656400FF4C0E /* Environment+PayPalWebCheckout.swift in Sources */ = {isa = PBXBuildFile; fileRef = BE4F784327EB629100FF4C0E /* Environment+PayPalWebCheckout.swift */; };
 		BE4F785427EB656400FF4C0E /* PayPalWebCheckoutClient.swift in Sources */ = {isa = PBXBuildFile; fileRef = BE4F784627EB629100FF4C0E /* PayPalWebCheckoutClient.swift */; };
 		BE4F785527EB656400FF4C0E /* PayPalError.swift in Sources */ = {isa = PBXBuildFile; fileRef = BE4F784427EB629100FF4C0E /* PayPalError.swift */; };
 		BE4F785727EB656400FF4C0E /* PayPalWebCheckoutRequest.swift in Sources */ = {isa = PBXBuildFile; fileRef = BE4F784527EB629100FF4C0E /* PayPalWebCheckoutRequest.swift */; };
 		BE4F785827EB656400FF4C0E /* PayPalWebCheckoutResult.swift in Sources */ = {isa = PBXBuildFile; fileRef = BE4F784727EB629100FF4C0E /* PayPalWebCheckoutResult.swift */; };
 		BEA100E726EF9EDA0036A6A5 /* HTTPNetworkingClient.swift in Sources */ = {isa = PBXBuildFile; fileRef = BEA100E626EF9EDA0036A6A5 /* HTTPNetworkingClient.swift */; };
+		BE0000032E1A000000000002 /* NetworkingClient.swift in Sources */ = {isa = PBXBuildFile; fileRef = BE0000022E1A000000000002 /* NetworkingClient.swift */; };
 		BEA100EC26EFA7790036A6A5 /* HTTPMethod.swift in Sources */ = {isa = PBXBuildFile; fileRef = BEA100EB26EFA7790036A6A5 /* HTTPMethod.swift */; };
 		BEA100EE26EFA7990036A6A5 /* HTTPHeader.swift in Sources */ = {isa = PBXBuildFile; fileRef = BEA100ED26EFA7990036A6A5 /* HTTPHeader.swift */; };
 		BEA100F026EFA7C20036A6A5 /* NetworkingError.swift in Sources */ = {isa = PBXBuildFile; fileRef = BEA100EF26EFA7C20036A6A5 /* NetworkingError.swift */; };
@@ -136,7 +138,6 @@
 		CB51FF7227FCB947001A97F5 /* PayPalWebCheckoutFundingSource.swift in Sources */ = {isa = PBXBuildFile; fileRef = CB51FF7127FCB947001A97F5 /* PayPalWebCheckoutFundingSource.swift */; };
 		CBC16DD529E99B4600307117 /* PaymentSource.swift in Sources */ = {isa = PBXBuildFile; fileRef = CB4BE285284802C200EA2DD1 /* PaymentSource.swift */; };
 		E6022E802857C6BE008B0E27 /* GraphQLHTTPResponse.swift in Sources */ = {isa = PBXBuildFile; fileRef = E64623222836A69E008AC8E1 /* GraphQLHTTPResponse.swift */; };
-		E64763712899B60C00074113 /* MockHTTPNetworkingClient.swift in Sources */ = {isa = PBXBuildFile; fileRef = E64763702899B60C00074113 /* MockHTTPNetworkingClient.swift */; };
 /* End PBXBuildFile section */
 
 /* Begin PBXContainerItemProxy section */
@@ -226,7 +227,6 @@
 		8036F87F2A30E492005B6186 /* HTTPResponse_Tests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = HTTPResponse_Tests.swift; sourceTree = "<group>"; };
 		803C31B8270E4C560067D36E /* MockURLSession.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MockURLSession.swift; sourceTree = "<group>"; };
 		804E62812937EBCE004B9FEF /* HTTP.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = HTTP.swift; sourceTree = "<group>"; };
-		BE0000002E1A000000000001 /* HTTPClient.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = HTTPClient.swift; sourceTree = "<group>"; };
 		804E628529380B04004B9FEF /* AnalyticsService.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AnalyticsService.swift; sourceTree = "<group>"; };
 		807BF58E2A2A5D19002F32B3 /* HTTPResponseParser.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = HTTPResponseParser.swift; sourceTree = "<group>"; };
 		807BF5902A2A5D48002F32B3 /* HTTPResponseParser_Tests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = HTTPResponseParser_Tests.swift; sourceTree = "<group>"; };
@@ -256,6 +256,7 @@
 		BC04836E27B2FB3600FA7B46 /* URLSessionProtocol.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = URLSessionProtocol.swift; sourceTree = "<group>"; };
 		BC04837327B2FC7300FA7B46 /* URLSession+URLSessionProtocol.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "URLSession+URLSessionProtocol.swift"; sourceTree = "<group>"; };
 		BC171FB02A8C156300B26DCB /* CoreConfig+MagnesSDK.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "CoreConfig+MagnesSDK.swift"; sourceTree = "<group>"; };
+		BC55C0812F7C6DA900631E5F /* MockNetworkingClient.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MockNetworkingClient.swift; sourceTree = "<group>"; };
 		BC7F8122275FC1350011EDC8 /* CardRequest.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CardRequest.swift; sourceTree = "<group>"; };
 		BC9C18D327D2775A0019B541 /* MockDeviceInspector.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MockDeviceInspector.swift; sourceTree = "<group>"; };
 		BC9C18D727D279C70019B541 /* MagnesSDKResult.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MagnesSDKResult.swift; sourceTree = "<group>"; };
@@ -279,6 +280,7 @@
 		BCF735FA27D2719400A52E03 /* MockMagnesSDK.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MockMagnesSDK.swift; sourceTree = "<group>"; };
 		BCFAC70927ED042500C3AF00 /* PaymentButtons.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = PaymentButtons.framework; sourceTree = BUILT_PRODUCTS_DIR; };
 		BCFAC71827ED043200C3AF00 /* PayPalUITests.xctest */ = {isa = PBXFileReference; explicitFileType = wrapper.cfbundle; includeInIndex = 0; path = PayPalUITests.xctest; sourceTree = BUILT_PRODUCTS_DIR; };
+		BE0000002E1A000000000001 /* HTTPClient.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = HTTPClient.swift; sourceTree = "<group>"; };
 		BE00B79B2742F96200758C63 /* PayPalButton.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PayPalButton.swift; sourceTree = "<group>"; };
 		BE00B79D2742F9F000758C63 /* Assets.xcassets */ = {isa = PBXFileReference; lastKnownFileType = folder.assetcatalog; path = Assets.xcassets; sourceTree = "<group>"; };
 		BE00B7A82743F6AF00758C63 /* PayPalCreditButton.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PayPalCreditButton.swift; sourceTree = "<group>"; };
@@ -293,6 +295,7 @@
 		BE9F36DE274859A000AFC7DA /* PaymentButtonColor.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PaymentButtonColor.swift; sourceTree = "<group>"; };
 		BE9F36E3275520E700AFC7DA /* PayPalCreditButton_Tests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PayPalCreditButton_Tests.swift; sourceTree = "<group>"; };
 		BEA100E626EF9EDA0036A6A5 /* HTTPNetworkingClient.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = HTTPNetworkingClient.swift; sourceTree = "<group>"; };
+		BE0000022E1A000000000002 /* NetworkingClient.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NetworkingClient.swift; sourceTree = "<group>"; };
 		BEA100EB26EFA7790036A6A5 /* HTTPMethod.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = HTTPMethod.swift; sourceTree = "<group>"; };
 		BEA100ED26EFA7990036A6A5 /* HTTPHeader.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = HTTPHeader.swift; sourceTree = "<group>"; };
 		BEA100EF26EFA7C20036A6A5 /* NetworkingError.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NetworkingError.swift; sourceTree = "<group>"; };
@@ -313,7 +316,6 @@
 		CB4BE28928512A9800EA2DD1 /* MockQuededURLSession.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MockQuededURLSession.swift; sourceTree = "<group>"; };
 		CB51FF7127FCB947001A97F5 /* PayPalWebCheckoutFundingSource.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PayPalWebCheckoutFundingSource.swift; sourceTree = "<group>"; };
 		E64623222836A69E008AC8E1 /* GraphQLHTTPResponse.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = GraphQLHTTPResponse.swift; sourceTree = "<group>"; };
-		E64763702899B60C00074113 /* MockHTTPNetworkingClient.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MockHTTPNetworkingClient.swift; sourceTree = "<group>"; };
 		OBJ_16 /* README.md */ = {isa = PBXFileReference; lastKnownFileType = net.daringfireball.markdown; path = README.md; sourceTree = "<group>"; };
 		OBJ_6 /* Package.swift */ = {isa = PBXFileReference; explicitFileType = sourcecode.swift; path = Package.swift; sourceTree = "<group>"; };
 /* End PBXFileReference section */
@@ -551,8 +553,8 @@
 			children = (
 				3B80D50B2A27979000D2EAC4 /* FailingJSONEncoder.swift */,
 				80E743FF270E40F300BACECA /* FakeRequests.swift */,
-				E64763702899B60C00074113 /* MockHTTPNetworkingClient.swift */,
 				802C4A732945670400896A5D /* MockHTTP.swift */,
+				BC55C0812F7C6DA900631E5F /* MockNetworkingClient.swift */,
 				CB4BE28928512A9800EA2DD1 /* MockQuededURLSession.swift */,
 				3B8F84912D933FAE00A151AC /* MockUpdateClientConfigAPI.swift */,
 				803C31B8270E4C560067D36E /* MockURLSession.swift */,
@@ -679,6 +681,7 @@
 			children = (
 				E646231928369B71008AC8E1 /* GraphQL */,
 				BEA100E626EF9EDA0036A6A5 /* HTTPNetworkingClient.swift */,
+				BE0000022E1A000000000002 /* NetworkingClient.swift */,
 				804E628529380B04004B9FEF /* AnalyticsService.swift */,
 				3BF06F3E2E15CC35002CA7B4 /* ClientConfigResponse.swift */,
 				80E2FDBF2A8353550045593D /* TrackingEventsAPI.swift */,
@@ -1204,10 +1207,11 @@
 				3DC42BA927187E8300B71645 /* ErrorResponse.swift in Sources */,
 				807D56AC2A869044009E591D /* GraphQLHTTPPostBody.swift in Sources */,
 				804E62822937EBCE004B9FEF /* HTTP.swift in Sources */,
-					BE0000012E1A000000000001 /* HTTPClient.swift in Sources */,
+				BE0000012E1A000000000001 /* HTTPClient.swift in Sources */,
 				BC04836F27B2FB3600FA7B46 /* URLSessionProtocol.swift in Sources */,
 				065A4DBC26FCD8090007014A /* CoreSDKError.swift in Sources */,
 				BEA100E726EF9EDA0036A6A5 /* HTTPNetworkingClient.swift in Sources */,
+				BE0000032E1A000000000002 /* NetworkingClient.swift in Sources */,
 				807BF58F2A2A5D19002F32B3 /* HTTPResponseParser.swift in Sources */,
 				807D56AE2A869064009E591D /* GraphQLRequest.swift in Sources */,
 			);
@@ -1224,7 +1228,7 @@
 				CB4BE28A28512A9800EA2DD1 /* MockQuededURLSession.swift in Sources */,
 				3BF06F432E16480F002CA7B4 /* MockUpdateClientConfigAPI.swift in Sources */,
 				80E74400270E40F300BACECA /* FakeRequests.swift in Sources */,
-				E64763712899B60C00074113 /* MockHTTPNetworkingClient.swift in Sources */,
+				BC55C0822F7C6DA900631E5F /* MockNetworkingClient.swift in Sources */,
 				3B80D50C2A27979000D2EAC4 /* FailingJSONEncoder.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;

--- a/PayPal.xcodeproj/project.pbxproj
+++ b/PayPal.xcodeproj/project.pbxproj
@@ -36,7 +36,7 @@
 		3DC42BA927187E8300B71645 /* ErrorResponse.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3DC42BA827187E8300B71645 /* ErrorResponse.swift */; };
 		8008D2052A9E54FF0003CAF4 /* CheckoutOrdersAPI_Tests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8008D2042A9E54FF0003CAF4 /* CheckoutOrdersAPI_Tests.swift */; };
 		8021B69029144E6D000FBC54 /* PayPalCoreConstants.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8021B68F29144E6D000FBC54 /* PayPalCoreConstants.swift */; };
-		802C4A742945670400896A5D /* MockHTTP.swift in Sources */ = {isa = PBXBuildFile; fileRef = 802C4A732945670400896A5D /* MockHTTP.swift */; };
+		802C4A742945670400896A5D /* MockHTTPClient.swift in Sources */ = {isa = PBXBuildFile; fileRef = 802C4A732945670400896A5D /* MockHTTPClient.swift */; };
 		802C4A762945676E00896A5D /* AnalyticsService_Tests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 802C4A752945676E00896A5D /* AnalyticsService_Tests.swift */; };
 		802EFBDB2A96B47A00AB709D /* TrackingEventsAPI_Tests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 802EFBD92A968BCD00AB709D /* TrackingEventsAPI_Tests.swift */; };
 		8034A9E726B875C90055AF13 /* CorePayments.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 80B9F85126B8750000D67843 /* CorePayments.framework */; };
@@ -217,7 +217,7 @@
 		3DC42BA827187E8300B71645 /* ErrorResponse.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ErrorResponse.swift; sourceTree = "<group>"; };
 		8008D2042A9E54FF0003CAF4 /* CheckoutOrdersAPI_Tests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CheckoutOrdersAPI_Tests.swift; sourceTree = "<group>"; };
 		8021B68F29144E6D000FBC54 /* PayPalCoreConstants.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PayPalCoreConstants.swift; sourceTree = "<group>"; };
-		802C4A732945670400896A5D /* MockHTTP.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MockHTTP.swift; sourceTree = "<group>"; };
+		802C4A732945670400896A5D /* MockHTTPClient.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MockHTTPClient.swift; sourceTree = "<group>"; };
 		802C4A752945676E00896A5D /* AnalyticsService_Tests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AnalyticsService_Tests.swift; sourceTree = "<group>"; };
 		802EFBD72A9685DF00AB709D /* MockTrackingEventsAPI.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MockTrackingEventsAPI.swift; sourceTree = "<group>"; };
 		802EFBD92A968BCD00AB709D /* TrackingEventsAPI_Tests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TrackingEventsAPI_Tests.swift; sourceTree = "<group>"; };
@@ -553,7 +553,7 @@
 			children = (
 				3B80D50B2A27979000D2EAC4 /* FailingJSONEncoder.swift */,
 				80E743FF270E40F300BACECA /* FakeRequests.swift */,
-				802C4A732945670400896A5D /* MockHTTP.swift */,
+				802C4A732945670400896A5D /* MockHTTPClient.swift */,
 				BC55C0812F7C6DA900631E5F /* MockNetworkingClient.swift */,
 				CB4BE28928512A9800EA2DD1 /* MockQuededURLSession.swift */,
 				3B8F84912D933FAE00A151AC /* MockUpdateClientConfigAPI.swift */,
@@ -1221,7 +1221,7 @@
 			isa = PBXSourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
-				802C4A742945670400896A5D /* MockHTTP.swift in Sources */,
+				802C4A742945670400896A5D /* MockHTTPClient.swift in Sources */,
 				CB4BE28C2851427600EA2DD1 /* MockViewController.swift in Sources */,
 				803C31B9270E4C560067D36E /* MockURLSession.swift in Sources */,
 				CB4BE28B2851423900EA2DD1 /* MockWebAuthenticationSession.swift in Sources */,

--- a/Sources/CardPayments/APIRequests/CheckoutOrdersAPI.swift
+++ b/Sources/CardPayments/APIRequests/CheckoutOrdersAPI.swift
@@ -11,7 +11,7 @@ class CheckoutOrdersAPI {
     // MARK: - Private Properties
 
     private let coreConfig: CoreConfig
-    private let networkingClient: HTTPNetworkingClient
+    private let networkingClient: NetworkingClient
     
     // MARK: - Initializer
     
@@ -21,7 +21,7 @@ class CheckoutOrdersAPI {
     }
     
     /// Exposed for injecting MockNetworkingClient in tests
-    init(coreConfig: CoreConfig, networkingClient: HTTPNetworkingClient) {
+    init(coreConfig: CoreConfig, networkingClient: NetworkingClient) {
         self.coreConfig = coreConfig
         self.networkingClient = networkingClient
     }

--- a/Sources/CardPayments/APIRequests/CheckoutOrdersAPI.swift
+++ b/Sources/CardPayments/APIRequests/CheckoutOrdersAPI.swift
@@ -11,17 +11,17 @@ class CheckoutOrdersAPI {
     // MARK: - Private Properties
 
     private let coreConfig: CoreConfig
-    private let networkingClient: NetworkingClient
+    private let networkingClient: HTTPNetworkingClient
     
     // MARK: - Initializer
     
     init(coreConfig: CoreConfig) {
         self.coreConfig = coreConfig
-        self.networkingClient = NetworkingClient(coreConfig: coreConfig)
+        self.networkingClient = HTTPNetworkingClient(coreConfig: coreConfig)
     }
     
-    /// Exposed for injecting MockNetworkingClient in tests
-    init(coreConfig: CoreConfig, networkingClient: NetworkingClient) {
+    /// Exposed for injecting MockHTTPNetworkingClient in tests
+    init(coreConfig: CoreConfig, networkingClient: HTTPNetworkingClient) {
         self.coreConfig = coreConfig
         self.networkingClient = networkingClient
     }

--- a/Sources/CardPayments/APIRequests/CheckoutOrdersAPI.swift
+++ b/Sources/CardPayments/APIRequests/CheckoutOrdersAPI.swift
@@ -20,7 +20,7 @@ class CheckoutOrdersAPI {
         self.networkingClient = HTTPNetworkingClient(coreConfig: coreConfig)
     }
     
-    /// Exposed for injecting MockHTTPNetworkingClient in tests
+    /// Exposed for injecting MockNetworkingClient in tests
     init(coreConfig: CoreConfig, networkingClient: HTTPNetworkingClient) {
         self.coreConfig = coreConfig
         self.networkingClient = networkingClient

--- a/Sources/CardPayments/APIRequests/VaultPaymentTokensAPI.swift
+++ b/Sources/CardPayments/APIRequests/VaultPaymentTokensAPI.swift
@@ -9,7 +9,7 @@ class VaultPaymentTokensAPI {
     // MARK: - Private Properties
     
     private let coreConfig: CoreConfig
-    private let networkingClient: HTTPNetworkingClient
+    private let networkingClient: NetworkingClient
     
     // MARK: - Initializer
     
@@ -19,7 +19,7 @@ class VaultPaymentTokensAPI {
     }
     
     /// Exposed for injecting MockNetworkingClient in tests
-    init(coreConfig: CoreConfig, networkingClient: HTTPNetworkingClient) {
+    init(coreConfig: CoreConfig, networkingClient: NetworkingClient) {
         self.coreConfig = coreConfig
         self.networkingClient = networkingClient
     }
@@ -57,7 +57,8 @@ class VaultPaymentTokensAPI {
             queryNameForURL: "UpdateVaultSetupToken"
         )
 
-        let httpResponse = try await networkingClient.fetch(request: graphQLRequest)
+        let httpResponse =
+            try await networkingClient.fetch(request: graphQLRequest, clientContext: nil)
         
         return try HTTPResponseParser().parseGraphQL(httpResponse, as: UpdateSetupTokenResponse.self)
     }

--- a/Sources/CardPayments/APIRequests/VaultPaymentTokensAPI.swift
+++ b/Sources/CardPayments/APIRequests/VaultPaymentTokensAPI.swift
@@ -18,7 +18,7 @@ class VaultPaymentTokensAPI {
         self.networkingClient = HTTPNetworkingClient(coreConfig: coreConfig)
     }
     
-    /// Exposed for injecting MockHTTPNetworkingClient in tests
+    /// Exposed for injecting MockNetworkingClient in tests
     init(coreConfig: CoreConfig, networkingClient: HTTPNetworkingClient) {
         self.coreConfig = coreConfig
         self.networkingClient = networkingClient

--- a/Sources/CardPayments/APIRequests/VaultPaymentTokensAPI.swift
+++ b/Sources/CardPayments/APIRequests/VaultPaymentTokensAPI.swift
@@ -9,17 +9,17 @@ class VaultPaymentTokensAPI {
     // MARK: - Private Properties
     
     private let coreConfig: CoreConfig
-    private let networkingClient: NetworkingClient
+    private let networkingClient: HTTPNetworkingClient
     
     // MARK: - Initializer
     
     init(coreConfig: CoreConfig) {
         self.coreConfig = coreConfig
-        self.networkingClient = NetworkingClient(coreConfig: coreConfig)
+        self.networkingClient = HTTPNetworkingClient(coreConfig: coreConfig)
     }
     
-    /// Exposed for injecting MockNetworkingClient in tests
-    init(coreConfig: CoreConfig, networkingClient: NetworkingClient) {
+    /// Exposed for injecting MockHTTPNetworkingClient in tests
+    init(coreConfig: CoreConfig, networkingClient: HTTPNetworkingClient) {
         self.coreConfig = coreConfig
         self.networkingClient = networkingClient
     }

--- a/Sources/CorePayments/Networking/HTTP.swift
+++ b/Sources/CorePayments/Networking/HTTP.swift
@@ -1,7 +1,7 @@
 import Foundation
 
 /// `HTTP` constructs `URLRequest`s and interfaces directly with `URLSession` to execute network requests.
-class HTTP {
+class HTTP: HTTPClient {
     
     let coreConfig: CoreConfig
     private var urlSession: URLSessionProtocol

--- a/Sources/CorePayments/Networking/HTTPClient.swift
+++ b/Sources/CorePayments/Networking/HTTPClient.swift
@@ -1,0 +1,7 @@
+import Foundation
+
+/// Protocol defining the interface for performing HTTP requests.
+protocol HTTPClient {
+
+    func performRequest(_ httpRequest: HTTPRequest) async throws -> HTTPResponse
+}

--- a/Sources/CorePayments/Networking/HTTPNetworkingClient.swift
+++ b/Sources/CorePayments/Networking/HTTPNetworkingClient.swift
@@ -1,13 +1,12 @@
 import Foundation
 
-/// This method is exposed for internal PayPal use only. Do not use. It is not covered by Semantic Versioning and may change or be removed at any time.
+/// This class is exposed for internal PayPal use only. Do not use. It is not covered by Semantic Versioning and may change or be removed at any time.
 ///
 /// `HTTPNetworkingClient` transforms REST & GraphQL requests into the proper HTTP format and executes network requests.
 @_documentation(visibility: private)
 public class HTTPNetworkingClient: NetworkingClient {
         
-    // MARK: - Internal Properties
-    
+    // MARK: - Private Properties
     private let http: HTTPClient
     private let coreConfig: CoreConfig
     

--- a/Sources/CorePayments/Networking/HTTPNetworkingClient.swift
+++ b/Sources/CorePayments/Networking/HTTPNetworkingClient.swift
@@ -2,22 +2,21 @@ import Foundation
 
 /// This method is exposed for internal PayPal use only. Do not use. It is not covered by Semantic Versioning and may change or be removed at any time.
 ///
-/// `NetworkingClient` transforms REST & GraphQL requests into the proper HTTP format and executes network requests.
+/// `HTTPNetworkingClient` transforms REST & GraphQL requests into the proper HTTP format and executes network requests.
 @_documentation(visibility: private)
-public class NetworkingClient {
+public class HTTPNetworkingClient {
         
     // MARK: - Internal Properties
     
-    private var http: HTTPClient
+    private let http: HTTPClient
     private let coreConfig: CoreConfig
     
     // MARK: - Public Initializer
 
-    public init(coreConfig: CoreConfig) {
-        self.http = HTTP(coreConfig: coreConfig)
-        self.coreConfig = coreConfig
+    public convenience init(coreConfig: CoreConfig) {
+        self.init(http: HTTP(coreConfig: coreConfig), coreConfig: coreConfig)
     }
-    
+
     // MARK: - Internal Initializer
 
     /// Exposed for testing

--- a/Sources/CorePayments/Networking/HTTPNetworkingClient.swift
+++ b/Sources/CorePayments/Networking/HTTPNetworkingClient.swift
@@ -4,7 +4,7 @@ import Foundation
 ///
 /// `HTTPNetworkingClient` transforms REST & GraphQL requests into the proper HTTP format and executes network requests.
 @_documentation(visibility: private)
-public class HTTPNetworkingClient {
+public class HTTPNetworkingClient: NetworkingClient {
         
     // MARK: - Internal Properties
     

--- a/Sources/CorePayments/Networking/HTTPNetworkingClient.swift
+++ b/Sources/CorePayments/Networking/HTTPNetworkingClient.swift
@@ -14,7 +14,7 @@ public class HTTPNetworkingClient: NetworkingClient {
     // MARK: - Public Initializer
 
     public convenience init(coreConfig: CoreConfig) {
-        self.init(http: HTTP(coreConfig: coreConfig), coreConfig: coreConfig)
+        self.init(http: URLSessionHTTPClient(coreConfig: coreConfig), coreConfig: coreConfig)
     }
 
     // MARK: - Internal Initializer

--- a/Sources/CorePayments/Networking/NetworkingClient.swift
+++ b/Sources/CorePayments/Networking/NetworkingClient.swift
@@ -1,0 +1,9 @@
+import Foundation
+
+/// Protocol defining the interface for performing REST and GraphQL network requests.
+@_documentation(visibility: private)
+public protocol NetworkingClient {
+
+    func fetch(request: RESTRequest) async throws -> HTTPResponse
+    func fetch(request: GraphQLRequest, clientContext: String?) async throws -> HTTPResponse
+}

--- a/Sources/CorePayments/Networking/NetworkingClient.swift
+++ b/Sources/CorePayments/Networking/NetworkingClient.swift
@@ -8,7 +8,7 @@ public class NetworkingClient {
         
     // MARK: - Internal Properties
     
-    private var http: HTTP
+    private var http: HTTPClient
     private let coreConfig: CoreConfig
     
     // MARK: - Public Initializer
@@ -21,9 +21,9 @@ public class NetworkingClient {
     // MARK: - Internal Initializer
 
     /// Exposed for testing
-    init(http: HTTP) {
+    init(http: HTTPClient, coreConfig: CoreConfig) {
         self.http = http
-        self.coreConfig = http.coreConfig
+        self.coreConfig = coreConfig
     }
     
     // MARK: - Public Methods

--- a/Sources/CorePayments/Networking/TrackingEventsAPI.swift
+++ b/Sources/CorePayments/Networking/TrackingEventsAPI.swift
@@ -8,7 +8,7 @@ class TrackingEventsAPI {
     // MARK: - Internal Properties
 
     var coreConfig: CoreConfig // exposed for testing
-    private var networkingClient: HTTPNetworkingClient
+    private var networkingClient: NetworkingClient
 
     // MARK: - Initializer
     
@@ -19,7 +19,7 @@ class TrackingEventsAPI {
     }
     
     /// Exposed for injecting MockNetworkingClient in tests
-    init(coreConfig: CoreConfig, networkingClient: HTTPNetworkingClient) {
+    init(coreConfig: CoreConfig, networkingClient: NetworkingClient) {
         self.coreConfig = coreConfig
         self.networkingClient = networkingClient
     }

--- a/Sources/CorePayments/Networking/TrackingEventsAPI.swift
+++ b/Sources/CorePayments/Networking/TrackingEventsAPI.swift
@@ -8,18 +8,18 @@ class TrackingEventsAPI {
     // MARK: - Internal Properties
 
     var coreConfig: CoreConfig // exposed for testing
-    private var networkingClient: NetworkingClient
+    private var networkingClient: HTTPNetworkingClient
 
     // MARK: - Initializer
     
     init(coreConfig merchantConfig: CoreConfig) {
         // api-m.sandbox.paypal.com does not currently send FPTI events to BigQuery/Looker
         self.coreConfig = CoreConfig(clientID: merchantConfig.clientID, environment: .live)
-        self.networkingClient = NetworkingClient(coreConfig: coreConfig)
+        self.networkingClient = HTTPNetworkingClient(coreConfig: coreConfig)
     }
     
-    /// Exposed for injecting MockNetworkingClient in tests
-    init(coreConfig: CoreConfig, networkingClient: NetworkingClient) {
+    /// Exposed for injecting MockHTTPNetworkingClient in tests
+    init(coreConfig: CoreConfig, networkingClient: HTTPNetworkingClient) {
         self.coreConfig = coreConfig
         self.networkingClient = networkingClient
     }

--- a/Sources/CorePayments/Networking/TrackingEventsAPI.swift
+++ b/Sources/CorePayments/Networking/TrackingEventsAPI.swift
@@ -18,7 +18,7 @@ class TrackingEventsAPI {
         self.networkingClient = HTTPNetworkingClient(coreConfig: coreConfig)
     }
     
-    /// Exposed for injecting MockHTTPNetworkingClient in tests
+    /// Exposed for injecting MockNetworkingClient in tests
     init(coreConfig: CoreConfig, networkingClient: HTTPNetworkingClient) {
         self.coreConfig = coreConfig
         self.networkingClient = networkingClient

--- a/Sources/CorePayments/Networking/URLSessionHTTPClient.swift
+++ b/Sources/CorePayments/Networking/URLSessionHTTPClient.swift
@@ -1,7 +1,7 @@
 import Foundation
 
-/// `HTTP` constructs `URLRequest`s and interfaces directly with `URLSession` to execute network requests.
-class HTTP: HTTPClient {
+/// `URLSessionHTTPClient` constructs `URLRequest`s and interfaces directly with `URLSession` to execute network requests.
+class URLSessionHTTPClient: HTTPClient {
     
     let coreConfig: CoreConfig
     private var urlSession: URLSessionProtocol

--- a/Sources/CorePayments/Networking/UpdateClientConfigAPI.swift
+++ b/Sources/CorePayments/Networking/UpdateClientConfigAPI.swift
@@ -16,7 +16,7 @@ public class UpdateClientConfigAPI {
         self.networkingClient = HTTPNetworkingClient(coreConfig: coreConfig)
     }
 
-    /// Exposed for injecting MockHTTPNetworkingClient in tests
+    /// Exposed for injecting MockNetworkingClient in tests
     init(coreConfig: CoreConfig, networkingClient: HTTPNetworkingClient) {
         self.coreConfig = coreConfig
         self.networkingClient = networkingClient

--- a/Sources/CorePayments/Networking/UpdateClientConfigAPI.swift
+++ b/Sources/CorePayments/Networking/UpdateClientConfigAPI.swift
@@ -7,17 +7,17 @@ public class UpdateClientConfigAPI {
     // MARK: - Private Properties
 
     private let coreConfig: CoreConfig
-    private let networkingClient: NetworkingClient
+    private let networkingClient: HTTPNetworkingClient
 
     // MARK: - Initializer
 
     public init(coreConfig: CoreConfig) {
         self.coreConfig = coreConfig
-        self.networkingClient = NetworkingClient(coreConfig: coreConfig)
+        self.networkingClient = HTTPNetworkingClient(coreConfig: coreConfig)
     }
 
-    /// Exposed for injecting MockNetworkingClient in tests
-    init(coreConfig: CoreConfig, networkingClient: NetworkingClient) {
+    /// Exposed for injecting MockHTTPNetworkingClient in tests
+    init(coreConfig: CoreConfig, networkingClient: HTTPNetworkingClient) {
         self.coreConfig = coreConfig
         self.networkingClient = networkingClient
     }

--- a/Sources/CorePayments/Networking/UpdateClientConfigAPI.swift
+++ b/Sources/CorePayments/Networking/UpdateClientConfigAPI.swift
@@ -7,7 +7,7 @@ public class UpdateClientConfigAPI {
     // MARK: - Private Properties
 
     private let coreConfig: CoreConfig
-    private let networkingClient: HTTPNetworkingClient
+    private let networkingClient: NetworkingClient
 
     // MARK: - Initializer
 
@@ -17,7 +17,7 @@ public class UpdateClientConfigAPI {
     }
 
     /// Exposed for injecting MockNetworkingClient in tests
-    init(coreConfig: CoreConfig, networkingClient: HTTPNetworkingClient) {
+    init(coreConfig: CoreConfig, networkingClient: NetworkingClient) {
         self.coreConfig = coreConfig
         self.networkingClient = networkingClient
     }

--- a/Sources/PayPalWebPayments/PayPalWebCheckoutClient.swift
+++ b/Sources/PayPalWebPayments/PayPalWebCheckoutClient.swift
@@ -10,7 +10,7 @@ public class PayPalWebCheckoutClient: NSObject {
 
     private let clientConfigAPI: UpdateClientConfigAPI
     private let webAuthenticationSession: WebAuthenticationSession
-    private let networkingClient: NetworkingClient
+    private let networkingClient: HTTPNetworkingClient
     private var analyticsService: AnalyticsService?
 
     /// Initialize a PayPalWebCheckoutClient to process PayPal transaction
@@ -19,14 +19,14 @@ public class PayPalWebCheckoutClient: NSObject {
     public init(config: CoreConfig) {
         self.config = config
         self.webAuthenticationSession = WebAuthenticationSession()
-        self.networkingClient = NetworkingClient(coreConfig: config)
+        self.networkingClient = HTTPNetworkingClient(coreConfig: config)
         self.clientConfigAPI = UpdateClientConfigAPI(coreConfig: config)
     }
     
     /// For internal use for testing/mocking purpose
     init(
         config: CoreConfig,
-        networkingClient: NetworkingClient,
+        networkingClient: HTTPNetworkingClient,
         clientConfigAPI: UpdateClientConfigAPI,
         webAuthenticationSession: WebAuthenticationSession
     ) {

--- a/Sources/PayPalWebPayments/PayPalWebCheckoutClient.swift
+++ b/Sources/PayPalWebPayments/PayPalWebCheckoutClient.swift
@@ -10,7 +10,7 @@ public class PayPalWebCheckoutClient: NSObject {
 
     private let clientConfigAPI: UpdateClientConfigAPI
     private let webAuthenticationSession: WebAuthenticationSession
-    private let networkingClient: HTTPNetworkingClient
+    private let networkingClient: NetworkingClient
     private var analyticsService: AnalyticsService?
 
     /// Initialize a PayPalWebCheckoutClient to process PayPal transaction
@@ -26,7 +26,7 @@ public class PayPalWebCheckoutClient: NSObject {
     /// For internal use for testing/mocking purpose
     init(
         config: CoreConfig,
-        networkingClient: HTTPNetworkingClient,
+        networkingClient: NetworkingClient,
         clientConfigAPI: UpdateClientConfigAPI,
         webAuthenticationSession: WebAuthenticationSession
     ) {

--- a/UnitTests/CardPaymentsTests/CardClient_Tests.swift
+++ b/UnitTests/CardPaymentsTests/CardClient_Tests.swift
@@ -33,7 +33,7 @@ class CardClient_Tests: XCTestCase {
 
     override func setUp() {
         super.setUp()
-        mockNetworkingClient = MockNetworkingClient(coreConfig: config)
+        mockNetworkingClient = MockNetworkingClient()
         cardRequest = CardRequest(orderID: "testOrderId", card: card)
         cardVaultRequest = CardVaultRequest(card: card, setupTokenID: "testSetupTokenId")
 

--- a/UnitTests/CardPaymentsTests/CheckoutOrdersAPI_Tests.swift
+++ b/UnitTests/CardPaymentsTests/CheckoutOrdersAPI_Tests.swift
@@ -26,8 +26,7 @@ class CheckoutOrdersAPI_Tests: XCTestCase {
     override func setUp() {
         super.setUp()
         
-        let mockHTTP = MockHTTP(coreConfig: coreConfig)
-        mockNetworkingClient = MockNetworkingClient(http: mockHTTP)
+        mockNetworkingClient = MockNetworkingClient()
         sut = CheckoutOrdersAPI(coreConfig: coreConfig, networkingClient: mockNetworkingClient)
     }
     

--- a/UnitTests/CardPaymentsTests/CheckoutOrdersAPI_Tests.swift
+++ b/UnitTests/CardPaymentsTests/CheckoutOrdersAPI_Tests.swift
@@ -1,5 +1,6 @@
 import Foundation
 import XCTest
+
 @testable import CardPayments
 @testable import CorePayments
 @testable import TestShared

--- a/UnitTests/CardPaymentsTests/VaultPaymentTokensAPI_Tests.swift
+++ b/UnitTests/CardPaymentsTests/VaultPaymentTokensAPI_Tests.swift
@@ -27,8 +27,7 @@ class VaultPaymentTokensAPI_Tests: XCTestCase {
     override func setUp() {
         super.setUp()
         
-        let mockHTTP = MockHTTP(coreConfig: coreConfig)
-        mockNetworkingClient = MockNetworkingClient(http: mockHTTP)
+        mockNetworkingClient = MockNetworkingClient()
         sut = VaultPaymentTokensAPI(coreConfig: coreConfig, networkingClient: mockNetworkingClient)
     }
     

--- a/UnitTests/CorePaymentTests/UpdateClientConfigAP_Tests.swift
+++ b/UnitTests/CorePaymentTests/UpdateClientConfigAP_Tests.swift
@@ -16,8 +16,7 @@ class UpdateClientConfigAPI_Tests: XCTestCase {
     override func setUp() {
         super.setUp()
 
-        let mockHTTP = MockHTTP(coreConfig: coreConfig)
-        mockNetworkingClient = MockNetworkingClient(http: mockHTTP)
+        mockNetworkingClient = MockNetworkingClient()
         sut = UpdateClientConfigAPI(coreConfig: coreConfig, networkingClient: mockNetworkingClient)
     }
 

--- a/UnitTests/PayPalWebPaymentsTests/PayPalWebCheckoutClient_Tests.swift
+++ b/UnitTests/PayPalWebPaymentsTests/PayPalWebCheckoutClient_Tests.swift
@@ -18,7 +18,7 @@ class PayPalClient_Tests: XCTestCase {
         super.setUp()
         config = CoreConfig(clientID: "testClientID", environment: .sandbox)
         mockWebAuthenticationSession = MockWebAuthenticationSession()
-        mockNetworkingClient = MockNetworkingClient(http: MockHTTP(coreConfig: config))
+        mockNetworkingClient = MockNetworkingClient()
         mockClientConfigAPI = MockClientConfigAPI(coreConfig: config, networkingClient: mockNetworkingClient)
 
 

--- a/UnitTests/PaymentsCoreTests/HTTP_Tests.swift
+++ b/UnitTests/PaymentsCoreTests/HTTP_Tests.swift
@@ -11,7 +11,7 @@ class HTTP_Tests: XCTestCase {
     
     let config = CoreConfig(clientID: "mockClientID", environment: .sandbox)
     var mockURLSession: MockURLSession!
-    var sut: HTTP!
+    var sut: URLSessionHTTPClient!
     
     // MARK: - Test lifecycle
     
@@ -25,7 +25,7 @@ class HTTP_Tests: XCTestCase {
         mockURLSession.cannedURLResponse = nil
         mockURLSession.cannedJSONData = nil
         
-        sut = HTTP(
+        sut = URLSessionHTTPClient(
             urlSession: mockURLSession,
             coreConfig: config
         )

--- a/UnitTests/PaymentsCoreTests/HTTP_Tests.swift
+++ b/UnitTests/PaymentsCoreTests/HTTP_Tests.swift
@@ -25,10 +25,7 @@ class HTTP_Tests: XCTestCase {
         mockURLSession.cannedURLResponse = nil
         mockURLSession.cannedJSONData = nil
         
-        sut = URLSessionHTTPClient(
-            urlSession: mockURLSession,
-            coreConfig: config
-        )
+        sut = URLSessionHTTPClient(urlSession: mockURLSession, coreConfig: config)
     }
     
     // MARK: - performRequest()

--- a/UnitTests/PaymentsCoreTests/NetworkingClient_Tests.swift
+++ b/UnitTests/PaymentsCoreTests/NetworkingClient_Tests.swift
@@ -7,7 +7,7 @@ class NetworkingClient_Tests: XCTestCase {
     // MARK: - Helper Properties
     
     var sut: HTTPNetworkingClient!
-    var mockHTTP: MockHTTP!
+    var mockHTTP: MockHTTPClient!
     let coreConfig = CoreConfig(clientID: "fake-client-id", environment: .sandbox)
     let base64EncodedFakeClientID = "ZmFrZS1jbGllbnQtaWQ6" // "fake-client-id" encoded
     let stubHTTPResponse = HTTPResponse(status: 200, body: nil)
@@ -17,7 +17,7 @@ class NetworkingClient_Tests: XCTestCase {
     override func setUp() {
         super.setUp()
         
-        mockHTTP = MockHTTP()
+        mockHTTP = MockHTTPClient()
         mockHTTP.stubHTTPResponse = stubHTTPResponse
         sut = HTTPNetworkingClient(http: mockHTTP, coreConfig: coreConfig)
     }
@@ -25,7 +25,7 @@ class NetworkingClient_Tests: XCTestCase {
     // MARK: - fetch() REST
     
     func testFetchREST_whenLive_usesProperPayPalURL() async throws {
-        let mockHTTP = MockHTTP()
+        let mockHTTP = MockHTTPClient()
         mockHTTP.stubHTTPResponse = HTTPResponse(status: 200, body: nil)
         let coreConfig = CoreConfig(clientID: "fake-client-id", environment: .live)
         let sut = HTTPNetworkingClient(http: mockHTTP, coreConfig: coreConfig)
@@ -103,7 +103,7 @@ class NetworkingClient_Tests: XCTestCase {
     // MARK: - fetch() GraphQL
     
     func testFetchGraphQL_whenLive_usesProperPayPalURL() async throws {
-        let mockHTTP = MockHTTP()
+        let mockHTTP = MockHTTPClient()
         mockHTTP.stubHTTPResponse = HTTPResponse(status: 200, body: nil)
         let coreConfig = CoreConfig(clientID: "fake-client-id", environment: .live)
         let sut = HTTPNetworkingClient(http: mockHTTP, coreConfig: coreConfig)

--- a/UnitTests/PaymentsCoreTests/NetworkingClient_Tests.swift
+++ b/UnitTests/PaymentsCoreTests/NetworkingClient_Tests.swift
@@ -6,9 +6,9 @@ class NetworkingClient_Tests: XCTestCase {
     
     // MARK: - Helper Properties
     
-    var sut: NetworkingClient!
+    var sut: HTTPNetworkingClient!
     var mockHTTP: MockHTTP!
-    var coreConfig = CoreConfig(clientID: "fake-client-id", environment: .sandbox)
+    let coreConfig = CoreConfig(clientID: "fake-client-id", environment: .sandbox)
     let base64EncodedFakeClientID = "ZmFrZS1jbGllbnQtaWQ6" // "fake-client-id" encoded
     let stubHTTPResponse = HTTPResponse(status: 200, body: nil)
     
@@ -17,17 +17,18 @@ class NetworkingClient_Tests: XCTestCase {
     override func setUp() {
         super.setUp()
         
-        mockHTTP = MockHTTP(coreConfig: coreConfig)
+        mockHTTP = MockHTTP()
         mockHTTP.stubHTTPResponse = stubHTTPResponse
-        sut = NetworkingClient(http: mockHTTP)
+        sut = HTTPNetworkingClient(http: mockHTTP, coreConfig: coreConfig)
     }
     
     // MARK: - fetch() REST
     
     func testFetchREST_whenLive_usesProperPayPalURL() async throws {
-        let mockHTTP = MockHTTP(coreConfig: CoreConfig(clientID: "123", environment: .live))
+        let mockHTTP = MockHTTP()
         mockHTTP.stubHTTPResponse = HTTPResponse(status: 200, body: nil)
-        let sut = NetworkingClient(http: mockHTTP)
+        let coreConfig = CoreConfig(clientID: "fake-client-id", environment: .live)
+        let sut = HTTPNetworkingClient(http: mockHTTP, coreConfig: coreConfig)
         
         let fakeGETRequest = RESTRequest(path: "", method: .get)
         
@@ -102,9 +103,10 @@ class NetworkingClient_Tests: XCTestCase {
     // MARK: - fetch() GraphQL
     
     func testFetchGraphQL_whenLive_usesProperPayPalURL() async throws {
-        let mockHTTP = MockHTTP(coreConfig: CoreConfig(clientID: "123", environment: .live))
+        let mockHTTP = MockHTTP()
         mockHTTP.stubHTTPResponse = HTTPResponse(status: 200, body: nil)
-        let sut = NetworkingClient(http: mockHTTP)
+        let coreConfig = CoreConfig(clientID: "fake-client-id", environment: .live)
+        let sut = HTTPNetworkingClient(http: mockHTTP, coreConfig: coreConfig)
         
         let fakeGraphQLRequest = GraphQLRequest(query: "fake-query", variables: FakeRequest(fakeParam: "fake-param"))
         

--- a/UnitTests/PaymentsCoreTests/TrackingEventsAPI_Tests.swift
+++ b/UnitTests/PaymentsCoreTests/TrackingEventsAPI_Tests.swift
@@ -25,8 +25,7 @@ class TrackingEventsAPI_Tests: XCTestCase {
     override func setUp() {
         super.setUp()
         
-        let mockHTTP = MockHTTP(coreConfig: coreConfig)
-        mockNetworkingClient = MockNetworkingClient(http: mockHTTP)
+        mockNetworkingClient = MockNetworkingClient()
         mockNetworkingClient.stubHTTPResponse = stubHTTPResponse
         sut = TrackingEventsAPI(coreConfig: coreConfig, networkingClient: mockNetworkingClient)
     }

--- a/UnitTests/TestShared/MockHTTP.swift
+++ b/UnitTests/TestShared/MockHTTP.swift
@@ -1,14 +1,14 @@
 @testable import CorePayments
 import Foundation
 
-class MockHTTP: HTTP {
+class MockHTTP: HTTPClient {
         
     var stubHTTPResponse: HTTPResponse?
     var stubHTTPError: Error?
     
     var capturedHTTPRequest: HTTPRequest?
     
-    override func performRequest(_ httpRequest: HTTPRequest) async throws -> HTTPResponse {
+    func performRequest(_ httpRequest: HTTPRequest) async throws -> HTTPResponse {
         capturedHTTPRequest = httpRequest
         
         if let stubHTTPError {

--- a/UnitTests/TestShared/MockHTTPClient.swift
+++ b/UnitTests/TestShared/MockHTTPClient.swift
@@ -1,7 +1,7 @@
 @testable import CorePayments
 import Foundation
 
-class MockHTTP: HTTPClient {
+class MockHTTPClient: HTTPClient {
         
     var stubHTTPResponse: HTTPResponse?
     var stubHTTPError: Error?

--- a/UnitTests/TestShared/MockNetworkingClient.swift
+++ b/UnitTests/TestShared/MockNetworkingClient.swift
@@ -9,7 +9,7 @@ class MockNetworkingClient: NetworkingClient {
     var capturedRESTRequest: RESTRequest?
     var capturedGraphQLRequest: GraphQLRequest?
     
-    override func fetch(request: RESTRequest) async throws -> HTTPResponse {
+    func fetch(request: RESTRequest) async throws -> HTTPResponse {
         capturedRESTRequest = request
         
         if let stubHTTPError {
@@ -23,7 +23,7 @@ class MockNetworkingClient: NetworkingClient {
         throw CoreSDKError(code: 0, domain: "", errorDescription: "Stubbed responses not implemented for this mock.")
     }
     
-    override func fetch(request: GraphQLRequest, clientContext: String? = nil) async throws -> HTTPResponse {
+    func fetch(request: GraphQLRequest, clientContext: String? = nil) async throws -> HTTPResponse {
         capturedGraphQLRequest = request
         
         if let stubHTTPError {


### PR DESCRIPTION
### Summary of changes

- Create `HTTPClient` protocol and `NetworkingClient` protocol to adhere to the best practice of Protocol Oriented Programming.
- Rename `HTTP` to `HTTPNetworkingClient`
- Simplify `MockHTTPClient` and `MockNetworkingClient` by making them implement the new protocols rather than subclassing concrete types. 
### Checklist

- [ ] ~Added a changelog entry~

### Authors
> List GitHub usernames for everyone who contributed to this pull request.

- @sshropshire