### PR TITLE
Fix CI: downgrade Xcode from 26.4.0 to 26.0.1

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -14,7 +14,7 @@ jobs:
           ref: ${{ github.event.pull_request.head.ref }}
           repository: ${{ github.event.pull_request.head.repo.full_name }}
       - name: Select Xcode Version
-        run: sudo xcode-select -switch /Applications/Xcode_26.4.0.app/Contents/Developer
+        run: sudo xcode-select -switch /Applications/Xcode_26.4.1.app/Contents/Developer
       - name: Run pod lib lint
         run: pod lib lint
   spm:
@@ -27,7 +27,7 @@ jobs:
           ref: ${{ github.event.pull_request.head.ref }}
           repository: ${{ github.event.pull_request.head.repo.full_name }}
       - name: Select Xcode Version
-        run: sudo xcode-select -switch /Applications/Xcode_26.4.0.app/Contents/Developer
+        run: sudo xcode-select -switch /Applications/Xcode_26.4.1.app/Contents/Developer
       - name: Use current branch
         run: sed -i '' 's/branch = .*/branch = \"'"${GITHUB_HEAD_REF//\//\/}"'\";/' SampleApps/SPMTest/SPMTest.xcodeproj/project.pbxproj
       - name: Run swift package resolve

--- a/.github/workflows/publish-docs.yml
+++ b/.github/workflows/publish-docs.yml
@@ -18,7 +18,7 @@ jobs:
         with:
           fetch-depth: 0
       - name: Select Xcode Version
-        run: sudo xcode-select -switch /Applications/Xcode_26.4.0.app/Contents/Developer
+        run: sudo xcode-select -switch /Applications/Xcode_26.4.1.app/Contents/Developer
       - name: Set git username and email
         run: |
           git config user.name paypalsdks

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -33,7 +33,7 @@ jobs:
         with:
           fetch-depth: 0
       - name: Select Xcode Version
-        run: sudo xcode-select -switch /Applications/Xcode_26.4.0.app/Contents/Developer
+        run: sudo xcode-select -switch /Applications/Xcode_26.4.1.app/Contents/Developer
       - name: Check for unreleased section in changelog
         run: grep "## unreleased" CHANGELOG.md || (echo "::error::No unreleased section found in CHANGELOG" && exit 1)
       - name: Set git username and email

--- a/.github/workflows/swiftlint.yml
+++ b/.github/workflows/swiftlint.yml
@@ -11,7 +11,7 @@ jobs:
       - name: Check out repository
         uses: actions/checkout@v2
       - name: Select Xcode Version
-        run: sudo xcode-select -switch /Applications/Xcode_26.4.0.app/Contents/Developer
+        run: sudo xcode-select -switch /Applications/Xcode_26.4.1.app/Contents/Developer
       - name: Install SwiftLint
         run: brew install swiftlint
       - name: Run SwiftLint

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -14,6 +14,6 @@ jobs:
           ref: ${{ github.event.pull_request.head.ref }}
           repository: ${{ github.event.pull_request.head.repo.full_name }}
       - name: Select Xcode Version
-        run: sudo xcode-select -switch /Applications/Xcode_26.4.0.app/Contents/Developer
+        run: sudo xcode-select -switch /Applications/Xcode_26.4.1.app/Contents/Developer
       - name: Run Unit Tests
         run: set -o pipefail && xcodebuild -workspace 'PayPal.xcworkspace' -sdk 'iphonesimulator' -configuration 'Debug' -scheme 'UnitTests' -destination 'platform=iOS Simulator,name=iPhone 17,OS=26.2' test | xcpretty


### PR DESCRIPTION
## Summary
- The `macos-26` runner image was updated on April 22 (`20260413.0345` → `20260422.0012`) and replaced `Xcode_26.4.0` with `Xcode_26.4.1`, breaking all CI checks across every PR targeting `v3-beta`
- Updates all 5 workflow files to use `Xcode_26.4.1.app`: build, tests, swiftlint, publish-docs, release

## Root cause
The GitHub Actions `macos-26-arm64` runner image bumped Xcode from 26.4.0 to 26.4.1 in the April 22 image release. Our workflows hardcoded `Xcode_26.4.0.app`, which no longer exists on the runner.

## Verification
All 4 checks pass on this PR:
- SwiftLint ✓
- Swift Package Manager ✓
- CocoaPods ✓
- Unit Tests ✓

🤖 Generated with [Claude Code](https://claude.com/claude-code)