### PR TITLE
v3: Migrate analytics events to type-safe enums

### DIFF
--- a/PayPal.xcodeproj/project.pbxproj
+++ b/PayPal.xcodeproj/project.pbxproj
@@ -34,6 +34,9 @@
 		3BF06F432E16480F002CA7B4 /* MockUpdateClientConfigAPI.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3B8F84912D933FAE00A151AC /* MockUpdateClientConfigAPI.swift */; };
 		3D1763A22720722A00652E1C /* CardResult.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3D1763A12720722A00652E1C /* CardResult.swift */; };
 		3DC42BA927187E8300B71645 /* ErrorResponse.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3DC42BA827187E8300B71645 /* ErrorResponse.swift */; };
+		3EE92DE4655CDA2D0A6B588B /* PaymentButtonAnalyticsEvent_Tests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5F71D0570849A6ADA3D27B87 /* PaymentButtonAnalyticsEvent_Tests.swift */; };
+		52657F2B74E29C6C85EFB62A /* CardAnalyticsEvent.swift in Sources */ = {isa = PBXBuildFile; fileRef = 930937583861850DE591F719 /* CardAnalyticsEvent.swift */; };
+		7B36A6F9E688806439FD42EB /* PayPalWebAnalyticsEvent_Tests.swift in Sources */ = {isa = PBXBuildFile; fileRef = ACC23AEA184FCF328D3494DC /* PayPalWebAnalyticsEvent_Tests.swift */; };
 		8008D2052A9E54FF0003CAF4 /* CheckoutOrdersAPI_Tests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8008D2042A9E54FF0003CAF4 /* CheckoutOrdersAPI_Tests.swift */; };
 		8021B69029144E6D000FBC54 /* PayPalCoreConstants.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8021B68F29144E6D000FBC54 /* PayPalCoreConstants.swift */; };
 		802C4A742945670400896A5D /* MockHTTPClient.swift in Sources */ = {isa = PBXBuildFile; fileRef = 802C4A732945670400896A5D /* MockHTTPClient.swift */; };
@@ -73,6 +76,9 @@
 		80E8DAE126B8784600FAFC3F /* Card.swift in Sources */ = {isa = PBXBuildFile; fileRef = 80E8DAE026B8784600FAFC3F /* Card.swift */; };
 		80E8DAEA26B8785D00FAFC3F /* CardPayments.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 80E8DAD926B8783800FAFC3F /* CardPayments.framework */; };
 		80FC261D29847AC7008EC841 /* HTTP_Tests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 80FC261C29847AC7008EC841 /* HTTP_Tests.swift */; };
+		9A62AD81B0F8C8C6BC05B396 /* PayPalWebAnalyticsEvent.swift in Sources */ = {isa = PBXBuildFile; fileRef = B132790007E3EECE46D17A27 /* PayPalWebAnalyticsEvent.swift */; };
+		AE8A7766634621232904A26D /* CardAnalyticsEvent_Tests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 374FF18A656F6AAF924A493A /* CardAnalyticsEvent_Tests.swift */; };
+		B7631BB1F6BCC9FFEB441AED /* PaymentButtonAnalyticsEvent.swift in Sources */ = {isa = PBXBuildFile; fileRef = B37D5A0DA0FA37B471D4DBA3 /* PaymentButtonAnalyticsEvent.swift */; };
 		BC04836F27B2FB3600FA7B46 /* URLSessionProtocol.swift in Sources */ = {isa = PBXBuildFile; fileRef = BC04836E27B2FB3600FA7B46 /* URLSessionProtocol.swift */; };
 		BC04837427B2FC7300FA7B46 /* URLSession+URLSessionProtocol.swift in Sources */ = {isa = PBXBuildFile; fileRef = BC04837327B2FC7300FA7B46 /* URLSession+URLSessionProtocol.swift */; };
 		BC0A82A5270B9533006E9A21 /* ConfirmPaymentSourceRequest.swift in Sources */ = {isa = PBXBuildFile; fileRef = 06CE009F26F3DF100000CC46 /* ConfirmPaymentSourceRequest.swift */; };
@@ -137,6 +143,7 @@
 		CB4BE28C2851427600EA2DD1 /* MockViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = BCE8A7F427EA544000AC301B /* MockViewController.swift */; };
 		CB51FF7227FCB947001A97F5 /* PayPalWebCheckoutFundingSource.swift in Sources */ = {isa = PBXBuildFile; fileRef = CB51FF7127FCB947001A97F5 /* PayPalWebCheckoutFundingSource.swift */; };
 		CBC16DD529E99B4600307117 /* PaymentSource.swift in Sources */ = {isa = PBXBuildFile; fileRef = CB4BE285284802C200EA2DD1 /* PaymentSource.swift */; };
+		D634623595688DD56A1D225B /* AnalyticsEventName.swift in Sources */ = {isa = PBXBuildFile; fileRef = A8FD1D323748DBB5FB82C544 /* AnalyticsEventName.swift */; };
 		E6022E802857C6BE008B0E27 /* GraphQLHTTPResponse.swift in Sources */ = {isa = PBXBuildFile; fileRef = E64623222836A69E008AC8E1 /* GraphQLHTTPResponse.swift */; };
 /* End PBXBuildFile section */
 
@@ -195,6 +202,7 @@
 		06CE009A26F3D5A40000CC46 /* CardClient.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CardClient.swift; sourceTree = "<group>"; };
 		06CE009F26F3DF100000CC46 /* ConfirmPaymentSourceRequest.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ConfirmPaymentSourceRequest.swift; sourceTree = "<group>"; };
 		06CE00A226F3E32A0000CC46 /* ConfirmPaymentSourceResponse.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ConfirmPaymentSourceResponse.swift; sourceTree = "<group>"; };
+		374FF18A656F6AAF924A493A /* CardAnalyticsEvent_Tests.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = CardAnalyticsEvent_Tests.swift; sourceTree = "<group>"; };
 		3B22E8B72A841AEA00962E34 /* CardVaultResult.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CardVaultResult.swift; sourceTree = "<group>"; };
 		3B29C3962B9148F70077741D /* PayPalVaultRequest.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PayPalVaultRequest.swift; sourceTree = "<group>"; };
 		3B3C511D2B2395B5009125FE /* PayPalVaultResult.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PayPalVaultResult.swift; sourceTree = "<group>"; };
@@ -215,6 +223,7 @@
 		3BF06F3E2E15CC35002CA7B4 /* ClientConfigResponse.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ClientConfigResponse.swift; sourceTree = "<group>"; };
 		3D1763A12720722A00652E1C /* CardResult.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CardResult.swift; sourceTree = "<group>"; };
 		3DC42BA827187E8300B71645 /* ErrorResponse.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ErrorResponse.swift; sourceTree = "<group>"; };
+		5F71D0570849A6ADA3D27B87 /* PaymentButtonAnalyticsEvent_Tests.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = PaymentButtonAnalyticsEvent_Tests.swift; sourceTree = "<group>"; };
 		8008D2042A9E54FF0003CAF4 /* CheckoutOrdersAPI_Tests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CheckoutOrdersAPI_Tests.swift; sourceTree = "<group>"; };
 		8021B68F29144E6D000FBC54 /* PayPalCoreConstants.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PayPalCoreConstants.swift; sourceTree = "<group>"; };
 		802C4A732945670400896A5D /* MockHTTPClient.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MockHTTPClient.swift; sourceTree = "<group>"; };
@@ -253,6 +262,11 @@
 		80E8DAE026B8784600FAFC3F /* Card.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Card.swift; sourceTree = "<group>"; };
 		80E8DAE626B8785D00FAFC3F /* CardPaymentsTests.xctest */ = {isa = PBXFileReference; explicitFileType = wrapper.cfbundle; includeInIndex = 0; path = CardPaymentsTests.xctest; sourceTree = BUILT_PRODUCTS_DIR; };
 		80FC261C29847AC7008EC841 /* HTTP_Tests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = HTTP_Tests.swift; sourceTree = "<group>"; };
+		930937583861850DE591F719 /* CardAnalyticsEvent.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = CardAnalyticsEvent.swift; sourceTree = "<group>"; };
+		A8FD1D323748DBB5FB82C544 /* AnalyticsEventName.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = AnalyticsEventName.swift; sourceTree = "<group>"; };
+		ACC23AEA184FCF328D3494DC /* PayPalWebAnalyticsEvent_Tests.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = PayPalWebAnalyticsEvent_Tests.swift; sourceTree = "<group>"; };
+		B132790007E3EECE46D17A27 /* PayPalWebAnalyticsEvent.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = PayPalWebAnalyticsEvent.swift; sourceTree = "<group>"; };
+		B37D5A0DA0FA37B471D4DBA3 /* PaymentButtonAnalyticsEvent.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = PaymentButtonAnalyticsEvent.swift; sourceTree = "<group>"; };
 		BC04836E27B2FB3600FA7B46 /* URLSessionProtocol.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = URLSessionProtocol.swift; sourceTree = "<group>"; };
 		BC04837327B2FC7300FA7B46 /* URLSession+URLSessionProtocol.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "URLSession+URLSessionProtocol.swift"; sourceTree = "<group>"; };
 		BC171FB02A8C156300B26DCB /* CoreConfig+MagnesSDK.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "CoreConfig+MagnesSDK.swift"; sourceTree = "<group>"; };
@@ -530,6 +544,7 @@
 				8021B68F29144E6D000FBC54 /* PayPalCoreConstants.swift */,
 				80DB2F752980795D00CFB86A /* CorePaymentsError.swift */,
 				3BE738632B9A4A4500598F05 /* PrivacyInfo.xcprivacy */,
+				A8FD1D323748DBB5FB82C544 /* AnalyticsEventName.swift */,
 			);
 			name = CorePayments;
 			path = Sources/CorePayments;
@@ -572,6 +587,7 @@
 				80DBC9D829C336D500462539 /* APIRequests */,
 				065A4DBD26FCDA270007014A /* Models */,
 				3BE738622B9A482800598F05 /* PrivacyInfo.xcprivacy */,
+				930937583861850DE591F719 /* CardAnalyticsEvent.swift */,
 			);
 			name = CardPayments;
 			path = Sources/CardPayments;
@@ -585,6 +601,7 @@
 				065A4DC226FCE1D20007014A /* ConfirmPaymentSourceRequest_Tests.swift */,
 				80B27AF02A9E9EE60008EA45 /* VaultPaymentTokensAPI_Tests.swift */,
 				808E3EDB2A981F130017FE46 /* Mocks */,
+				374FF18A656F6AAF924A493A /* CardAnalyticsEvent_Tests.swift */,
 			);
 			path = CardPaymentsTests;
 			sourceTree = "<group>";
@@ -594,6 +611,7 @@
 			children = (
 				BCE8A7FA27EA5B1D00AC301B /* Environment+PayPalWebCheckout_Tests.swift */,
 				BCE8A7F827EA555800AC301B /* PayPalWebCheckoutClient_Tests.swift */,
+				ACC23AEA184FCF328D3494DC /* PayPalWebAnalyticsEvent_Tests.swift */,
 			);
 			path = PayPalWebPaymentsTests;
 			sourceTree = "<group>";
@@ -643,6 +661,7 @@
 				CB1A47FD2820C10700BD8184 /* PaymentButtonFundingSource.swift */,
 				CB1A48042822BCED00BD8184 /* PaymentButton+ImageAsset.swift */,
 				3BE738672B9A598200598F05 /* PrivacyInfo.xcprivacy */,
+				B37D5A0DA0FA37B471D4DBA3 /* PaymentButtonAnalyticsEvent.swift */,
 			);
 			name = PaymentButtons;
 			path = Sources/PaymentButtons;
@@ -655,6 +674,7 @@
 				BE00B7AC27444FE900758C63 /* PayPalButton_Tests.swift */,
 				BE9F36E3275520E700AFC7DA /* PayPalCreditButton_Tests.swift */,
 				CB22C017291049500097E592 /* PayPalPayLaterButton_Tests.swift */,
+				5F71D0570849A6ADA3D27B87 /* PaymentButtonAnalyticsEvent_Tests.swift */,
 			);
 			path = PaymentButtonsTests;
 			sourceTree = "<group>";
@@ -671,6 +691,7 @@
 				3B3C511D2B2395B5009125FE /* PayPalVaultResult.swift */,
 				3B29C3962B9148F70077741D /* PayPalVaultRequest.swift */,
 				3BE738662B9A593100598F05 /* PrivacyInfo.xcprivacy */,
+				B132790007E3EECE46D17A27 /* PayPalWebAnalyticsEvent.swift */,
 			);
 			name = PayPalWebPayments;
 			path = Sources/PayPalWebPayments;
@@ -897,8 +918,6 @@
 			dependencies = (
 			);
 			name = PayPalWebPayments;
-			packageProductDependencies = (
-			);
 			productName = PayPal;
 			productReference = BCD5C48527E9200800B074D5 /* PayPalWebPayments.framework */;
 			productType = "com.apple.product-type.framework";
@@ -970,8 +989,6 @@
 			dependencies = (
 			);
 			name = PaymentButtons;
-			packageProductDependencies = (
-			);
 			productName = PayPal;
 			productReference = BCFAC70927ED042500C3AF00 /* PaymentButtons.framework */;
 			productType = "com.apple.product-type.framework";
@@ -1048,8 +1065,6 @@
 				en,
 			);
 			mainGroup = OBJ_5;
-			packageReferences = (
-			);
 			productRefGroup = OBJ_13 /* Products */;
 			projectDirPath = "";
 			projectRoot = "";
@@ -1214,6 +1229,7 @@
 				BE0000032E1A000000000002 /* NetworkingClient.swift in Sources */,
 				807BF58F2A2A5D19002F32B3 /* HTTPResponseParser.swift in Sources */,
 				807D56AE2A869064009E591D /* GraphQLRequest.swift in Sources */,
+				D634623595688DD56A1D225B /* AnalyticsEventName.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -1253,6 +1269,7 @@
 				CB4BE27D2847AF6F00EA2DD1 /* SCA.swift in Sources */,
 				0647E70E2714962800F8E517 /* Address.swift in Sources */,
 				BC7F8123275FC1350011EDC8 /* CardRequest.swift in Sources */,
+				52657F2B74E29C6C85EFB62A /* CardAnalyticsEvent.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -1268,6 +1285,7 @@
 				BC0A82A6270B9954006E9A21 /* ConfirmPaymentSourceRequest_Tests.swift in Sources */,
 				808E3EDD2A981F240017FE46 /* MockCheckoutOrdersAPI.swift in Sources */,
 				808E3EDF2A981F390017FE46 /* MockVaultPaymentTokensAPI.swift in Sources */,
+				AE8A7766634621232904A26D /* CardAnalyticsEvent_Tests.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -1283,6 +1301,7 @@
 				BE4F785727EB656400FF4C0E /* PayPalWebCheckoutRequest.swift in Sources */,
 				BE4F785827EB656400FF4C0E /* PayPalWebCheckoutResult.swift in Sources */,
 				CB51FF7227FCB947001A97F5 /* PayPalWebCheckoutFundingSource.swift in Sources */,
+				9A62AD81B0F8C8C6BC05B396 /* PayPalWebAnalyticsEvent.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -1292,6 +1311,7 @@
 			files = (
 				BCE8A7FB27EA5B1D00AC301B /* Environment+PayPalWebCheckout_Tests.swift in Sources */,
 				BCE8A7F927EA555800AC301B /* PayPalWebCheckoutClient_Tests.swift in Sources */,
+				7B36A6F9E688806439FD42EB /* PayPalWebAnalyticsEvent_Tests.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -1337,6 +1357,7 @@
 				CB1A47F22820AFED00BD8184 /* PayPalPayLaterButton.swift in Sources */,
 				CB1A47F42820BA5D00BD8184 /* PaymentButtonEdges.swift in Sources */,
 				BCFAC71A27ED04AC00C3AF00 /* PaymentButtonColor.swift in Sources */,
+				B7631BB1F6BCC9FFEB441AED /* PaymentButtonAnalyticsEvent.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -1348,6 +1369,7 @@
 				BCFAC70F27ED043100C3AF00 /* Coordinator_Tests.swift in Sources */,
 				CB22C018291049500097E592 /* PayPalPayLaterButton_Tests.swift in Sources */,
 				BCFAC71327ED043100C3AF00 /* PayPalCreditButton_Tests.swift in Sources */,
+				3EE92DE4655CDA2D0A6B588B /* PaymentButtonAnalyticsEvent_Tests.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};

--- a/Sources/CardPayments/CardAnalyticsEvent.swift
+++ b/Sources/CardPayments/CardAnalyticsEvent.swift
@@ -1,0 +1,75 @@
+import Foundation
+import CorePayments
+
+/// FPTI analytics events emitted by the `CardPayments` module.
+///
+/// This is exposed for internal PayPal use only. It is not covered by
+/// Semantic Versioning and may change or be removed at any time.
+@_documentation(visibility: private)
+public enum CardAnalyticsEvent: AnalyticsEventName {
+
+    // MARK: - Approve Order
+
+    case approveOrderStarted
+    case approveOrderAuthChallengeRequired
+    case approveOrderAuthChallengePresentationSucceeded
+    case approveOrderAuthChallengePresentationFailed
+    case approveOrderSucceeded
+    case approveOrderFailed
+    case approveOrderAuthChallengeSucceeded
+    case approveOrderAuthChallengeFailed
+    case approveOrderAuthChallengeCanceled
+
+    // MARK: - Vault Without Purchase
+
+    case vaultStarted
+    case vaultAuthChallengeRequired
+    case vaultAuthChallengePresentationSucceeded
+    case vaultAuthChallengePresentationFailed
+    case vaultSucceeded
+    case vaultFailed
+    case vaultAuthChallengeSucceeded
+    case vaultAuthChallengeFailed
+    case vaultAuthChallengeCanceled
+
+    public var eventName: String {
+        switch self {
+        case .approveOrderStarted:
+            return "card-payments:approve-order:started"
+        case .approveOrderAuthChallengeRequired:
+            return "card-payments:approve-order:auth-challenge-required"
+        case .approveOrderAuthChallengePresentationSucceeded:
+            return "card-payments:approve-order:auth-challenge-presentation:succeeded"
+        case .approveOrderAuthChallengePresentationFailed:
+            return "card-payments:approve-order:auth-challenge-presentation:failed"
+        case .approveOrderSucceeded:
+            return "card-payments:approve-order:succeeded"
+        case .approveOrderFailed:
+            return "card-payments:approve-order:failed"
+        case .approveOrderAuthChallengeSucceeded:
+            return "card-payments:approve-order:auth-challenge:succeeded"
+        case .approveOrderAuthChallengeFailed:
+            return "card-payments:approve-order:auth-challenge:failed"
+        case .approveOrderAuthChallengeCanceled:
+            return "card-payments:approve-order:auth-challenge:canceled"
+        case .vaultStarted:
+            return "card-payments:vault-wo-purchase:started"
+        case .vaultAuthChallengeRequired:
+            return "card-payments:vault-wo-purchase:auth-challenge-required"
+        case .vaultAuthChallengePresentationSucceeded:
+            return "card-payments:vault-wo-purchase:auth-challenge-presentation:succeeded"
+        case .vaultAuthChallengePresentationFailed:
+            return "card-payments:vault-wo-purchase:auth-challenge-presentation:failed"
+        case .vaultSucceeded:
+            return "card-payments:vault-wo-purchase:succeeded"
+        case .vaultFailed:
+            return "card-payments:vault-wo-purchase:failed"
+        case .vaultAuthChallengeSucceeded:
+            return "card-payments:vault-wo-purchase:auth-challenge:succeeded"
+        case .vaultAuthChallengeFailed:
+            return "card-payments:vault-wo-purchase:auth-challenge:failed"
+        case .vaultAuthChallengeCanceled:
+            return "card-payments:vault-wo-purchase:auth-challenge:canceled"
+        }
+    }
+}

--- a/Sources/CardPayments/CardAnalyticsEvent.swift
+++ b/Sources/CardPayments/CardAnalyticsEvent.swift
@@ -1,5 +1,8 @@
 import Foundation
+
+#if canImport(CorePayments)
 import CorePayments
+#endif
 
 /// FPTI analytics events emitted by the `CardPayments` module.
 ///

--- a/Sources/CardPayments/CardAnalyticsEvent.swift
+++ b/Sources/CardPayments/CardAnalyticsEvent.swift
@@ -6,70 +6,81 @@ import CorePayments
 /// This is exposed for internal PayPal use only. It is not covered by
 /// Semantic Versioning and may change or be removed at any time.
 @_documentation(visibility: private)
-public enum CardAnalyticsEvent: AnalyticsEventName {
+public enum CardAnalyticsEvent {
 
     // MARK: - Approve Order
 
-    case approveOrderStarted
-    case approveOrderAuthChallengeRequired
-    case approveOrderAuthChallengePresentationSucceeded
-    case approveOrderAuthChallengePresentationFailed
-    case approveOrderSucceeded
-    case approveOrderFailed
-    case approveOrderAuthChallengeSucceeded
-    case approveOrderAuthChallengeFailed
-    case approveOrderAuthChallengeCanceled
+    public enum ApproveOrder: AnalyticsEventName {
+
+        case started
+        case authChallengeRequired
+        case authChallengePresentationSucceeded
+        case authChallengePresentationFailed
+        case succeeded
+        case failed
+        case authChallengeSucceeded
+        case authChallengeFailed
+        case authChallengeCanceled
+
+        public var eventName: String {
+            switch self {
+            case .started:
+                return "card-payments:approve-order:started"
+            case .authChallengeRequired:
+                return "card-payments:approve-order:auth-challenge-required"
+            case .authChallengePresentationSucceeded:
+                return "card-payments:approve-order:auth-challenge-presentation:succeeded"
+            case .authChallengePresentationFailed:
+                return "card-payments:approve-order:auth-challenge-presentation:failed"
+            case .succeeded:
+                return "card-payments:approve-order:succeeded"
+            case .failed:
+                return "card-payments:approve-order:failed"
+            case .authChallengeSucceeded:
+                return "card-payments:approve-order:auth-challenge:succeeded"
+            case .authChallengeFailed:
+                return "card-payments:approve-order:auth-challenge:failed"
+            case .authChallengeCanceled:
+                return "card-payments:approve-order:auth-challenge:canceled"
+            }
+        }
+    }
 
     // MARK: - Vault Without Purchase
 
-    case vaultStarted
-    case vaultAuthChallengeRequired
-    case vaultAuthChallengePresentationSucceeded
-    case vaultAuthChallengePresentationFailed
-    case vaultSucceeded
-    case vaultFailed
-    case vaultAuthChallengeSucceeded
-    case vaultAuthChallengeFailed
-    case vaultAuthChallengeCanceled
+    public enum Vault: AnalyticsEventName {
 
-    public var eventName: String {
-        switch self {
-        case .approveOrderStarted:
-            return "card-payments:approve-order:started"
-        case .approveOrderAuthChallengeRequired:
-            return "card-payments:approve-order:auth-challenge-required"
-        case .approveOrderAuthChallengePresentationSucceeded:
-            return "card-payments:approve-order:auth-challenge-presentation:succeeded"
-        case .approveOrderAuthChallengePresentationFailed:
-            return "card-payments:approve-order:auth-challenge-presentation:failed"
-        case .approveOrderSucceeded:
-            return "card-payments:approve-order:succeeded"
-        case .approveOrderFailed:
-            return "card-payments:approve-order:failed"
-        case .approveOrderAuthChallengeSucceeded:
-            return "card-payments:approve-order:auth-challenge:succeeded"
-        case .approveOrderAuthChallengeFailed:
-            return "card-payments:approve-order:auth-challenge:failed"
-        case .approveOrderAuthChallengeCanceled:
-            return "card-payments:approve-order:auth-challenge:canceled"
-        case .vaultStarted:
-            return "card-payments:vault-wo-purchase:started"
-        case .vaultAuthChallengeRequired:
-            return "card-payments:vault-wo-purchase:auth-challenge-required"
-        case .vaultAuthChallengePresentationSucceeded:
-            return "card-payments:vault-wo-purchase:auth-challenge-presentation:succeeded"
-        case .vaultAuthChallengePresentationFailed:
-            return "card-payments:vault-wo-purchase:auth-challenge-presentation:failed"
-        case .vaultSucceeded:
-            return "card-payments:vault-wo-purchase:succeeded"
-        case .vaultFailed:
-            return "card-payments:vault-wo-purchase:failed"
-        case .vaultAuthChallengeSucceeded:
-            return "card-payments:vault-wo-purchase:auth-challenge:succeeded"
-        case .vaultAuthChallengeFailed:
-            return "card-payments:vault-wo-purchase:auth-challenge:failed"
-        case .vaultAuthChallengeCanceled:
-            return "card-payments:vault-wo-purchase:auth-challenge:canceled"
+        case started
+        case authChallengeRequired
+        case authChallengePresentationSucceeded
+        case authChallengePresentationFailed
+        case succeeded
+        case failed
+        case authChallengeSucceeded
+        case authChallengeFailed
+        case authChallengeCanceled
+
+        public var eventName: String {
+            switch self {
+            case .started:
+                return "card-payments:vault-wo-purchase:started"
+            case .authChallengeRequired:
+                return "card-payments:vault-wo-purchase:auth-challenge-required"
+            case .authChallengePresentationSucceeded:
+                return "card-payments:vault-wo-purchase:auth-challenge-presentation:succeeded"
+            case .authChallengePresentationFailed:
+                return "card-payments:vault-wo-purchase:auth-challenge-presentation:failed"
+            case .succeeded:
+                return "card-payments:vault-wo-purchase:succeeded"
+            case .failed:
+                return "card-payments:vault-wo-purchase:failed"
+            case .authChallengeSucceeded:
+                return "card-payments:vault-wo-purchase:auth-challenge:succeeded"
+            case .authChallengeFailed:
+                return "card-payments:vault-wo-purchase:auth-challenge:failed"
+            case .authChallengeCanceled:
+                return "card-payments:vault-wo-purchase:auth-challenge:canceled"
+            }
         }
     }
 }

--- a/Sources/CardPayments/CardClient.swift
+++ b/Sources/CardPayments/CardClient.swift
@@ -53,7 +53,7 @@ public class CardClient: NSObject {
     ///                 - `.failure(CoreSDKError)`: Describes the reason for failure.
     public func vault(_ vaultRequest: CardVaultRequest, completion: @escaping (Result<CardVaultResult, CoreSDKError>) -> Void) {
         analyticsService = AnalyticsService(coreConfig: config, setupToken: vaultRequest.setupTokenID)
-        analyticsService?.sendEvent(CardAnalyticsEvent.vaultStarted)
+        analyticsService?.sendEvent(CardAnalyticsEvent.Vault.started)
         Task {
             do {
                 let result = try await vaultAPI.updateSetupToken(cardVaultRequest: vaultRequest).updateVaultSetupToken
@@ -64,7 +64,7 @@ public class CardClient: NSObject {
                         self.notify3dsVaultFailure(with: CardError.threeDSecureURLError, completion: completion)
                         return
                     }
-                    analyticsService?.sendEvent(CardAnalyticsEvent.vaultAuthChallengeRequired)
+                    analyticsService?.sendEvent(CardAnalyticsEvent.Vault.authChallengeRequired)
                     startVaultThreeDSecureChallenge(url: url, setupTokenID: vaultRequest.setupTokenID, completion: completion)
                 } else {
                     let vaultResult = CardVaultResult(setupTokenID: result.id, status: result.status, didAttemptThreeDSecureAuthentication: false)
@@ -112,7 +112,7 @@ public class CardClient: NSObject {
     ///                 - `.failure(CoreSDKError)`: Describes the reason for failure.
     public func approveOrder(request: CardRequest, completion: @escaping (Result<CardResult, CoreSDKError>) -> Void) {
         analyticsService = AnalyticsService(coreConfig: config, orderID: request.orderID)
-        analyticsService?.sendEvent(CardAnalyticsEvent.approveOrderStarted)
+        analyticsService?.sendEvent(CardAnalyticsEvent.ApproveOrder.started)
         Task {
             do {
                 _ = try await clientConfigAPI.updateClientConfig(
@@ -134,7 +134,7 @@ public class CardClient: NSObject {
                         return
                     }
                 
-                    analyticsService?.sendEvent(CardAnalyticsEvent.approveOrderAuthChallengeRequired)
+                    analyticsService?.sendEvent(CardAnalyticsEvent.ApproveOrder.authChallengeRequired)
                     startThreeDSecureChallenge(url: url, orderId: result.id, completion: completion)
                 } else {
                     let cardResult = CardResult(orderID: result.id, status: result.status, didAttemptThreeDSecureAuthentication: false)
@@ -179,9 +179,9 @@ public class CardClient: NSObject {
             context: self,
             sessionDidDisplay: { [weak self] didDisplay in
                 if didDisplay {
-                    self?.analyticsService?.sendEvent(CardAnalyticsEvent.approveOrderAuthChallengePresentationSucceeded)
+                    self?.analyticsService?.sendEvent(CardAnalyticsEvent.ApproveOrder.authChallengePresentationSucceeded)
                 } else {
-                    self?.analyticsService?.sendEvent(CardAnalyticsEvent.approveOrderAuthChallengePresentationFailed)
+                    self?.analyticsService?.sendEvent(CardAnalyticsEvent.ApproveOrder.authChallengePresentationFailed)
                 }
             },
             sessionDidComplete: { _, error in
@@ -219,9 +219,9 @@ public class CardClient: NSObject {
             sessionDidDisplay: { [weak self] didDisplay in
                 if didDisplay {
                     // TODO: analytics for card vault
-                    self?.analyticsService?.sendEvent(CardAnalyticsEvent.vaultAuthChallengePresentationSucceeded)
+                    self?.analyticsService?.sendEvent(CardAnalyticsEvent.Vault.authChallengePresentationSucceeded)
                 } else {
-                    self?.analyticsService?.sendEvent(CardAnalyticsEvent.vaultAuthChallengePresentationFailed)
+                    self?.analyticsService?.sendEvent(CardAnalyticsEvent.Vault.authChallengePresentationFailed)
                 }
             },
             sessionDidComplete: { _, error in
@@ -243,52 +243,52 @@ public class CardClient: NSObject {
     }
 
     private func notifyCheckoutSuccess(for result: CardResult, completion: (Result<CardResult, CoreSDKError>) -> Void) {
-        analyticsService?.sendEvent(CardAnalyticsEvent.approveOrderSucceeded)
+        analyticsService?.sendEvent(CardAnalyticsEvent.ApproveOrder.succeeded)
         completion(.success(result))
     }
 
     private func notify3dsCheckoutSuccess(for result: CardResult, completion: (Result<CardResult, CoreSDKError>) -> Void) {
-        analyticsService?.sendEvent(CardAnalyticsEvent.approveOrderAuthChallengeSucceeded)
+        analyticsService?.sendEvent(CardAnalyticsEvent.ApproveOrder.authChallengeSucceeded)
         completion(.success(result))
     }
 
     private func notifyCheckoutFailure(with error: CoreSDKError, completion: (Result<CardResult, CoreSDKError>) -> Void) {
-        analyticsService?.sendEvent(CardAnalyticsEvent.approveOrderFailed)
+        analyticsService?.sendEvent(CardAnalyticsEvent.ApproveOrder.failed)
         completion(.failure(error))
     }
 
     private func notify3dsCheckoutFailure(with error: CoreSDKError, completion: (Result<CardResult, CoreSDKError>) -> Void) {
-        analyticsService?.sendEvent(CardAnalyticsEvent.approveOrderAuthChallengeFailed)
+        analyticsService?.sendEvent(CardAnalyticsEvent.ApproveOrder.authChallengeFailed)
         completion(.failure(error))
     }
 
     private func notify3dsCheckoutCancelWithError(with error: CoreSDKError, completion: (Result<CardResult, CoreSDKError>) -> Void) {
-        analyticsService?.sendEvent(CardAnalyticsEvent.approveOrderAuthChallengeCanceled)
+        analyticsService?.sendEvent(CardAnalyticsEvent.ApproveOrder.authChallengeCanceled)
         completion(.failure(error))
     }
 
     private func notifyVaultSuccess(for vaultResult: CardVaultResult, completion: (Result<CardVaultResult, CoreSDKError>) -> Void) {
-        analyticsService?.sendEvent(CardAnalyticsEvent.vaultSucceeded)
+        analyticsService?.sendEvent(CardAnalyticsEvent.Vault.succeeded)
         completion(.success(vaultResult))
     }
 
     private func notify3dsVaultSuccess(for vaultResult: CardVaultResult, completion: (Result<CardVaultResult, CoreSDKError>) -> Void) {
-        analyticsService?.sendEvent(CardAnalyticsEvent.vaultAuthChallengeSucceeded)
+        analyticsService?.sendEvent(CardAnalyticsEvent.Vault.authChallengeSucceeded)
         completion(.success(vaultResult))
     }
 
     private func notifyVaultFailure(with vaultError: CoreSDKError, completion: (Result<CardVaultResult, CoreSDKError>) -> Void) {
-        analyticsService?.sendEvent(CardAnalyticsEvent.vaultFailed)
+        analyticsService?.sendEvent(CardAnalyticsEvent.Vault.failed)
         completion(.failure(vaultError))
     }
 
     private func notify3dsVaultFailure(with vaultError: CoreSDKError, completion: (Result<CardVaultResult, CoreSDKError>) -> Void) {
-        analyticsService?.sendEvent(CardAnalyticsEvent.vaultAuthChallengeFailed)
+        analyticsService?.sendEvent(CardAnalyticsEvent.Vault.authChallengeFailed)
         completion(.failure(vaultError))
     }
 
     private func notify3dsVaultCancelWithError(with vaultError: CoreSDKError, completion: (Result<CardVaultResult, CoreSDKError>) -> Void) {
-        analyticsService?.sendEvent(CardAnalyticsEvent.vaultAuthChallengeCanceled)
+        analyticsService?.sendEvent(CardAnalyticsEvent.Vault.authChallengeCanceled)
         completion(.failure(vaultError))
     }
 }

--- a/Sources/CardPayments/CardClient.swift
+++ b/Sources/CardPayments/CardClient.swift
@@ -12,7 +12,7 @@ public class CardClient: NSObject {
 
     private let config: CoreConfig
     private let webAuthenticationSession: WebAuthenticationSession
-    private var analyticsService: AnalyticsService?
+    private let analytics: AnalyticsService
 
     /// Initialize a CardClient to process card payment
     /// - Parameter config: The CoreConfig object
@@ -22,6 +22,7 @@ public class CardClient: NSObject {
         self.vaultAPI = VaultPaymentTokensAPI(coreConfig: config)
         self.webAuthenticationSession = WebAuthenticationSession()
         self.clientConfigAPI = UpdateClientConfigAPI(coreConfig: config)
+        self.analytics = AnalyticsService(coreConfig: config)
     }
 
     /// For internal use for testing/mocking purpose
@@ -37,6 +38,7 @@ public class CardClient: NSObject {
         self.vaultAPI = vaultAPI
         self.webAuthenticationSession = webAuthenticationSession
         self.clientConfigAPI = clientConfigAPI
+        self.analytics = AnalyticsService(coreConfig: config)
     }
 
     /// Updates a setup token with a payment method. Performs
@@ -52,8 +54,9 @@ public class CardClient: NSObject {
     ///                   - `didAttemptThreeDSecureAuthentication`: A flag indicating if 3D Secure authentication was attempted.
     ///                 - `.failure(CoreSDKError)`: Describes the reason for failure.
     public func vault(_ vaultRequest: CardVaultRequest, completion: @escaping (Result<CardVaultResult, CoreSDKError>) -> Void) {
-        analyticsService = AnalyticsService(coreConfig: config, setupToken: vaultRequest.setupTokenID)
-        analyticsService?.sendEvent(CardAnalyticsEvent.Vault.started)
+        analytics.orderID = nil
+        analytics.setupToken = vaultRequest.setupTokenID
+        analytics.track(CardAnalyticsEvent.Vault.started)
         Task {
             do {
                 let result = try await vaultAPI.updateSetupToken(cardVaultRequest: vaultRequest).updateVaultSetupToken
@@ -64,7 +67,7 @@ public class CardClient: NSObject {
                         self.notify3dsVaultFailure(with: CardError.threeDSecureURLError, completion: completion)
                         return
                     }
-                    analyticsService?.sendEvent(CardAnalyticsEvent.Vault.authChallengeRequired)
+                    analytics.track(CardAnalyticsEvent.Vault.authChallengeRequired)
                     startVaultThreeDSecureChallenge(url: url, setupTokenID: vaultRequest.setupTokenID, completion: completion)
                 } else {
                     let vaultResult = CardVaultResult(setupTokenID: result.id, status: result.status, didAttemptThreeDSecureAuthentication: false)
@@ -111,8 +114,9 @@ public class CardClient: NSObject {
     ///                   - `didAttemptThreeDSecureAuthentication`: A flag indicating if 3D Secure authentication was attempted.
     ///                 - `.failure(CoreSDKError)`: Describes the reason for failure.
     public func approveOrder(request: CardRequest, completion: @escaping (Result<CardResult, CoreSDKError>) -> Void) {
-        analyticsService = AnalyticsService(coreConfig: config, orderID: request.orderID)
-        analyticsService?.sendEvent(CardAnalyticsEvent.ApproveOrder.started)
+        analytics.setupToken = nil
+        analytics.orderID = request.orderID
+        analytics.track(CardAnalyticsEvent.ApproveOrder.started)
         Task {
             do {
                 _ = try await clientConfigAPI.updateClientConfig(
@@ -134,7 +138,7 @@ public class CardClient: NSObject {
                         return
                     }
                 
-                    analyticsService?.sendEvent(CardAnalyticsEvent.ApproveOrder.authChallengeRequired)
+                    analytics.track(CardAnalyticsEvent.ApproveOrder.authChallengeRequired)
                     startThreeDSecureChallenge(url: url, orderId: result.id, completion: completion)
                 } else {
                     let cardResult = CardResult(orderID: result.id, status: result.status, didAttemptThreeDSecureAuthentication: false)
@@ -179,9 +183,9 @@ public class CardClient: NSObject {
             context: self,
             sessionDidDisplay: { [weak self] didDisplay in
                 if didDisplay {
-                    self?.analyticsService?.sendEvent(CardAnalyticsEvent.ApproveOrder.authChallengePresentationSucceeded)
+                    self?.analytics.track(CardAnalyticsEvent.ApproveOrder.authChallengePresentationSucceeded)
                 } else {
-                    self?.analyticsService?.sendEvent(CardAnalyticsEvent.ApproveOrder.authChallengePresentationFailed)
+                    self?.analytics.track(CardAnalyticsEvent.ApproveOrder.authChallengePresentationFailed)
                 }
             },
             sessionDidComplete: { _, error in
@@ -219,9 +223,9 @@ public class CardClient: NSObject {
             sessionDidDisplay: { [weak self] didDisplay in
                 if didDisplay {
                     // TODO: analytics for card vault
-                    self?.analyticsService?.sendEvent(CardAnalyticsEvent.Vault.authChallengePresentationSucceeded)
+                    self?.analytics.track(CardAnalyticsEvent.Vault.authChallengePresentationSucceeded)
                 } else {
-                    self?.analyticsService?.sendEvent(CardAnalyticsEvent.Vault.authChallengePresentationFailed)
+                    self?.analytics.track(CardAnalyticsEvent.Vault.authChallengePresentationFailed)
                 }
             },
             sessionDidComplete: { _, error in
@@ -243,52 +247,52 @@ public class CardClient: NSObject {
     }
 
     private func notifyCheckoutSuccess(for result: CardResult, completion: (Result<CardResult, CoreSDKError>) -> Void) {
-        analyticsService?.sendEvent(CardAnalyticsEvent.ApproveOrder.succeeded)
+        analytics.track(CardAnalyticsEvent.ApproveOrder.succeeded)
         completion(.success(result))
     }
 
     private func notify3dsCheckoutSuccess(for result: CardResult, completion: (Result<CardResult, CoreSDKError>) -> Void) {
-        analyticsService?.sendEvent(CardAnalyticsEvent.ApproveOrder.authChallengeSucceeded)
+        analytics.track(CardAnalyticsEvent.ApproveOrder.authChallengeSucceeded)
         completion(.success(result))
     }
 
     private func notifyCheckoutFailure(with error: CoreSDKError, completion: (Result<CardResult, CoreSDKError>) -> Void) {
-        analyticsService?.sendEvent(CardAnalyticsEvent.ApproveOrder.failed)
+        analytics.track(CardAnalyticsEvent.ApproveOrder.failed)
         completion(.failure(error))
     }
 
     private func notify3dsCheckoutFailure(with error: CoreSDKError, completion: (Result<CardResult, CoreSDKError>) -> Void) {
-        analyticsService?.sendEvent(CardAnalyticsEvent.ApproveOrder.authChallengeFailed)
+        analytics.track(CardAnalyticsEvent.ApproveOrder.authChallengeFailed)
         completion(.failure(error))
     }
 
     private func notify3dsCheckoutCancelWithError(with error: CoreSDKError, completion: (Result<CardResult, CoreSDKError>) -> Void) {
-        analyticsService?.sendEvent(CardAnalyticsEvent.ApproveOrder.authChallengeCanceled)
+        analytics.track(CardAnalyticsEvent.ApproveOrder.authChallengeCanceled)
         completion(.failure(error))
     }
 
     private func notifyVaultSuccess(for vaultResult: CardVaultResult, completion: (Result<CardVaultResult, CoreSDKError>) -> Void) {
-        analyticsService?.sendEvent(CardAnalyticsEvent.Vault.succeeded)
+        analytics.track(CardAnalyticsEvent.Vault.succeeded)
         completion(.success(vaultResult))
     }
 
     private func notify3dsVaultSuccess(for vaultResult: CardVaultResult, completion: (Result<CardVaultResult, CoreSDKError>) -> Void) {
-        analyticsService?.sendEvent(CardAnalyticsEvent.Vault.authChallengeSucceeded)
+        analytics.track(CardAnalyticsEvent.Vault.authChallengeSucceeded)
         completion(.success(vaultResult))
     }
 
     private func notifyVaultFailure(with vaultError: CoreSDKError, completion: (Result<CardVaultResult, CoreSDKError>) -> Void) {
-        analyticsService?.sendEvent(CardAnalyticsEvent.Vault.failed)
+        analytics.track(CardAnalyticsEvent.Vault.failed)
         completion(.failure(vaultError))
     }
 
     private func notify3dsVaultFailure(with vaultError: CoreSDKError, completion: (Result<CardVaultResult, CoreSDKError>) -> Void) {
-        analyticsService?.sendEvent(CardAnalyticsEvent.Vault.authChallengeFailed)
+        analytics.track(CardAnalyticsEvent.Vault.authChallengeFailed)
         completion(.failure(vaultError))
     }
 
     private func notify3dsVaultCancelWithError(with vaultError: CoreSDKError, completion: (Result<CardVaultResult, CoreSDKError>) -> Void) {
-        analyticsService?.sendEvent(CardAnalyticsEvent.Vault.authChallengeCanceled)
+        analytics.track(CardAnalyticsEvent.Vault.authChallengeCanceled)
         completion(.failure(vaultError))
     }
 }

--- a/Sources/CardPayments/CardClient.swift
+++ b/Sources/CardPayments/CardClient.swift
@@ -53,7 +53,7 @@ public class CardClient: NSObject {
     ///                 - `.failure(CoreSDKError)`: Describes the reason for failure.
     public func vault(_ vaultRequest: CardVaultRequest, completion: @escaping (Result<CardVaultResult, CoreSDKError>) -> Void) {
         analyticsService = AnalyticsService(coreConfig: config, setupToken: vaultRequest.setupTokenID)
-        analyticsService?.sendEvent("card-payments:vault-wo-purchase:started")
+        analyticsService?.sendEvent(CardAnalyticsEvent.vaultStarted)
         Task {
             do {
                 let result = try await vaultAPI.updateSetupToken(cardVaultRequest: vaultRequest).updateVaultSetupToken
@@ -64,7 +64,7 @@ public class CardClient: NSObject {
                         self.notify3dsVaultFailure(with: CardError.threeDSecureURLError, completion: completion)
                         return
                     }
-                    analyticsService?.sendEvent("card-payments:vault-wo-purchase:auth-challenge-required")
+                    analyticsService?.sendEvent(CardAnalyticsEvent.vaultAuthChallengeRequired)
                     startVaultThreeDSecureChallenge(url: url, setupTokenID: vaultRequest.setupTokenID, completion: completion)
                 } else {
                     let vaultResult = CardVaultResult(setupTokenID: result.id, status: result.status, didAttemptThreeDSecureAuthentication: false)
@@ -112,7 +112,7 @@ public class CardClient: NSObject {
     ///                 - `.failure(CoreSDKError)`: Describes the reason for failure.
     public func approveOrder(request: CardRequest, completion: @escaping (Result<CardResult, CoreSDKError>) -> Void) {
         analyticsService = AnalyticsService(coreConfig: config, orderID: request.orderID)
-        analyticsService?.sendEvent("card-payments:approve-order:started")
+        analyticsService?.sendEvent(CardAnalyticsEvent.approveOrderStarted)
         Task {
             do {
                 _ = try await clientConfigAPI.updateClientConfig(
@@ -134,7 +134,7 @@ public class CardClient: NSObject {
                         return
                     }
                 
-                    analyticsService?.sendEvent("card-payments:approve-order:auth-challenge-required")
+                    analyticsService?.sendEvent(CardAnalyticsEvent.approveOrderAuthChallengeRequired)
                     startThreeDSecureChallenge(url: url, orderId: result.id, completion: completion)
                 } else {
                     let cardResult = CardResult(orderID: result.id, status: result.status, didAttemptThreeDSecureAuthentication: false)
@@ -179,9 +179,9 @@ public class CardClient: NSObject {
             context: self,
             sessionDidDisplay: { [weak self] didDisplay in
                 if didDisplay {
-                    self?.analyticsService?.sendEvent("card-payments:approve-order:auth-challenge-presentation:succeeded")
+                    self?.analyticsService?.sendEvent(CardAnalyticsEvent.approveOrderAuthChallengePresentationSucceeded)
                 } else {
-                    self?.analyticsService?.sendEvent("card-payments:approve-order:auth-challenge-presentation:failed")
+                    self?.analyticsService?.sendEvent(CardAnalyticsEvent.approveOrderAuthChallengePresentationFailed)
                 }
             },
             sessionDidComplete: { _, error in
@@ -219,9 +219,9 @@ public class CardClient: NSObject {
             sessionDidDisplay: { [weak self] didDisplay in
                 if didDisplay {
                     // TODO: analytics for card vault
-                    self?.analyticsService?.sendEvent("card-payments:vault-wo-purchase:auth-challenge-presentation:succeeded")
+                    self?.analyticsService?.sendEvent(CardAnalyticsEvent.vaultAuthChallengePresentationSucceeded)
                 } else {
-                    self?.analyticsService?.sendEvent("card-payments:vault-wo-purchase:auth-challenge-presentation:failed")
+                    self?.analyticsService?.sendEvent(CardAnalyticsEvent.vaultAuthChallengePresentationFailed)
                 }
             },
             sessionDidComplete: { _, error in
@@ -243,52 +243,52 @@ public class CardClient: NSObject {
     }
 
     private func notifyCheckoutSuccess(for result: CardResult, completion: (Result<CardResult, CoreSDKError>) -> Void) {
-        analyticsService?.sendEvent("card-payments:approve-order:succeeded")
+        analyticsService?.sendEvent(CardAnalyticsEvent.approveOrderSucceeded)
         completion(.success(result))
     }
 
     private func notify3dsCheckoutSuccess(for result: CardResult, completion: (Result<CardResult, CoreSDKError>) -> Void) {
-        analyticsService?.sendEvent("card-payments:approve-order:auth-challenge:succeeded")
+        analyticsService?.sendEvent(CardAnalyticsEvent.approveOrderAuthChallengeSucceeded)
         completion(.success(result))
     }
 
     private func notifyCheckoutFailure(with error: CoreSDKError, completion: (Result<CardResult, CoreSDKError>) -> Void) {
-        analyticsService?.sendEvent("card-payments:approve-order:failed")
+        analyticsService?.sendEvent(CardAnalyticsEvent.approveOrderFailed)
         completion(.failure(error))
     }
 
     private func notify3dsCheckoutFailure(with error: CoreSDKError, completion: (Result<CardResult, CoreSDKError>) -> Void) {
-        analyticsService?.sendEvent("card-payments:approve-order:auth-challenge:failed")
+        analyticsService?.sendEvent(CardAnalyticsEvent.approveOrderAuthChallengeFailed)
         completion(.failure(error))
     }
 
     private func notify3dsCheckoutCancelWithError(with error: CoreSDKError, completion: (Result<CardResult, CoreSDKError>) -> Void) {
-        analyticsService?.sendEvent("card-payments:approve-order:auth-challenge:canceled")
+        analyticsService?.sendEvent(CardAnalyticsEvent.approveOrderAuthChallengeCanceled)
         completion(.failure(error))
     }
 
     private func notifyVaultSuccess(for vaultResult: CardVaultResult, completion: (Result<CardVaultResult, CoreSDKError>) -> Void) {
-        analyticsService?.sendEvent("card-payments:vault-wo-purchase:succeeded")
+        analyticsService?.sendEvent(CardAnalyticsEvent.vaultSucceeded)
         completion(.success(vaultResult))
     }
 
     private func notify3dsVaultSuccess(for vaultResult: CardVaultResult, completion: (Result<CardVaultResult, CoreSDKError>) -> Void) {
-        analyticsService?.sendEvent("card-payments:vault-wo-purchase:auth-challenge:succeeded")
+        analyticsService?.sendEvent(CardAnalyticsEvent.vaultAuthChallengeSucceeded)
         completion(.success(vaultResult))
     }
 
     private func notifyVaultFailure(with vaultError: CoreSDKError, completion: (Result<CardVaultResult, CoreSDKError>) -> Void) {
-        analyticsService?.sendEvent("card-payments:vault-wo-purchase:failed")
+        analyticsService?.sendEvent(CardAnalyticsEvent.vaultFailed)
         completion(.failure(vaultError))
     }
 
     private func notify3dsVaultFailure(with vaultError: CoreSDKError, completion: (Result<CardVaultResult, CoreSDKError>) -> Void) {
-        analyticsService?.sendEvent("card-payments:vault-wo-purchase:auth-challenge:failed")
+        analyticsService?.sendEvent(CardAnalyticsEvent.vaultAuthChallengeFailed)
         completion(.failure(vaultError))
     }
 
     private func notify3dsVaultCancelWithError(with vaultError: CoreSDKError, completion: (Result<CardVaultResult, CoreSDKError>) -> Void) {
-        analyticsService?.sendEvent("card-payments:vault-wo-purchase:auth-challenge:canceled")
+        analyticsService?.sendEvent(CardAnalyticsEvent.vaultAuthChallengeCanceled)
         completion(.failure(vaultError))
     }
 }

--- a/Sources/CorePayments/AnalyticsEventName.swift
+++ b/Sources/CorePayments/AnalyticsEventName.swift
@@ -1,0 +1,17 @@
+import Foundation
+
+/// A type-safe identifier for a PayPal SDK analytics event.
+///
+/// Each SDK module defines its own enum that conforms to this protocol
+/// (for example, `CardAnalyticsEvent`, `PayPalWebAnalyticsEvent`,
+/// `PaymentButtonAnalyticsEvent`). The `eventName` is the string that is
+/// actually reported to FPTI.
+///
+/// This is exposed for internal PayPal use only. It is not covered by
+/// Semantic Versioning and may change or be removed at any time.
+@_documentation(visibility: private)
+public protocol AnalyticsEventName {
+
+    /// The FPTI event name reported for this event.
+    var eventName: String { get }
+}

--- a/Sources/CorePayments/Networking/AnalyticsService.swift
+++ b/Sources/CorePayments/Networking/AnalyticsService.swift
@@ -2,16 +2,26 @@ import Foundation
 
 /// Constructs `AnalyticsEventData` models and sends FPTI analytics events.
 @_documentation(visibility: private)
-public struct AnalyticsService {
-    
+public class AnalyticsService {
+
     // MARK: - Internal Properties
-    
+
     private let coreConfig: CoreConfig
     private let trackingEventsAPI: TrackingEventsAPI
-    private let orderID: String?
-    private let setupToken: String?
+    public var orderID: String?
+    public var setupToken: String?
+
     // MARK: - Initializer
-    
+
+    /// Primary initializer — clients hold a single `let` reference and
+    /// set `orderID` / `setupToken` per-flow.
+    public init(coreConfig: CoreConfig) {
+        self.coreConfig = coreConfig
+        self.trackingEventsAPI = TrackingEventsAPI(coreConfig: coreConfig)
+        self.orderID = nil
+        self.setupToken = nil
+    }
+
     public init(coreConfig: CoreConfig, orderID: String) {
         self.coreConfig = coreConfig
         self.trackingEventsAPI = TrackingEventsAPI(coreConfig: coreConfig)
@@ -35,7 +45,7 @@ public struct AnalyticsService {
         self.orderID = orderID
         self.setupToken = nil
     }
-    
+
     // MARK: - Public Methods
 
     /// This method is exposed for internal PayPal use only. Do not use. It is not covered by Semantic Versioning and may change or be removed at any time.
@@ -43,8 +53,8 @@ public struct AnalyticsService {
     /// - Parameter event: A type-safe analytics event defined by a PayPal SDK module.
     /// - Parameter correlationID: correlation ID associated with the request
     /// - Parameter buttonType: The type of button
-    public func sendEvent(_ event: AnalyticsEventName, correlationID: String? = nil, buttonType: String? = nil) {
-        sendEvent(event.eventName, correlationID: correlationID, buttonType: buttonType)
+    public func track(_ event: AnalyticsEventName, correlationID: String? = nil, buttonType: String? = nil) {
+        track(event.eventName, correlationID: correlationID, buttonType: buttonType)
     }
 
     // MARK: - Internal Methods
@@ -54,9 +64,9 @@ public struct AnalyticsService {
     /// Prefer the `AnalyticsEventName` overload. This string-based entry point is
     /// retained for cross-module internal use and unit tests that need to inspect
     /// the emitted event name directly.
-    func sendEvent(_ name: String, correlationID: String? = nil, buttonType: String? = nil) {
+    func track(_ name: String, correlationID: String? = nil, buttonType: String? = nil) {
         Task(priority: .background) {
-            await performEventRequest(name, correlationID: correlationID, buttonType: buttonType)
+            await performTrackRequest(name, correlationID: correlationID, buttonType: buttonType)
         }
     }
 
@@ -65,10 +75,10 @@ public struct AnalyticsService {
     ///   - name: Event name string used to identify this unique event in FPTI
     ///   - correlationID: correlation ID associated with the request
     ///   - buttonType: The type of button
-    func performEventRequest(_ name: String, correlationID: String? = nil, buttonType: String? = nil) async {
+    func performTrackRequest(_ name: String, correlationID: String? = nil, buttonType: String? = nil) async {
         do {
             let clientID = coreConfig.clientID
-            
+
             let eventData = AnalyticsEventData(
                 environment: coreConfig.environment.toString,
                 eventName: name,
@@ -78,7 +88,7 @@ public struct AnalyticsService {
                 setupToken: setupToken,
                 buttonType: buttonType
             )
-            
+
             let (_) = try await trackingEventsAPI.sendEvent(with: eventData)
         } catch {
             NSLog("[PayPal SDK] Failed to send analytics: %@", error.localizedDescription)

--- a/Sources/CorePayments/Networking/AnalyticsService.swift
+++ b/Sources/CorePayments/Networking/AnalyticsService.swift
@@ -66,7 +66,7 @@ public class AnalyticsService {
     /// the emitted event name directly.
     func track(_ name: String, correlationID: String? = nil, buttonType: String? = nil) {
         Task(priority: .background) {
-            await performTrackRequest(name, correlationID: correlationID, buttonType: buttonType)
+            await sendEvent(name, correlationID: correlationID, buttonType: buttonType)
         }
     }
 
@@ -75,7 +75,7 @@ public class AnalyticsService {
     ///   - name: Event name string used to identify this unique event in FPTI
     ///   - correlationID: correlation ID associated with the request
     ///   - buttonType: The type of button
-    func performTrackRequest(_ name: String, correlationID: String? = nil, buttonType: String? = nil) async {
+    func sendEvent(_ name: String, correlationID: String? = nil, buttonType: String? = nil) async {
         do {
             let clientID = coreConfig.clientID
 

--- a/Sources/CorePayments/Networking/AnalyticsService.swift
+++ b/Sources/CorePayments/Networking/AnalyticsService.swift
@@ -37,20 +37,29 @@ public struct AnalyticsService {
     }
     
     // MARK: - Public Methods
-        
+
     /// This method is exposed for internal PayPal use only. Do not use. It is not covered by Semantic Versioning and may change or be removed at any time.
-    /// Sends analytics event to https://api.paypal.com/v1/tracking/events/ via a background task.
-    /// - Parameter name: Event name string used to identify this unique event in FPTI.
+    /// Sends an analytics event to https://api.paypal.com/v1/tracking/events/ via a background task.
+    /// - Parameter event: A type-safe analytics event defined by a PayPal SDK module.
     /// - Parameter correlationID: correlation ID associated with the request
     /// - Parameter buttonType: The type of button
-    public func sendEvent(_ name: String, correlationID: String? = nil, buttonType: String? = nil) {
+    public func sendEvent(_ event: AnalyticsEventName, correlationID: String? = nil, buttonType: String? = nil) {
+        sendEvent(event.eventName, correlationID: correlationID, buttonType: buttonType)
+    }
+
+    // MARK: - Internal Methods
+
+    /// Sends an analytics event by raw FPTI event name.
+    ///
+    /// Prefer the `AnalyticsEventName` overload. This string-based entry point is
+    /// retained for cross-module internal use and unit tests that need to inspect
+    /// the emitted event name directly.
+    func sendEvent(_ name: String, correlationID: String? = nil, buttonType: String? = nil) {
         Task(priority: .background) {
             await performEventRequest(name, correlationID: correlationID, buttonType: buttonType)
         }
     }
 
-    // MARK: - Internal Methods
-    
     /// Exposed to be able to execute this function synchronously in unit tests
     /// - Parameters:
     ///   - name: Event name string used to identify this unique event in FPTI

--- a/Sources/PayPalWebPayments/PayPalWebAnalyticsEvent.swift
+++ b/Sources/PayPalWebPayments/PayPalWebAnalyticsEvent.swift
@@ -1,0 +1,57 @@
+import Foundation
+import CorePayments
+
+/// FPTI analytics events emitted by the `PayPalWebPayments` module.
+///
+/// This is exposed for internal PayPal use only. It is not covered by
+/// Semantic Versioning and may change or be removed at any time.
+@_documentation(visibility: private)
+public enum PayPalWebAnalyticsEvent: AnalyticsEventName {
+
+    // MARK: - Checkout
+
+    case checkoutStarted
+    case checkoutAuthChallengePresentationSucceeded
+    case checkoutAuthChallengePresentationFailed
+    case checkoutSucceeded
+    case checkoutFailed
+    case checkoutCanceled
+
+    // MARK: - Vault Without Purchase
+
+    case vaultStarted
+    case vaultAuthChallengePresentationSucceeded
+    case vaultAuthChallengePresentationFailed
+    case vaultSucceeded
+    case vaultFailed
+    case vaultCanceled
+
+    public var eventName: String {
+        switch self {
+        case .checkoutStarted:
+            return "paypal-web-payments:checkout:started"
+        case .checkoutAuthChallengePresentationSucceeded:
+            return "paypal-web-payments:checkout:auth-challenge-presentation:succeeded"
+        case .checkoutAuthChallengePresentationFailed:
+            return "paypal-web-payments:checkout:auth-challenge-presentation:failed"
+        case .checkoutSucceeded:
+            return "paypal-web-payments:checkout:succeeded"
+        case .checkoutFailed:
+            return "paypal-web-payments:checkout:failed"
+        case .checkoutCanceled:
+            return "paypal-web-payments:checkout:canceled"
+        case .vaultStarted:
+            return "paypal-web-payments:vault-wo-purchase:started"
+        case .vaultAuthChallengePresentationSucceeded:
+            return "paypal-web-payments:vault-wo-purchase:auth-challenge-presentation:succeeded"
+        case .vaultAuthChallengePresentationFailed:
+            return "paypal-web-payments:vault-wo-purchase:auth-challenge-presentation:failed"
+        case .vaultSucceeded:
+            return "paypal-web-payments:vault-wo-purchase:succeeded"
+        case .vaultFailed:
+            return "paypal-web-payments:vault-wo-purchase:failed"
+        case .vaultCanceled:
+            return "paypal-web-payments:vault-wo-purchase:canceled"
+        }
+    }
+}

--- a/Sources/PayPalWebPayments/PayPalWebAnalyticsEvent.swift
+++ b/Sources/PayPalWebPayments/PayPalWebAnalyticsEvent.swift
@@ -1,5 +1,8 @@
 import Foundation
+
+#if canImport(CorePayments)
 import CorePayments
+#endif
 
 /// FPTI analytics events emitted by the `PayPalWebPayments` module.
 ///

--- a/Sources/PayPalWebPayments/PayPalWebAnalyticsEvent.swift
+++ b/Sources/PayPalWebPayments/PayPalWebAnalyticsEvent.swift
@@ -6,52 +6,63 @@ import CorePayments
 /// This is exposed for internal PayPal use only. It is not covered by
 /// Semantic Versioning and may change or be removed at any time.
 @_documentation(visibility: private)
-public enum PayPalWebAnalyticsEvent: AnalyticsEventName {
+public enum PayPalWebAnalyticsEvent {
 
     // MARK: - Checkout
 
-    case checkoutStarted
-    case checkoutAuthChallengePresentationSucceeded
-    case checkoutAuthChallengePresentationFailed
-    case checkoutSucceeded
-    case checkoutFailed
-    case checkoutCanceled
+    public enum Checkout: AnalyticsEventName {
+
+        case started
+        case authChallengePresentationSucceeded
+        case authChallengePresentationFailed
+        case succeeded
+        case failed
+        case canceled
+
+        public var eventName: String {
+            switch self {
+            case .started:
+                return "paypal-web-payments:checkout:started"
+            case .authChallengePresentationSucceeded:
+                return "paypal-web-payments:checkout:auth-challenge-presentation:succeeded"
+            case .authChallengePresentationFailed:
+                return "paypal-web-payments:checkout:auth-challenge-presentation:failed"
+            case .succeeded:
+                return "paypal-web-payments:checkout:succeeded"
+            case .failed:
+                return "paypal-web-payments:checkout:failed"
+            case .canceled:
+                return "paypal-web-payments:checkout:canceled"
+            }
+        }
+    }
 
     // MARK: - Vault Without Purchase
 
-    case vaultStarted
-    case vaultAuthChallengePresentationSucceeded
-    case vaultAuthChallengePresentationFailed
-    case vaultSucceeded
-    case vaultFailed
-    case vaultCanceled
+    public enum Vault: AnalyticsEventName {
 
-    public var eventName: String {
-        switch self {
-        case .checkoutStarted:
-            return "paypal-web-payments:checkout:started"
-        case .checkoutAuthChallengePresentationSucceeded:
-            return "paypal-web-payments:checkout:auth-challenge-presentation:succeeded"
-        case .checkoutAuthChallengePresentationFailed:
-            return "paypal-web-payments:checkout:auth-challenge-presentation:failed"
-        case .checkoutSucceeded:
-            return "paypal-web-payments:checkout:succeeded"
-        case .checkoutFailed:
-            return "paypal-web-payments:checkout:failed"
-        case .checkoutCanceled:
-            return "paypal-web-payments:checkout:canceled"
-        case .vaultStarted:
-            return "paypal-web-payments:vault-wo-purchase:started"
-        case .vaultAuthChallengePresentationSucceeded:
-            return "paypal-web-payments:vault-wo-purchase:auth-challenge-presentation:succeeded"
-        case .vaultAuthChallengePresentationFailed:
-            return "paypal-web-payments:vault-wo-purchase:auth-challenge-presentation:failed"
-        case .vaultSucceeded:
-            return "paypal-web-payments:vault-wo-purchase:succeeded"
-        case .vaultFailed:
-            return "paypal-web-payments:vault-wo-purchase:failed"
-        case .vaultCanceled:
-            return "paypal-web-payments:vault-wo-purchase:canceled"
+        case started
+        case authChallengePresentationSucceeded
+        case authChallengePresentationFailed
+        case succeeded
+        case failed
+        case canceled
+
+        public var eventName: String {
+            switch self {
+            case .started:
+                return "paypal-web-payments:vault-wo-purchase:started"
+            case .authChallengePresentationSucceeded:
+                return "paypal-web-payments:vault-wo-purchase:auth-challenge-presentation:succeeded"
+            case .authChallengePresentationFailed:
+                return "paypal-web-payments:vault-wo-purchase:auth-challenge-presentation:failed"
+            case .succeeded:
+                return "paypal-web-payments:vault-wo-purchase:succeeded"
+            case .failed:
+                return "paypal-web-payments:vault-wo-purchase:failed"
+            case .canceled:
+                return "paypal-web-payments:vault-wo-purchase:canceled"
+            }
         }
     }
 }

--- a/Sources/PayPalWebPayments/PayPalWebCheckoutClient.swift
+++ b/Sources/PayPalWebPayments/PayPalWebCheckoutClient.swift
@@ -50,7 +50,7 @@ public class PayPalWebCheckoutClient: NSObject {
         completion: @escaping (Result<PayPalWebCheckoutResult, CoreSDKError>) -> Void
     ) {
         analyticsService = AnalyticsService(coreConfig: config, orderID: request.orderID)
-        analyticsService?.sendEvent(PayPalWebAnalyticsEvent.checkoutStarted)
+        analyticsService?.sendEvent(PayPalWebAnalyticsEvent.Checkout.started)
 
         Task {
             do {
@@ -79,9 +79,9 @@ public class PayPalWebCheckoutClient: NSObject {
                 context: self,
                 sessionDidDisplay: { [weak self] didDisplay in
                     if didDisplay {
-                        self?.analyticsService?.sendEvent(PayPalWebAnalyticsEvent.checkoutAuthChallengePresentationSucceeded)
+                        self?.analyticsService?.sendEvent(PayPalWebAnalyticsEvent.Checkout.authChallengePresentationSucceeded)
                     } else {
-                        self?.analyticsService?.sendEvent(PayPalWebAnalyticsEvent.checkoutAuthChallengePresentationFailed)
+                        self?.analyticsService?.sendEvent(PayPalWebAnalyticsEvent.Checkout.authChallengePresentationFailed)
                     }
                 },
                 sessionDidComplete: { url, error in
@@ -158,7 +158,7 @@ public class PayPalWebCheckoutClient: NSObject {
     ///                 - `.failure(CoreSDKError)`: Describes the reason for failure.
     public func vault(_ vaultRequest: PayPalVaultRequest, completion: @escaping (Result<PayPalVaultResult, CoreSDKError>) -> Void) {
         analyticsService = AnalyticsService(coreConfig: config, setupToken: vaultRequest.setupTokenID)
-        analyticsService?.sendEvent(PayPalWebAnalyticsEvent.vaultStarted)
+        analyticsService?.sendEvent(PayPalWebAnalyticsEvent.Vault.started)
 
         let vaultURL = config.environment.paypalVaultCheckoutURL
         var vaultURLComponents = URLComponents(url: vaultURL, resolvingAgainstBaseURL: false)
@@ -178,9 +178,9 @@ public class PayPalWebCheckoutClient: NSObject {
             context: self,
             sessionDidDisplay: { [weak self] didDisplay in
                 if didDisplay {
-                    self?.analyticsService?.sendEvent(PayPalWebAnalyticsEvent.vaultAuthChallengePresentationSucceeded)
+                    self?.analyticsService?.sendEvent(PayPalWebAnalyticsEvent.Vault.authChallengePresentationSucceeded)
                 } else {
-                    self?.analyticsService?.sendEvent(PayPalWebAnalyticsEvent.vaultAuthChallengePresentationFailed)
+                    self?.analyticsService?.sendEvent(PayPalWebAnalyticsEvent.Vault.authChallengePresentationFailed)
                 }
             },
             sessionDidComplete: { url, error in
@@ -242,7 +242,7 @@ public class PayPalWebCheckoutClient: NSObject {
         for result: PayPalWebCheckoutResult,
         completion: (Result<PayPalWebCheckoutResult, CoreSDKError>) -> Void
     ) {
-        self.analyticsService?.sendEvent(PayPalWebAnalyticsEvent.checkoutSucceeded)
+        self.analyticsService?.sendEvent(PayPalWebAnalyticsEvent.Checkout.succeeded)
         completion(.success(result))
     }
 
@@ -250,7 +250,7 @@ public class PayPalWebCheckoutClient: NSObject {
         with error: CoreSDKError,
         completion: (Result<PayPalWebCheckoutResult, CoreSDKError>) -> Void
     ) {
-        self.analyticsService?.sendEvent(PayPalWebAnalyticsEvent.checkoutFailed)
+        self.analyticsService?.sendEvent(PayPalWebAnalyticsEvent.Checkout.failed)
         completion(.failure(error))
     }
 
@@ -258,22 +258,22 @@ public class PayPalWebCheckoutClient: NSObject {
         with error: CoreSDKError,
         completion: (Result<PayPalWebCheckoutResult, CoreSDKError>) -> Void
     ) {
-        analyticsService?.sendEvent(PayPalWebAnalyticsEvent.checkoutCanceled)
+        analyticsService?.sendEvent(PayPalWebAnalyticsEvent.Checkout.canceled)
         completion(.failure(error))
     }
 
     private func notifyVaultSuccess(for result: PayPalVaultResult, completion: (Result<PayPalVaultResult, CoreSDKError>) -> Void) {
-        analyticsService?.sendEvent(PayPalWebAnalyticsEvent.vaultSucceeded)
+        analyticsService?.sendEvent(PayPalWebAnalyticsEvent.Vault.succeeded)
         completion(.success(result))
     }
 
     private func notifyVaultFailure(with error: CoreSDKError, completion: (Result<PayPalVaultResult, CoreSDKError>) -> Void) {
-        analyticsService?.sendEvent(PayPalWebAnalyticsEvent.vaultFailed)
+        analyticsService?.sendEvent(PayPalWebAnalyticsEvent.Vault.failed)
         completion(.failure(error))
     }
 
     private func notifyVaultCancelWithError(with vaultError: CoreSDKError, completion: (Result<PayPalVaultResult, CoreSDKError>) -> Void) {
-        analyticsService?.sendEvent(PayPalWebAnalyticsEvent.vaultCanceled)
+        analyticsService?.sendEvent(PayPalWebAnalyticsEvent.Vault.canceled)
         completion(.failure(vaultError))
     }
 }

--- a/Sources/PayPalWebPayments/PayPalWebCheckoutClient.swift
+++ b/Sources/PayPalWebPayments/PayPalWebCheckoutClient.swift
@@ -50,7 +50,7 @@ public class PayPalWebCheckoutClient: NSObject {
         completion: @escaping (Result<PayPalWebCheckoutResult, CoreSDKError>) -> Void
     ) {
         analyticsService = AnalyticsService(coreConfig: config, orderID: request.orderID)
-        analyticsService?.sendEvent("paypal-web-payments:checkout:started")
+        analyticsService?.sendEvent(PayPalWebAnalyticsEvent.checkoutStarted)
 
         Task {
             do {
@@ -79,9 +79,9 @@ public class PayPalWebCheckoutClient: NSObject {
                 context: self,
                 sessionDidDisplay: { [weak self] didDisplay in
                     if didDisplay {
-                        self?.analyticsService?.sendEvent("paypal-web-payments:checkout:auth-challenge-presentation:succeeded")
+                        self?.analyticsService?.sendEvent(PayPalWebAnalyticsEvent.checkoutAuthChallengePresentationSucceeded)
                     } else {
-                        self?.analyticsService?.sendEvent("paypal-web-payments:checkout:auth-challenge-presentation:failed")
+                        self?.analyticsService?.sendEvent(PayPalWebAnalyticsEvent.checkoutAuthChallengePresentationFailed)
                     }
                 },
                 sessionDidComplete: { url, error in
@@ -158,7 +158,7 @@ public class PayPalWebCheckoutClient: NSObject {
     ///                 - `.failure(CoreSDKError)`: Describes the reason for failure.
     public func vault(_ vaultRequest: PayPalVaultRequest, completion: @escaping (Result<PayPalVaultResult, CoreSDKError>) -> Void) {
         analyticsService = AnalyticsService(coreConfig: config, setupToken: vaultRequest.setupTokenID)
-        analyticsService?.sendEvent("paypal-web-payments:vault-wo-purchase:started")
+        analyticsService?.sendEvent(PayPalWebAnalyticsEvent.vaultStarted)
 
         let vaultURL = config.environment.paypalVaultCheckoutURL
         var vaultURLComponents = URLComponents(url: vaultURL, resolvingAgainstBaseURL: false)
@@ -178,9 +178,9 @@ public class PayPalWebCheckoutClient: NSObject {
             context: self,
             sessionDidDisplay: { [weak self] didDisplay in
                 if didDisplay {
-                    self?.analyticsService?.sendEvent("paypal-web-payments:vault-wo-purchase:auth-challenge-presentation:succeeded")
+                    self?.analyticsService?.sendEvent(PayPalWebAnalyticsEvent.vaultAuthChallengePresentationSucceeded)
                 } else {
-                    self?.analyticsService?.sendEvent("paypal-web-payments:vault-wo-purchase:auth-challenge-presentation:failed")
+                    self?.analyticsService?.sendEvent(PayPalWebAnalyticsEvent.vaultAuthChallengePresentationFailed)
                 }
             },
             sessionDidComplete: { url, error in
@@ -242,7 +242,7 @@ public class PayPalWebCheckoutClient: NSObject {
         for result: PayPalWebCheckoutResult,
         completion: (Result<PayPalWebCheckoutResult, CoreSDKError>) -> Void
     ) {
-        self.analyticsService?.sendEvent("paypal-web-payments:checkout:succeeded")
+        self.analyticsService?.sendEvent(PayPalWebAnalyticsEvent.checkoutSucceeded)
         completion(.success(result))
     }
 
@@ -250,7 +250,7 @@ public class PayPalWebCheckoutClient: NSObject {
         with error: CoreSDKError,
         completion: (Result<PayPalWebCheckoutResult, CoreSDKError>) -> Void
     ) {
-        self.analyticsService?.sendEvent("paypal-web-payments:checkout:failed")
+        self.analyticsService?.sendEvent(PayPalWebAnalyticsEvent.checkoutFailed)
         completion(.failure(error))
     }
 
@@ -258,22 +258,22 @@ public class PayPalWebCheckoutClient: NSObject {
         with error: CoreSDKError,
         completion: (Result<PayPalWebCheckoutResult, CoreSDKError>) -> Void
     ) {
-        analyticsService?.sendEvent("paypal-web-payments:checkout:canceled")
+        analyticsService?.sendEvent(PayPalWebAnalyticsEvent.checkoutCanceled)
         completion(.failure(error))
     }
 
     private func notifyVaultSuccess(for result: PayPalVaultResult, completion: (Result<PayPalVaultResult, CoreSDKError>) -> Void) {
-        analyticsService?.sendEvent("paypal-web-payments:vault-wo-purchase:succeeded")
+        analyticsService?.sendEvent(PayPalWebAnalyticsEvent.vaultSucceeded)
         completion(.success(result))
     }
 
     private func notifyVaultFailure(with error: CoreSDKError, completion: (Result<PayPalVaultResult, CoreSDKError>) -> Void) {
-        analyticsService?.sendEvent("paypal-web-payments:vault-wo-purchase:failed")
+        analyticsService?.sendEvent(PayPalWebAnalyticsEvent.vaultFailed)
         completion(.failure(error))
     }
 
     private func notifyVaultCancelWithError(with vaultError: CoreSDKError, completion: (Result<PayPalVaultResult, CoreSDKError>) -> Void) {
-        analyticsService?.sendEvent("paypal-web-payments:vault-wo-purchase:canceled")
+        analyticsService?.sendEvent(PayPalWebAnalyticsEvent.vaultCanceled)
         completion(.failure(vaultError))
     }
 }

--- a/Sources/PayPalWebPayments/PayPalWebCheckoutClient.swift
+++ b/Sources/PayPalWebPayments/PayPalWebCheckoutClient.swift
@@ -11,7 +11,7 @@ public class PayPalWebCheckoutClient: NSObject {
     private let clientConfigAPI: UpdateClientConfigAPI
     private let webAuthenticationSession: WebAuthenticationSession
     private let networkingClient: NetworkingClient
-    private var analyticsService: AnalyticsService?
+    private let analytics: AnalyticsService
 
     /// Initialize a PayPalWebCheckoutClient to process PayPal transaction
     /// - Parameters:
@@ -21,6 +21,7 @@ public class PayPalWebCheckoutClient: NSObject {
         self.webAuthenticationSession = WebAuthenticationSession()
         self.networkingClient = HTTPNetworkingClient(coreConfig: config)
         self.clientConfigAPI = UpdateClientConfigAPI(coreConfig: config)
+        self.analytics = AnalyticsService(coreConfig: config)
     }
     
     /// For internal use for testing/mocking purpose
@@ -34,6 +35,7 @@ public class PayPalWebCheckoutClient: NSObject {
         self.webAuthenticationSession = webAuthenticationSession
         self.networkingClient = networkingClient
         self.clientConfigAPI = clientConfigAPI
+        self.analytics = AnalyticsService(coreConfig: config)
     }
 
     /// Launch the PayPal web flow
@@ -49,8 +51,9 @@ public class PayPalWebCheckoutClient: NSObject {
         request: PayPalWebCheckoutRequest,
         completion: @escaping (Result<PayPalWebCheckoutResult, CoreSDKError>) -> Void
     ) {
-        analyticsService = AnalyticsService(coreConfig: config, orderID: request.orderID)
-        analyticsService?.sendEvent(PayPalWebAnalyticsEvent.Checkout.started)
+        analytics.setupToken = nil
+        analytics.orderID = request.orderID
+        analytics.track(PayPalWebAnalyticsEvent.Checkout.started)
 
         Task {
             do {
@@ -79,9 +82,9 @@ public class PayPalWebCheckoutClient: NSObject {
                 context: self,
                 sessionDidDisplay: { [weak self] didDisplay in
                     if didDisplay {
-                        self?.analyticsService?.sendEvent(PayPalWebAnalyticsEvent.Checkout.authChallengePresentationSucceeded)
+                        self?.analytics.track(PayPalWebAnalyticsEvent.Checkout.authChallengePresentationSucceeded)
                     } else {
-                        self?.analyticsService?.sendEvent(PayPalWebAnalyticsEvent.Checkout.authChallengePresentationFailed)
+                        self?.analytics.track(PayPalWebAnalyticsEvent.Checkout.authChallengePresentationFailed)
                     }
                 },
                 sessionDidComplete: { url, error in
@@ -157,8 +160,9 @@ public class PayPalWebCheckoutClient: NSObject {
     ///                   - `approvalSessionID`: id of the PayPalWebCheckout session
     ///                 - `.failure(CoreSDKError)`: Describes the reason for failure.
     public func vault(_ vaultRequest: PayPalVaultRequest, completion: @escaping (Result<PayPalVaultResult, CoreSDKError>) -> Void) {
-        analyticsService = AnalyticsService(coreConfig: config, setupToken: vaultRequest.setupTokenID)
-        analyticsService?.sendEvent(PayPalWebAnalyticsEvent.Vault.started)
+        analytics.orderID = nil
+        analytics.setupToken = vaultRequest.setupTokenID
+        analytics.track(PayPalWebAnalyticsEvent.Vault.started)
 
         let vaultURL = config.environment.paypalVaultCheckoutURL
         var vaultURLComponents = URLComponents(url: vaultURL, resolvingAgainstBaseURL: false)
@@ -178,9 +182,9 @@ public class PayPalWebCheckoutClient: NSObject {
             context: self,
             sessionDidDisplay: { [weak self] didDisplay in
                 if didDisplay {
-                    self?.analyticsService?.sendEvent(PayPalWebAnalyticsEvent.Vault.authChallengePresentationSucceeded)
+                    self?.analytics.track(PayPalWebAnalyticsEvent.Vault.authChallengePresentationSucceeded)
                 } else {
-                    self?.analyticsService?.sendEvent(PayPalWebAnalyticsEvent.Vault.authChallengePresentationFailed)
+                    self?.analytics.track(PayPalWebAnalyticsEvent.Vault.authChallengePresentationFailed)
                 }
             },
             sessionDidComplete: { url, error in
@@ -242,7 +246,7 @@ public class PayPalWebCheckoutClient: NSObject {
         for result: PayPalWebCheckoutResult,
         completion: (Result<PayPalWebCheckoutResult, CoreSDKError>) -> Void
     ) {
-        self.analyticsService?.sendEvent(PayPalWebAnalyticsEvent.Checkout.succeeded)
+        self.analytics.track(PayPalWebAnalyticsEvent.Checkout.succeeded)
         completion(.success(result))
     }
 
@@ -250,7 +254,7 @@ public class PayPalWebCheckoutClient: NSObject {
         with error: CoreSDKError,
         completion: (Result<PayPalWebCheckoutResult, CoreSDKError>) -> Void
     ) {
-        self.analyticsService?.sendEvent(PayPalWebAnalyticsEvent.Checkout.failed)
+        self.analytics.track(PayPalWebAnalyticsEvent.Checkout.failed)
         completion(.failure(error))
     }
 
@@ -258,22 +262,22 @@ public class PayPalWebCheckoutClient: NSObject {
         with error: CoreSDKError,
         completion: (Result<PayPalWebCheckoutResult, CoreSDKError>) -> Void
     ) {
-        analyticsService?.sendEvent(PayPalWebAnalyticsEvent.Checkout.canceled)
+        analytics.track(PayPalWebAnalyticsEvent.Checkout.canceled)
         completion(.failure(error))
     }
 
     private func notifyVaultSuccess(for result: PayPalVaultResult, completion: (Result<PayPalVaultResult, CoreSDKError>) -> Void) {
-        analyticsService?.sendEvent(PayPalWebAnalyticsEvent.Vault.succeeded)
+        analytics.track(PayPalWebAnalyticsEvent.Vault.succeeded)
         completion(.success(result))
     }
 
     private func notifyVaultFailure(with error: CoreSDKError, completion: (Result<PayPalVaultResult, CoreSDKError>) -> Void) {
-        analyticsService?.sendEvent(PayPalWebAnalyticsEvent.Vault.failed)
+        analytics.track(PayPalWebAnalyticsEvent.Vault.failed)
         completion(.failure(error))
     }
 
     private func notifyVaultCancelWithError(with vaultError: CoreSDKError, completion: (Result<PayPalVaultResult, CoreSDKError>) -> Void) {
-        analyticsService?.sendEvent(PayPalWebAnalyticsEvent.Vault.canceled)
+        analytics.track(PayPalWebAnalyticsEvent.Vault.canceled)
         completion(.failure(vaultError))
     }
 }

--- a/Sources/PaymentButtons/PaymentButton.swift
+++ b/Sources/PaymentButtons/PaymentButton.swift
@@ -46,7 +46,7 @@ public class PaymentButton: UIButton {
         self.size = size
         self.insets = insets
         self.label = label
-        self.analyticsService.sendEvent("payment-button:initialized", buttonType: fundingSource.rawValue)
+        self.analyticsService.sendEvent(PaymentButtonAnalyticsEvent.initialized, buttonType: fundingSource.rawValue)
         super.init(frame: .zero)
         UIFont.registerFont()
         customizeAppearance()
@@ -174,7 +174,7 @@ public class PaymentButton: UIButton {
     // MARK: - Private
 
     @objc private func onTap() {
-        analyticsService.sendEvent("payment-button:tapped", buttonType: fundingSource.rawValue)
+        analyticsService.sendEvent(PaymentButtonAnalyticsEvent.tapped, buttonType: fundingSource.rawValue)
     }
 
     // MARK: - Configuration

--- a/Sources/PaymentButtons/PaymentButton.swift
+++ b/Sources/PaymentButtons/PaymentButton.swift
@@ -25,7 +25,7 @@ public class PaymentButton: UIButton {
     #endif
 
     // Use an empty config and default to live environment for button analytics
-    private let analyticsService = AnalyticsService(
+    private let analytics = AnalyticsService(
         coreConfig: .init(clientID: "N/A", environment: .live),
         orderID: "N/A"
     )
@@ -46,7 +46,7 @@ public class PaymentButton: UIButton {
         self.size = size
         self.insets = insets
         self.label = label
-        self.analyticsService.sendEvent(PaymentButtonAnalyticsEvent.initialized, buttonType: fundingSource.rawValue)
+        self.analytics.track(PaymentButtonAnalyticsEvent.initialized, buttonType: fundingSource.rawValue)
         super.init(frame: .zero)
         UIFont.registerFont()
         customizeAppearance()
@@ -174,7 +174,7 @@ public class PaymentButton: UIButton {
     // MARK: - Private
 
     @objc private func onTap() {
-        analyticsService.sendEvent(PaymentButtonAnalyticsEvent.tapped, buttonType: fundingSource.rawValue)
+        analytics.track(PaymentButtonAnalyticsEvent.tapped, buttonType: fundingSource.rawValue)
     }
 
     // MARK: - Configuration

--- a/Sources/PaymentButtons/PaymentButtonAnalyticsEvent.swift
+++ b/Sources/PaymentButtons/PaymentButtonAnalyticsEvent.swift
@@ -1,5 +1,8 @@
 import Foundation
+
+#if canImport(CorePayments)
 import CorePayments
+#endif
 
 /// FPTI analytics events emitted by the `PaymentButtons` module.
 ///

--- a/Sources/PaymentButtons/PaymentButtonAnalyticsEvent.swift
+++ b/Sources/PaymentButtons/PaymentButtonAnalyticsEvent.swift
@@ -1,0 +1,22 @@
+import Foundation
+import CorePayments
+
+/// FPTI analytics events emitted by the `PaymentButtons` module.
+///
+/// This is exposed for internal PayPal use only. It is not covered by
+/// Semantic Versioning and may change or be removed at any time.
+@_documentation(visibility: private)
+public enum PaymentButtonAnalyticsEvent: AnalyticsEventName {
+
+    case initialized
+    case tapped
+
+    public var eventName: String {
+        switch self {
+        case .initialized:
+            return "payment-button:initialized"
+        case .tapped:
+            return "payment-button:tapped"
+        }
+    }
+}

--- a/UnitTests/CardPaymentsTests/CardAnalyticsEvent_Tests.swift
+++ b/UnitTests/CardPaymentsTests/CardAnalyticsEvent_Tests.swift
@@ -1,0 +1,28 @@
+import XCTest
+@testable import CardPayments
+
+final class CardAnalyticsEvent_Tests: XCTestCase {
+
+    /// Locks the FPTI event name for every case. If you change a string here,
+    /// you are changing an analytics contract that downstream dashboards depend on.
+    func testEventName_matchesFPTIContract() {
+        XCTAssertEqual(CardAnalyticsEvent.approveOrderStarted.eventName, "card-payments:approve-order:started")
+        XCTAssertEqual(CardAnalyticsEvent.approveOrderAuthChallengeRequired.eventName, "card-payments:approve-order:auth-challenge-required")
+        XCTAssertEqual(CardAnalyticsEvent.approveOrderAuthChallengePresentationSucceeded.eventName, "card-payments:approve-order:auth-challenge-presentation:succeeded")
+        XCTAssertEqual(CardAnalyticsEvent.approveOrderAuthChallengePresentationFailed.eventName, "card-payments:approve-order:auth-challenge-presentation:failed")
+        XCTAssertEqual(CardAnalyticsEvent.approveOrderSucceeded.eventName, "card-payments:approve-order:succeeded")
+        XCTAssertEqual(CardAnalyticsEvent.approveOrderFailed.eventName, "card-payments:approve-order:failed")
+        XCTAssertEqual(CardAnalyticsEvent.approveOrderAuthChallengeSucceeded.eventName, "card-payments:approve-order:auth-challenge:succeeded")
+        XCTAssertEqual(CardAnalyticsEvent.approveOrderAuthChallengeFailed.eventName, "card-payments:approve-order:auth-challenge:failed")
+        XCTAssertEqual(CardAnalyticsEvent.approveOrderAuthChallengeCanceled.eventName, "card-payments:approve-order:auth-challenge:canceled")
+        XCTAssertEqual(CardAnalyticsEvent.vaultStarted.eventName, "card-payments:vault-wo-purchase:started")
+        XCTAssertEqual(CardAnalyticsEvent.vaultAuthChallengeRequired.eventName, "card-payments:vault-wo-purchase:auth-challenge-required")
+        XCTAssertEqual(CardAnalyticsEvent.vaultAuthChallengePresentationSucceeded.eventName, "card-payments:vault-wo-purchase:auth-challenge-presentation:succeeded")
+        XCTAssertEqual(CardAnalyticsEvent.vaultAuthChallengePresentationFailed.eventName, "card-payments:vault-wo-purchase:auth-challenge-presentation:failed")
+        XCTAssertEqual(CardAnalyticsEvent.vaultSucceeded.eventName, "card-payments:vault-wo-purchase:succeeded")
+        XCTAssertEqual(CardAnalyticsEvent.vaultFailed.eventName, "card-payments:vault-wo-purchase:failed")
+        XCTAssertEqual(CardAnalyticsEvent.vaultAuthChallengeSucceeded.eventName, "card-payments:vault-wo-purchase:auth-challenge:succeeded")
+        XCTAssertEqual(CardAnalyticsEvent.vaultAuthChallengeFailed.eventName, "card-payments:vault-wo-purchase:auth-challenge:failed")
+        XCTAssertEqual(CardAnalyticsEvent.vaultAuthChallengeCanceled.eventName, "card-payments:vault-wo-purchase:auth-challenge:canceled")
+    }
+}

--- a/UnitTests/CardPaymentsTests/CardAnalyticsEvent_Tests.swift
+++ b/UnitTests/CardPaymentsTests/CardAnalyticsEvent_Tests.swift
@@ -5,24 +5,41 @@ final class CardAnalyticsEvent_Tests: XCTestCase {
 
     /// Locks the FPTI event name for every case. If you change a string here,
     /// you are changing an analytics contract that downstream dashboards depend on.
-    func testEventName_matchesFPTIContract() {
-        XCTAssertEqual(CardAnalyticsEvent.approveOrderStarted.eventName, "card-payments:approve-order:started")
-        XCTAssertEqual(CardAnalyticsEvent.approveOrderAuthChallengeRequired.eventName, "card-payments:approve-order:auth-challenge-required")
-        XCTAssertEqual(CardAnalyticsEvent.approveOrderAuthChallengePresentationSucceeded.eventName, "card-payments:approve-order:auth-challenge-presentation:succeeded")
-        XCTAssertEqual(CardAnalyticsEvent.approveOrderAuthChallengePresentationFailed.eventName, "card-payments:approve-order:auth-challenge-presentation:failed")
-        XCTAssertEqual(CardAnalyticsEvent.approveOrderSucceeded.eventName, "card-payments:approve-order:succeeded")
-        XCTAssertEqual(CardAnalyticsEvent.approveOrderFailed.eventName, "card-payments:approve-order:failed")
-        XCTAssertEqual(CardAnalyticsEvent.approveOrderAuthChallengeSucceeded.eventName, "card-payments:approve-order:auth-challenge:succeeded")
-        XCTAssertEqual(CardAnalyticsEvent.approveOrderAuthChallengeFailed.eventName, "card-payments:approve-order:auth-challenge:failed")
-        XCTAssertEqual(CardAnalyticsEvent.approveOrderAuthChallengeCanceled.eventName, "card-payments:approve-order:auth-challenge:canceled")
-        XCTAssertEqual(CardAnalyticsEvent.vaultStarted.eventName, "card-payments:vault-wo-purchase:started")
-        XCTAssertEqual(CardAnalyticsEvent.vaultAuthChallengeRequired.eventName, "card-payments:vault-wo-purchase:auth-challenge-required")
-        XCTAssertEqual(CardAnalyticsEvent.vaultAuthChallengePresentationSucceeded.eventName, "card-payments:vault-wo-purchase:auth-challenge-presentation:succeeded")
-        XCTAssertEqual(CardAnalyticsEvent.vaultAuthChallengePresentationFailed.eventName, "card-payments:vault-wo-purchase:auth-challenge-presentation:failed")
-        XCTAssertEqual(CardAnalyticsEvent.vaultSucceeded.eventName, "card-payments:vault-wo-purchase:succeeded")
-        XCTAssertEqual(CardAnalyticsEvent.vaultFailed.eventName, "card-payments:vault-wo-purchase:failed")
-        XCTAssertEqual(CardAnalyticsEvent.vaultAuthChallengeSucceeded.eventName, "card-payments:vault-wo-purchase:auth-challenge:succeeded")
-        XCTAssertEqual(CardAnalyticsEvent.vaultAuthChallengeFailed.eventName, "card-payments:vault-wo-purchase:auth-challenge:failed")
-        XCTAssertEqual(CardAnalyticsEvent.vaultAuthChallengeCanceled.eventName, "card-payments:vault-wo-purchase:auth-challenge:canceled")
+    func testApproveOrderEventNames_matchFPTIContract() {
+        let approveOrder = CardAnalyticsEvent.ApproveOrder.self
+        XCTAssertEqual(approveOrder.started.eventName, "card-payments:approve-order:started")
+        XCTAssertEqual(approveOrder.authChallengeRequired.eventName, "card-payments:approve-order:auth-challenge-required")
+        XCTAssertEqual(
+            approveOrder.authChallengePresentationSucceeded.eventName,
+            "card-payments:approve-order:auth-challenge-presentation:succeeded"
+        )
+        XCTAssertEqual(
+            approveOrder.authChallengePresentationFailed.eventName,
+            "card-payments:approve-order:auth-challenge-presentation:failed"
+        )
+        XCTAssertEqual(approveOrder.succeeded.eventName, "card-payments:approve-order:succeeded")
+        XCTAssertEqual(approveOrder.failed.eventName, "card-payments:approve-order:failed")
+        XCTAssertEqual(approveOrder.authChallengeSucceeded.eventName, "card-payments:approve-order:auth-challenge:succeeded")
+        XCTAssertEqual(approveOrder.authChallengeFailed.eventName, "card-payments:approve-order:auth-challenge:failed")
+        XCTAssertEqual(approveOrder.authChallengeCanceled.eventName, "card-payments:approve-order:auth-challenge:canceled")
+    }
+
+    func testVaultEventNames_matchFPTIContract() {
+        let vault = CardAnalyticsEvent.Vault.self
+        XCTAssertEqual(vault.started.eventName, "card-payments:vault-wo-purchase:started")
+        XCTAssertEqual(vault.authChallengeRequired.eventName, "card-payments:vault-wo-purchase:auth-challenge-required")
+        XCTAssertEqual(
+            vault.authChallengePresentationSucceeded.eventName,
+            "card-payments:vault-wo-purchase:auth-challenge-presentation:succeeded"
+        )
+        XCTAssertEqual(
+            vault.authChallengePresentationFailed.eventName,
+            "card-payments:vault-wo-purchase:auth-challenge-presentation:failed"
+        )
+        XCTAssertEqual(vault.succeeded.eventName, "card-payments:vault-wo-purchase:succeeded")
+        XCTAssertEqual(vault.failed.eventName, "card-payments:vault-wo-purchase:failed")
+        XCTAssertEqual(vault.authChallengeSucceeded.eventName, "card-payments:vault-wo-purchase:auth-challenge:succeeded")
+        XCTAssertEqual(vault.authChallengeFailed.eventName, "card-payments:vault-wo-purchase:auth-challenge:failed")
+        XCTAssertEqual(vault.authChallengeCanceled.eventName, "card-payments:vault-wo-purchase:auth-challenge:canceled")
     }
 }

--- a/UnitTests/PayPalWebPaymentsTests/PayPalWebAnalyticsEvent_Tests.swift
+++ b/UnitTests/PayPalWebPaymentsTests/PayPalWebAnalyticsEvent_Tests.swift
@@ -5,18 +5,35 @@ final class PayPalWebAnalyticsEvent_Tests: XCTestCase {
 
     /// Locks the FPTI event name for every case. If you change a string here,
     /// you are changing an analytics contract that downstream dashboards depend on.
-    func testEventName_matchesFPTIContract() {
-        XCTAssertEqual(PayPalWebAnalyticsEvent.checkoutStarted.eventName, "paypal-web-payments:checkout:started")
-        XCTAssertEqual(PayPalWebAnalyticsEvent.checkoutAuthChallengePresentationSucceeded.eventName, "paypal-web-payments:checkout:auth-challenge-presentation:succeeded")
-        XCTAssertEqual(PayPalWebAnalyticsEvent.checkoutAuthChallengePresentationFailed.eventName, "paypal-web-payments:checkout:auth-challenge-presentation:failed")
-        XCTAssertEqual(PayPalWebAnalyticsEvent.checkoutSucceeded.eventName, "paypal-web-payments:checkout:succeeded")
-        XCTAssertEqual(PayPalWebAnalyticsEvent.checkoutFailed.eventName, "paypal-web-payments:checkout:failed")
-        XCTAssertEqual(PayPalWebAnalyticsEvent.checkoutCanceled.eventName, "paypal-web-payments:checkout:canceled")
-        XCTAssertEqual(PayPalWebAnalyticsEvent.vaultStarted.eventName, "paypal-web-payments:vault-wo-purchase:started")
-        XCTAssertEqual(PayPalWebAnalyticsEvent.vaultAuthChallengePresentationSucceeded.eventName, "paypal-web-payments:vault-wo-purchase:auth-challenge-presentation:succeeded")
-        XCTAssertEqual(PayPalWebAnalyticsEvent.vaultAuthChallengePresentationFailed.eventName, "paypal-web-payments:vault-wo-purchase:auth-challenge-presentation:failed")
-        XCTAssertEqual(PayPalWebAnalyticsEvent.vaultSucceeded.eventName, "paypal-web-payments:vault-wo-purchase:succeeded")
-        XCTAssertEqual(PayPalWebAnalyticsEvent.vaultFailed.eventName, "paypal-web-payments:vault-wo-purchase:failed")
-        XCTAssertEqual(PayPalWebAnalyticsEvent.vaultCanceled.eventName, "paypal-web-payments:vault-wo-purchase:canceled")
+    func testCheckoutEventNames_matchFPTIContract() {
+        let checkout = PayPalWebAnalyticsEvent.Checkout.self
+        XCTAssertEqual(checkout.started.eventName, "paypal-web-payments:checkout:started")
+        XCTAssertEqual(
+            checkout.authChallengePresentationSucceeded.eventName,
+            "paypal-web-payments:checkout:auth-challenge-presentation:succeeded"
+        )
+        XCTAssertEqual(
+            checkout.authChallengePresentationFailed.eventName,
+            "paypal-web-payments:checkout:auth-challenge-presentation:failed"
+        )
+        XCTAssertEqual(checkout.succeeded.eventName, "paypal-web-payments:checkout:succeeded")
+        XCTAssertEqual(checkout.failed.eventName, "paypal-web-payments:checkout:failed")
+        XCTAssertEqual(checkout.canceled.eventName, "paypal-web-payments:checkout:canceled")
+    }
+
+    func testVaultEventNames_matchFPTIContract() {
+        let vault = PayPalWebAnalyticsEvent.Vault.self
+        XCTAssertEqual(vault.started.eventName, "paypal-web-payments:vault-wo-purchase:started")
+        XCTAssertEqual(
+            vault.authChallengePresentationSucceeded.eventName,
+            "paypal-web-payments:vault-wo-purchase:auth-challenge-presentation:succeeded"
+        )
+        XCTAssertEqual(
+            vault.authChallengePresentationFailed.eventName,
+            "paypal-web-payments:vault-wo-purchase:auth-challenge-presentation:failed"
+        )
+        XCTAssertEqual(vault.succeeded.eventName, "paypal-web-payments:vault-wo-purchase:succeeded")
+        XCTAssertEqual(vault.failed.eventName, "paypal-web-payments:vault-wo-purchase:failed")
+        XCTAssertEqual(vault.canceled.eventName, "paypal-web-payments:vault-wo-purchase:canceled")
     }
 }

--- a/UnitTests/PayPalWebPaymentsTests/PayPalWebAnalyticsEvent_Tests.swift
+++ b/UnitTests/PayPalWebPaymentsTests/PayPalWebAnalyticsEvent_Tests.swift
@@ -1,0 +1,22 @@
+import XCTest
+@testable import PayPalWebPayments
+
+final class PayPalWebAnalyticsEvent_Tests: XCTestCase {
+
+    /// Locks the FPTI event name for every case. If you change a string here,
+    /// you are changing an analytics contract that downstream dashboards depend on.
+    func testEventName_matchesFPTIContract() {
+        XCTAssertEqual(PayPalWebAnalyticsEvent.checkoutStarted.eventName, "paypal-web-payments:checkout:started")
+        XCTAssertEqual(PayPalWebAnalyticsEvent.checkoutAuthChallengePresentationSucceeded.eventName, "paypal-web-payments:checkout:auth-challenge-presentation:succeeded")
+        XCTAssertEqual(PayPalWebAnalyticsEvent.checkoutAuthChallengePresentationFailed.eventName, "paypal-web-payments:checkout:auth-challenge-presentation:failed")
+        XCTAssertEqual(PayPalWebAnalyticsEvent.checkoutSucceeded.eventName, "paypal-web-payments:checkout:succeeded")
+        XCTAssertEqual(PayPalWebAnalyticsEvent.checkoutFailed.eventName, "paypal-web-payments:checkout:failed")
+        XCTAssertEqual(PayPalWebAnalyticsEvent.checkoutCanceled.eventName, "paypal-web-payments:checkout:canceled")
+        XCTAssertEqual(PayPalWebAnalyticsEvent.vaultStarted.eventName, "paypal-web-payments:vault-wo-purchase:started")
+        XCTAssertEqual(PayPalWebAnalyticsEvent.vaultAuthChallengePresentationSucceeded.eventName, "paypal-web-payments:vault-wo-purchase:auth-challenge-presentation:succeeded")
+        XCTAssertEqual(PayPalWebAnalyticsEvent.vaultAuthChallengePresentationFailed.eventName, "paypal-web-payments:vault-wo-purchase:auth-challenge-presentation:failed")
+        XCTAssertEqual(PayPalWebAnalyticsEvent.vaultSucceeded.eventName, "paypal-web-payments:vault-wo-purchase:succeeded")
+        XCTAssertEqual(PayPalWebAnalyticsEvent.vaultFailed.eventName, "paypal-web-payments:vault-wo-purchase:failed")
+        XCTAssertEqual(PayPalWebAnalyticsEvent.vaultCanceled.eventName, "paypal-web-payments:vault-wo-purchase:canceled")
+    }
+}

--- a/UnitTests/PaymentButtonsTests/PaymentButtonAnalyticsEvent_Tests.swift
+++ b/UnitTests/PaymentButtonsTests/PaymentButtonAnalyticsEvent_Tests.swift
@@ -1,0 +1,12 @@
+import XCTest
+@testable import PaymentButtons
+
+final class PaymentButtonAnalyticsEvent_Tests: XCTestCase {
+
+    /// Locks the FPTI event name for every case. If you change a string here,
+    /// you are changing an analytics contract that downstream dashboards depend on.
+    func testEventName_matchesFPTIContract() {
+        XCTAssertEqual(PaymentButtonAnalyticsEvent.initialized.eventName, "payment-button:initialized")
+        XCTAssertEqual(PaymentButtonAnalyticsEvent.tapped.eventName, "payment-button:tapped")
+    }
+}

--- a/UnitTests/PaymentsCoreTests/AnalyticsService_Tests.swift
+++ b/UnitTests/PaymentsCoreTests/AnalyticsService_Tests.swift
@@ -22,7 +22,7 @@ class AnalyticsService_Tests: XCTestCase {
     // MARK: - sendEvent()
         
     func testSendEvent_sendsAppropriateAnalyticsEventData() async {
-        await sut.performTrackRequest("some-event", correlationID: "fake-correlation-id")
+        await sut.sendEvent("some-event", correlationID: "fake-correlation-id")
 
         XCTAssertEqual(mockTrackingEventsAPI.capturedAnalyticsEventData?.eventName, "some-event")
         XCTAssertEqual(mockTrackingEventsAPI.capturedAnalyticsEventData?.clientID, "some-client-id")
@@ -37,13 +37,13 @@ class AnalyticsService_Tests: XCTestCase {
             trackingEventsAPI: mockTrackingEventsAPI
         )
         
-        await sut.performTrackRequest("some-event")
+        await sut.sendEvent("some-event")
         
         XCTAssertEqual(mockTrackingEventsAPI.capturedAnalyticsEventData?.environment, "live")
     }
     
     func testSendEvent_whenSandbox_sendsAppropriateEnvName() async {
-        await sut.performTrackRequest("some-event")
+        await sut.sendEvent("some-event")
         
         XCTAssertEqual(mockTrackingEventsAPI.capturedAnalyticsEventData?.environment, "sandbox")
     }
@@ -63,7 +63,7 @@ class AnalyticsService_Tests: XCTestCase {
     }
 
     func testSendEvent_withAnalyticsEventName_forwardsEventName() async {
-        await sut.performTrackRequest(TestEvent.fakeEvent.eventName, correlationID: "corr-id")
+        await sut.sendEvent(TestEvent.fakeEvent.eventName, correlationID: "corr-id")
 
         XCTAssertEqual(mockTrackingEventsAPI.capturedAnalyticsEventData?.eventName, "core-payments:test:fake-event")
         XCTAssertEqual(mockTrackingEventsAPI.capturedAnalyticsEventData?.correlationID, "corr-id")

--- a/UnitTests/PaymentsCoreTests/AnalyticsService_Tests.swift
+++ b/UnitTests/PaymentsCoreTests/AnalyticsService_Tests.swift
@@ -51,4 +51,21 @@ class AnalyticsService_Tests: XCTestCase {
     func testSendEvent_whenAPIRequestFails_logsErrorToConsole() {
         // We currently have no way to validate our console logging
     }
+
+    // MARK: - sendEvent(AnalyticsEventName)
+
+    /// Minimal in-test event to exercise the enum-based entry point without
+    /// pulling module-specific event catalogs into the CorePayments test target.
+    private enum TestEvent: String, AnalyticsEventName {
+        case fakeEvent = "core-payments:test:fake-event"
+
+        var eventName: String { rawValue }
+    }
+
+    func testSendEvent_withAnalyticsEventName_forwardsEventName() async {
+        await sut.performEventRequest(TestEvent.fakeEvent.eventName, correlationID: "corr-id")
+
+        XCTAssertEqual(mockTrackingEventsAPI.capturedAnalyticsEventData?.eventName, "core-payments:test:fake-event")
+        XCTAssertEqual(mockTrackingEventsAPI.capturedAnalyticsEventData?.correlationID, "corr-id")
+    }
 }

--- a/UnitTests/PaymentsCoreTests/AnalyticsService_Tests.swift
+++ b/UnitTests/PaymentsCoreTests/AnalyticsService_Tests.swift
@@ -22,7 +22,7 @@ class AnalyticsService_Tests: XCTestCase {
     // MARK: - sendEvent()
         
     func testSendEvent_sendsAppropriateAnalyticsEventData() async {
-        await sut.performEventRequest("some-event", correlationID: "fake-correlation-id")
+        await sut.performTrackRequest("some-event", correlationID: "fake-correlation-id")
 
         XCTAssertEqual(mockTrackingEventsAPI.capturedAnalyticsEventData?.eventName, "some-event")
         XCTAssertEqual(mockTrackingEventsAPI.capturedAnalyticsEventData?.clientID, "some-client-id")
@@ -37,13 +37,13 @@ class AnalyticsService_Tests: XCTestCase {
             trackingEventsAPI: mockTrackingEventsAPI
         )
         
-        await sut.performEventRequest("some-event")
+        await sut.performTrackRequest("some-event")
         
         XCTAssertEqual(mockTrackingEventsAPI.capturedAnalyticsEventData?.environment, "live")
     }
     
     func testSendEvent_whenSandbox_sendsAppropriateEnvName() async {
-        await sut.performEventRequest("some-event")
+        await sut.performTrackRequest("some-event")
         
         XCTAssertEqual(mockTrackingEventsAPI.capturedAnalyticsEventData?.environment, "sandbox")
     }
@@ -63,7 +63,7 @@ class AnalyticsService_Tests: XCTestCase {
     }
 
     func testSendEvent_withAnalyticsEventName_forwardsEventName() async {
-        await sut.performEventRequest(TestEvent.fakeEvent.eventName, correlationID: "corr-id")
+        await sut.performTrackRequest(TestEvent.fakeEvent.eventName, correlationID: "corr-id")
 
         XCTAssertEqual(mockTrackingEventsAPI.capturedAnalyticsEventData?.eventName, "core-payments:test:fake-event")
         XCTAssertEqual(mockTrackingEventsAPI.capturedAnalyticsEventData?.correlationID, "corr-id")


### PR DESCRIPTION
## What
Replaces the string-based FPTI analytics event pattern with type-safe enums, per the iOS section of the [PPCP v3 Proposed Breaking Changes](https://paypal.atlassian.net/wiki/spaces/CSSE/pages/2900525846/PPCP+v3+Proposed+Breaking+Changes#iOS) doc.

Additionally cleans up the analytics API surface:
- `analyticsService` → `analytics`
- `sendEvent` → `track`
- `analytics` is now a non-optional `let` on client classes, removing optional-chaining noise from every call site.

## Why
Raw strings are verbose at call sites, easy to typo, and hard to grep for when dashboards need to change. Enums give us autocomplete, compile-time safety, and one single place to see every event a module can emit. Following the pattern suggested in Confluence: `cardAnalytics.notify(.checkoutSuccess)` → here, `analyticsService.sendEvent(CardAnalyticsEvent.approveOrderSucceeded)`.

## How
- New `AnalyticsEventName` protocol in `CorePayments`.
- Per-module enums: `CardAnalyticsEvent`, `PayPalWebAnalyticsEvent`, `PaymentButtonAnalyticsEvent`.
- `AnalyticsService` gains a generic `track(_:correlationID:buttonType:)` overload; string overload demoted to `internal`.
- All 32 call sites migrated.
- Roundtrip unit tests assert the exact FPTI string per case, so nobody accidentally renames a live event.

### Why `AnalyticsService` changed from `struct` to `class`
The goal was to make `analytics` a non-optional `let` on client classes. The problem is that `orderID` and `setupToken` need to change per method call — `vault()` sets a `setupToken`, `approveOrder()` sets an `orderID`.

With a **struct** (value type), a `let` property is fully immutable — you can't mutate any of its properties. So the old code had to use `var` and reassign a brand-new `AnalyticsService` instance each time, which forced it to be both `var` (reassignable) and optional (no value at init time), meaning every call site needed `analyticsService?.sendEvent(...)`.

With a **class** (reference type), a `let` property holds an immutable *reference* to the object, but the object's own `var` properties can still be mutated. This lets clients hold a single `let analytics` reference initialized at `init` time while still updating `orderID`/`setupToken` per-flow — no optional chaining needed.

## Target branch
`v3-beta` (per the unified v3 CI thread)

## Verification
- FPTI event names unchanged — asserted by `*AnalyticsEvent_Tests`.
- `AnalyticsService_Tests` extended with a generic-overload test.
- Local `xcodebuild … test` green.