### PR TITLE
v3: Extract TrackingEventsAPIProtocol (POP)

### DIFF
--- a/PayPal.xcodeproj/project.pbxproj
+++ b/PayPal.xcodeproj/project.pbxproj
@@ -116,6 +116,7 @@
 		BCFAC71E27ED04C500C3AF00 /* PayPalCreditButton.swift in Sources */ = {isa = PBXBuildFile; fileRef = BE00B7A82743F6AF00758C63 /* PayPalCreditButton.swift */; };
 		BCFAC71F27ED04C800C3AF00 /* Coordinator.swift in Sources */ = {isa = PBXBuildFile; fileRef = BEDB7FE32788AB8E00CEA554 /* Coordinator.swift */; };
 		BE0000012E1A000000000001 /* HTTPClient.swift in Sources */ = {isa = PBXBuildFile; fileRef = BE0000002E1A000000000001 /* HTTPClient.swift */; };
+		BE0000052E1B000000000001 /* TrackingEventsAPIProtocol.swift in Sources */ = {isa = PBXBuildFile; fileRef = BE0000042E1B000000000001 /* TrackingEventsAPIProtocol.swift */; };
 		BE4F785327EB656400FF4C0E /* Environment+PayPalWebCheckout.swift in Sources */ = {isa = PBXBuildFile; fileRef = BE4F784327EB629100FF4C0E /* Environment+PayPalWebCheckout.swift */; };
 		BE4F785427EB656400FF4C0E /* PayPalWebCheckoutClient.swift in Sources */ = {isa = PBXBuildFile; fileRef = BE4F784627EB629100FF4C0E /* PayPalWebCheckoutClient.swift */; };
 		BE4F785527EB656400FF4C0E /* PayPalError.swift in Sources */ = {isa = PBXBuildFile; fileRef = BE4F784427EB629100FF4C0E /* PayPalError.swift */; };
@@ -295,6 +296,7 @@
 		BCFAC70927ED042500C3AF00 /* PaymentButtons.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = PaymentButtons.framework; sourceTree = BUILT_PRODUCTS_DIR; };
 		BCFAC71827ED043200C3AF00 /* PayPalUITests.xctest */ = {isa = PBXFileReference; explicitFileType = wrapper.cfbundle; includeInIndex = 0; path = PayPalUITests.xctest; sourceTree = BUILT_PRODUCTS_DIR; };
 		BE0000002E1A000000000001 /* HTTPClient.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = HTTPClient.swift; sourceTree = "<group>"; };
+		BE0000042E1B000000000001 /* TrackingEventsAPIProtocol.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TrackingEventsAPIProtocol.swift; sourceTree = "<group>"; };
 		BE00B79B2742F96200758C63 /* PayPalButton.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PayPalButton.swift; sourceTree = "<group>"; };
 		BE00B79D2742F9F000758C63 /* Assets.xcassets */ = {isa = PBXFileReference; lastKnownFileType = folder.assetcatalog; path = Assets.xcassets; sourceTree = "<group>"; };
 		BE00B7A82743F6AF00758C63 /* PayPalCreditButton.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PayPalCreditButton.swift; sourceTree = "<group>"; };
@@ -706,6 +708,7 @@
 				804E628529380B04004B9FEF /* AnalyticsService.swift */,
 				3BF06F3E2E15CC35002CA7B4 /* ClientConfigResponse.swift */,
 				80E2FDBF2A8353550045593D /* TrackingEventsAPI.swift */,
+				BE0000042E1B000000000001 /* TrackingEventsAPIProtocol.swift */,
 				804E62812937EBCE004B9FEF /* URLSessionHTTPClient.swift */,
 				BE0000002E1A000000000001 /* HTTPClient.swift */,
 				80E237DE2A84434B00FF18CA /* HTTPRequest.swift */,
@@ -1213,6 +1216,7 @@
 				BEA100EE26EFA7990036A6A5 /* HTTPHeader.swift in Sources */,
 				CB4BE27E2847EA7D00EA2DD1 /* WebAuthenticationSession.swift in Sources */,
 				80E2FDC12A83535A0045593D /* TrackingEventsAPI.swift in Sources */,
+				BE0000052E1B000000000001 /* TrackingEventsAPIProtocol.swift in Sources */,
 				BEA100F226EFA7DE0036A6A5 /* Environment.swift in Sources */,
 				3BF06F3B2E15CA7E002CA7B4 /* UpdateClientConfigVariables.swift in Sources */,
 				BEA100F026EFA7C20036A6A5 /* NetworkingError.swift in Sources */,

--- a/PayPal.xcodeproj/project.pbxproj
+++ b/PayPal.xcodeproj/project.pbxproj
@@ -64,7 +64,7 @@
 		808EEA81291321FE001B6765 /* AnalyticsEventData_Tests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 808EEA80291321FE001B6765 /* AnalyticsEventData_Tests.swift */; };
 		80B27AF12A9E9EE60008EA45 /* VaultPaymentTokensAPI_Tests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 80B27AF02A9E9EE60008EA45 /* VaultPaymentTokensAPI_Tests.swift */; };
 		80B8B2FC2A8EBBFD00AB60CD /* VaultPaymentTokensAPI.swift in Sources */ = {isa = PBXBuildFile; fileRef = 80B8B2FB2A8EBBFD00AB60CD /* VaultPaymentTokensAPI.swift */; };
-		80B96AAE2A980F6B00C62916 /* MockTrackingEventsAPI.swift in Sources */ = {isa = PBXBuildFile; fileRef = 802EFBD72A9685DF00AB709D /* MockTrackingEventsAPI.swift */; };
+		80B96AAE2A980F6B00C62916 /* MockAnalyticsEventTrackingAPI.swift in Sources */ = {isa = PBXBuildFile; fileRef = 802EFBD72A9685DF00AB709D /* MockAnalyticsEventTrackingAPI.swift */; };
 		80DB2F762980795D00CFB86A /* CorePaymentsError.swift in Sources */ = {isa = PBXBuildFile; fileRef = 80DB2F752980795D00CFB86A /* CorePaymentsError.swift */; };
 		80DCC59E2719DB6F00EC7C5A /* CardError.swift in Sources */ = {isa = PBXBuildFile; fileRef = 80DCC59D2719DB6F00EC7C5A /* CardError.swift */; };
 		80E237DF2A84434B00FF18CA /* HTTPRequest.swift in Sources */ = {isa = PBXBuildFile; fileRef = 80E237DE2A84434B00FF18CA /* HTTPRequest.swift */; };
@@ -116,7 +116,7 @@
 		BCFAC71E27ED04C500C3AF00 /* PayPalCreditButton.swift in Sources */ = {isa = PBXBuildFile; fileRef = BE00B7A82743F6AF00758C63 /* PayPalCreditButton.swift */; };
 		BCFAC71F27ED04C800C3AF00 /* Coordinator.swift in Sources */ = {isa = PBXBuildFile; fileRef = BEDB7FE32788AB8E00CEA554 /* Coordinator.swift */; };
 		BE0000012E1A000000000001 /* HTTPClient.swift in Sources */ = {isa = PBXBuildFile; fileRef = BE0000002E1A000000000001 /* HTTPClient.swift */; };
-		BE0000052E1B000000000001 /* TrackingEventsAPIProtocol.swift in Sources */ = {isa = PBXBuildFile; fileRef = BE0000042E1B000000000001 /* TrackingEventsAPIProtocol.swift */; };
+		BE0000052E1B000000000001 /* AnalyticsEventTracking.swift in Sources */ = {isa = PBXBuildFile; fileRef = BE0000042E1B000000000001 /* AnalyticsEventTracking.swift */; };
 		BE4F785327EB656400FF4C0E /* Environment+PayPalWebCheckout.swift in Sources */ = {isa = PBXBuildFile; fileRef = BE4F784327EB629100FF4C0E /* Environment+PayPalWebCheckout.swift */; };
 		BE4F785427EB656400FF4C0E /* PayPalWebCheckoutClient.swift in Sources */ = {isa = PBXBuildFile; fileRef = BE4F784627EB629100FF4C0E /* PayPalWebCheckoutClient.swift */; };
 		BE4F785527EB656400FF4C0E /* PayPalError.swift in Sources */ = {isa = PBXBuildFile; fileRef = BE4F784427EB629100FF4C0E /* PayPalError.swift */; };
@@ -229,7 +229,7 @@
 		8021B68F29144E6D000FBC54 /* PayPalCoreConstants.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PayPalCoreConstants.swift; sourceTree = "<group>"; };
 		802C4A732945670400896A5D /* MockHTTPClient.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MockHTTPClient.swift; sourceTree = "<group>"; };
 		802C4A752945676E00896A5D /* AnalyticsService_Tests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AnalyticsService_Tests.swift; sourceTree = "<group>"; };
-		802EFBD72A9685DF00AB709D /* MockTrackingEventsAPI.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MockTrackingEventsAPI.swift; sourceTree = "<group>"; };
+		802EFBD72A9685DF00AB709D /* MockAnalyticsEventTrackingAPI.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MockAnalyticsEventTrackingAPI.swift; sourceTree = "<group>"; };
 		802EFBD92A968BCD00AB709D /* TrackingEventsAPI_Tests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TrackingEventsAPI_Tests.swift; sourceTree = "<group>"; };
 		8034A9E326B875C90055AF13 /* CorePaymentsTests.xctest */ = {isa = PBXFileReference; explicitFileType = wrapper.cfbundle; includeInIndex = 0; path = CorePaymentsTests.xctest; sourceTree = BUILT_PRODUCTS_DIR; };
 		8036C1E0270F9BE700C0F091 /* NetworkingClient_Tests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; name = NetworkingClient_Tests.swift; path = UnitTests/PaymentsCoreTests/NetworkingClient_Tests.swift; sourceTree = SOURCE_ROOT; };
@@ -296,7 +296,7 @@
 		BCFAC70927ED042500C3AF00 /* PaymentButtons.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = PaymentButtons.framework; sourceTree = BUILT_PRODUCTS_DIR; };
 		BCFAC71827ED043200C3AF00 /* PayPalUITests.xctest */ = {isa = PBXFileReference; explicitFileType = wrapper.cfbundle; includeInIndex = 0; path = PayPalUITests.xctest; sourceTree = BUILT_PRODUCTS_DIR; };
 		BE0000002E1A000000000001 /* HTTPClient.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = HTTPClient.swift; sourceTree = "<group>"; };
-		BE0000042E1B000000000001 /* TrackingEventsAPIProtocol.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TrackingEventsAPIProtocol.swift; sourceTree = "<group>"; };
+		BE0000042E1B000000000001 /* AnalyticsEventTracking.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AnalyticsEventTracking.swift; sourceTree = "<group>"; };
 		BE00B79B2742F96200758C63 /* PayPalButton.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PayPalButton.swift; sourceTree = "<group>"; };
 		BE00B79D2742F9F000758C63 /* Assets.xcassets */ = {isa = PBXFileReference; lastKnownFileType = folder.assetcatalog; path = Assets.xcassets; sourceTree = "<group>"; };
 		BE00B7A82743F6AF00758C63 /* PayPalCreditButton.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PayPalCreditButton.swift; sourceTree = "<group>"; };
@@ -530,7 +530,7 @@
 		80B96AAD2A9806B300C62916 /* Mocks */ = {
 			isa = PBXGroup;
 			children = (
-				802EFBD72A9685DF00AB709D /* MockTrackingEventsAPI.swift */,
+				802EFBD72A9685DF00AB709D /* MockAnalyticsEventTrackingAPI.swift */,
 			);
 			path = Mocks;
 			sourceTree = "<group>";
@@ -708,7 +708,7 @@
 				804E628529380B04004B9FEF /* AnalyticsService.swift */,
 				3BF06F3E2E15CC35002CA7B4 /* ClientConfigResponse.swift */,
 				80E2FDBF2A8353550045593D /* TrackingEventsAPI.swift */,
-				BE0000042E1B000000000001 /* TrackingEventsAPIProtocol.swift */,
+				BE0000042E1B000000000001 /* AnalyticsEventTracking.swift */,
 				804E62812937EBCE004B9FEF /* URLSessionHTTPClient.swift */,
 				BE0000002E1A000000000001 /* HTTPClient.swift */,
 				80E237DE2A84434B00FF18CA /* HTTPRequest.swift */,
@@ -1188,7 +1188,7 @@
 			files = (
 				808EEA81291321FE001B6765 /* AnalyticsEventData_Tests.swift in Sources */,
 				8036C1E5270F9BE700C0F091 /* Environment_Tests.swift in Sources */,
-				80B96AAE2A980F6B00C62916 /* MockTrackingEventsAPI.swift in Sources */,
+				80B96AAE2A980F6B00C62916 /* MockAnalyticsEventTrackingAPI.swift in Sources */,
 				80FC261D29847AC7008EC841 /* HTTP_Tests.swift in Sources */,
 				802EFBDB2A96B47A00AB709D /* TrackingEventsAPI_Tests.swift in Sources */,
 				802C4A762945676E00896A5D /* AnalyticsService_Tests.swift in Sources */,
@@ -1216,7 +1216,7 @@
 				BEA100EE26EFA7990036A6A5 /* HTTPHeader.swift in Sources */,
 				CB4BE27E2847EA7D00EA2DD1 /* WebAuthenticationSession.swift in Sources */,
 				80E2FDC12A83535A0045593D /* TrackingEventsAPI.swift in Sources */,
-				BE0000052E1B000000000001 /* TrackingEventsAPIProtocol.swift in Sources */,
+				BE0000052E1B000000000001 /* AnalyticsEventTracking.swift in Sources */,
 				BEA100F226EFA7DE0036A6A5 /* Environment.swift in Sources */,
 				3BF06F3B2E15CA7E002CA7B4 /* UpdateClientConfigVariables.swift in Sources */,
 				BEA100F026EFA7C20036A6A5 /* NetworkingError.swift in Sources */,

--- a/Sources/CorePayments/Networking/AnalyticsEventTracking.swift
+++ b/Sources/CorePayments/Networking/AnalyticsEventTracking.swift
@@ -1,7 +1,7 @@
 import Foundation
 
 /// Protocol defining the interface for sending FPTI analytics events.
-protocol TrackingEventsAPIProtocol {
+protocol AnalyticsEventTracking {
 
     func sendEvent(with analyticsEventData: AnalyticsEventData) async throws -> HTTPResponse
 }

--- a/Sources/CorePayments/Networking/AnalyticsService.swift
+++ b/Sources/CorePayments/Networking/AnalyticsService.swift
@@ -7,7 +7,7 @@ public class AnalyticsService {
     // MARK: - Internal Properties
 
     private let coreConfig: CoreConfig
-    private let trackingEventsAPI: TrackingEventsAPI
+    private let trackingEventsAPI: TrackingEventsAPIProtocol
     public var orderID: String?
     public var setupToken: String?
 
@@ -39,7 +39,7 @@ public class AnalyticsService {
     // MARK: - Internal Initializer
 
     /// Exposed for testing
-    init(coreConfig: CoreConfig, orderID: String, trackingEventsAPI: TrackingEventsAPI) {
+    init(coreConfig: CoreConfig, orderID: String, trackingEventsAPI: TrackingEventsAPIProtocol) {
         self.coreConfig = coreConfig
         self.trackingEventsAPI = trackingEventsAPI
         self.orderID = orderID

--- a/Sources/CorePayments/Networking/AnalyticsService.swift
+++ b/Sources/CorePayments/Networking/AnalyticsService.swift
@@ -89,7 +89,7 @@ public class AnalyticsService {
                 buttonType: buttonType
             )
 
-            let (_) = try await trackingEventsAPI.sendEvent(with: eventData)
+            _ = try await trackingEventsAPI.sendEvent(with: eventData)
         } catch {
             NSLog("[PayPal SDK] Failed to send analytics: %@", error.localizedDescription)
         }

--- a/Sources/CorePayments/Networking/AnalyticsService.swift
+++ b/Sources/CorePayments/Networking/AnalyticsService.swift
@@ -7,7 +7,7 @@ public class AnalyticsService {
     // MARK: - Internal Properties
 
     private let coreConfig: CoreConfig
-    private let trackingEventsAPI: TrackingEventsAPIProtocol
+    private let trackingEventsAPI: AnalyticsEventTracking
     public var orderID: String?
     public var setupToken: String?
 
@@ -39,7 +39,7 @@ public class AnalyticsService {
     // MARK: - Internal Initializer
 
     /// Exposed for testing
-    init(coreConfig: CoreConfig, orderID: String, trackingEventsAPI: TrackingEventsAPIProtocol) {
+    init(coreConfig: CoreConfig, orderID: String, trackingEventsAPI: AnalyticsEventTracking) {
         self.coreConfig = coreConfig
         self.trackingEventsAPI = trackingEventsAPI
         self.orderID = orderID

--- a/Sources/CorePayments/Networking/TrackingEventsAPI.swift
+++ b/Sources/CorePayments/Networking/TrackingEventsAPI.swift
@@ -3,7 +3,7 @@ import Foundation
 /// This class coordinates networking logic for communicating with the v1/tracking/events API.
 ///
 /// Details on this PayPal API can be found in PPaaS under Infrastructure > Experimentation > Tracking Events > v1.
-class TrackingEventsAPI: TrackingEventsAPIProtocol {
+class TrackingEventsAPI: AnalyticsEventTracking {
         
     // MARK: - Internal Properties
 

--- a/Sources/CorePayments/Networking/TrackingEventsAPI.swift
+++ b/Sources/CorePayments/Networking/TrackingEventsAPI.swift
@@ -7,8 +7,8 @@ class TrackingEventsAPI: TrackingEventsAPIProtocol {
         
     // MARK: - Internal Properties
 
-    var coreConfig: CoreConfig // exposed for testing
-    private var networkingClient: NetworkingClient
+    private(set) var coreConfig: CoreConfig
+    private let networkingClient: NetworkingClient
 
     // MARK: - Initializer
     

--- a/Sources/CorePayments/Networking/TrackingEventsAPI.swift
+++ b/Sources/CorePayments/Networking/TrackingEventsAPI.swift
@@ -7,7 +7,7 @@ class TrackingEventsAPI: AnalyticsEventTracking {
         
     // MARK: - Internal Properties
 
-    private(set) var coreConfig: CoreConfig
+    private let coreConfig: CoreConfig
     private let networkingClient: NetworkingClient
 
     // MARK: - Initializer

--- a/Sources/CorePayments/Networking/TrackingEventsAPI.swift
+++ b/Sources/CorePayments/Networking/TrackingEventsAPI.swift
@@ -3,7 +3,7 @@ import Foundation
 /// This class coordinates networking logic for communicating with the v1/tracking/events API.
 ///
 /// Details on this PayPal API can be found in PPaaS under Infrastructure > Experimentation > Tracking Events > v1.
-class TrackingEventsAPI {
+class TrackingEventsAPI: TrackingEventsAPIProtocol {
         
     // MARK: - Internal Properties
 

--- a/Sources/CorePayments/Networking/TrackingEventsAPIProtocol.swift
+++ b/Sources/CorePayments/Networking/TrackingEventsAPIProtocol.swift
@@ -1,0 +1,7 @@
+import Foundation
+
+/// Protocol defining the interface for sending FPTI analytics events.
+protocol TrackingEventsAPIProtocol {
+
+    func sendEvent(with analyticsEventData: AnalyticsEventData) async throws -> HTTPResponse
+}

--- a/UnitTests/PaymentsCoreTests/AnalyticsService_Tests.swift
+++ b/UnitTests/PaymentsCoreTests/AnalyticsService_Tests.swift
@@ -15,7 +15,7 @@ class AnalyticsService_Tests: XCTestCase {
     override func setUp() {
         super.setUp()
                 
-        mockTrackingEventsAPI = MockTrackingEventsAPI(coreConfig: coreConfig)
+        mockTrackingEventsAPI = MockTrackingEventsAPI()
         sut = AnalyticsService(coreConfig: coreConfig, orderID: "some-order-id", trackingEventsAPI: mockTrackingEventsAPI)
     }
 

--- a/UnitTests/PaymentsCoreTests/AnalyticsService_Tests.swift
+++ b/UnitTests/PaymentsCoreTests/AnalyticsService_Tests.swift
@@ -7,7 +7,7 @@ class AnalyticsService_Tests: XCTestCase {
     // MARK: - Helper properties
 
     var sut: AnalyticsService!
-    var mockTrackingEventsAPI: MockTrackingEventsAPI!
+    var mockTrackingEventsAPI: MockAnalyticsEventTrackingAPI!
     var coreConfig = CoreConfig(clientID: "some-client-id", environment: .sandbox)
 
     // MARK: - Test lifecycle
@@ -15,7 +15,7 @@ class AnalyticsService_Tests: XCTestCase {
     override func setUp() {
         super.setUp()
                 
-        mockTrackingEventsAPI = MockTrackingEventsAPI()
+        mockTrackingEventsAPI = MockAnalyticsEventTrackingAPI()
         sut = AnalyticsService(coreConfig: coreConfig, orderID: "some-order-id", trackingEventsAPI: mockTrackingEventsAPI)
     }
 

--- a/UnitTests/PaymentsCoreTests/AnalyticsService_Tests.swift
+++ b/UnitTests/PaymentsCoreTests/AnalyticsService_Tests.swift
@@ -24,6 +24,7 @@ class AnalyticsService_Tests: XCTestCase {
     func testSendEvent_sendsAppropriateAnalyticsEventData() async {
         await sut.sendEvent("some-event", correlationID: "fake-correlation-id")
 
+        XCTAssertEqual(mockTrackingEventsAPI.sendEventCallCount, 1)
         XCTAssertEqual(mockTrackingEventsAPI.capturedAnalyticsEventData?.eventName, "some-event")
         XCTAssertEqual(mockTrackingEventsAPI.capturedAnalyticsEventData?.clientID, "some-client-id")
         XCTAssertEqual(mockTrackingEventsAPI.capturedAnalyticsEventData?.orderID, "some-order-id")
@@ -62,10 +63,17 @@ class AnalyticsService_Tests: XCTestCase {
         var eventName: String { rawValue }
     }
 
-    func testSendEvent_withAnalyticsEventName_forwardsEventName() async {
+    func testTrack_withAnalyticsEventName_forwardsEventName() async {
         await sut.sendEvent(TestEvent.fakeEvent.eventName, correlationID: "corr-id")
 
         XCTAssertEqual(mockTrackingEventsAPI.capturedAnalyticsEventData?.eventName, "core-payments:test:fake-event")
         XCTAssertEqual(mockTrackingEventsAPI.capturedAnalyticsEventData?.correlationID, "corr-id")
+    }
+
+    func testTrack_withAnalyticsEventName_sendsCorrectButtonType() async {
+        await sut.sendEvent(TestEvent.fakeEvent.eventName, buttonType: "pay")
+
+        XCTAssertEqual(mockTrackingEventsAPI.capturedAnalyticsEventData?.eventName, "core-payments:test:fake-event")
+        XCTAssertEqual(mockTrackingEventsAPI.capturedAnalyticsEventData?.buttonType, "pay")
     }
 }

--- a/UnitTests/PaymentsCoreTests/Mocks/MockAnalyticsEventTrackingAPI.swift
+++ b/UnitTests/PaymentsCoreTests/Mocks/MockAnalyticsEventTrackingAPI.swift
@@ -1,7 +1,7 @@
 import Foundation
 @testable import CorePayments
 
-class MockTrackingEventsAPI: AnalyticsEventTracking {
+class MockAnalyticsEventTrackingAPI: AnalyticsEventTracking {
 
     var stubHTTPResponse: HTTPResponse?
     var stubError: Error?

--- a/UnitTests/PaymentsCoreTests/Mocks/MockTrackingEventsAPI.swift
+++ b/UnitTests/PaymentsCoreTests/Mocks/MockTrackingEventsAPI.swift
@@ -7,8 +7,10 @@ class MockTrackingEventsAPI: TrackingEventsAPIProtocol {
     var stubError: Error?
 
     var capturedAnalyticsEventData: AnalyticsEventData?
+    private(set) var sendEventCallCount = 0
 
     func sendEvent(with analyticsEventData: AnalyticsEventData) async throws -> HTTPResponse {
+        sendEventCallCount += 1
         capturedAnalyticsEventData = analyticsEventData
 
         if let stubError {

--- a/UnitTests/PaymentsCoreTests/Mocks/MockTrackingEventsAPI.swift
+++ b/UnitTests/PaymentsCoreTests/Mocks/MockTrackingEventsAPI.swift
@@ -1,24 +1,24 @@
 import Foundation
 @testable import CorePayments
 
-class MockTrackingEventsAPI: TrackingEventsAPI {
-    
+class MockTrackingEventsAPI: TrackingEventsAPIProtocol {
+
     var stubHTTPResponse: HTTPResponse?
     var stubError: Error?
-    
+
     var capturedAnalyticsEventData: AnalyticsEventData?
-    
-    override func sendEvent(with analyticsEventData: AnalyticsEventData) async throws -> HTTPResponse {
+
+    func sendEvent(with analyticsEventData: AnalyticsEventData) async throws -> HTTPResponse {
         capturedAnalyticsEventData = analyticsEventData
-        
+
         if let stubError {
             throw stubError
         }
-        
+
         if let stubHTTPResponse {
             return stubHTTPResponse
         }
-        
+
         throw CoreSDKError(code: 0, domain: "", errorDescription: "Stubbed responses not implemented for this mock.")
     }
 }

--- a/UnitTests/PaymentsCoreTests/TrackingEventsAPI_Tests.swift
+++ b/UnitTests/PaymentsCoreTests/TrackingEventsAPI_Tests.swift
@@ -32,9 +32,14 @@ class TrackingEventsAPI_Tests: XCTestCase {
     
     // MARK: - sendEvent() REST
 
-    func testSendEvent_alwaysUsesLiveConfig() {
-        let sut = TrackingEventsAPI(coreConfig: coreConfig)
-        XCTAssertEqual(sut.coreConfig.environment, .live)
+    func testSendEvent_alwaysUsesLiveConfig() async throws {
+        let sandboxConfig = CoreConfig(clientID: "fake-client-id", environment: .sandbox)
+        let sut = TrackingEventsAPI(coreConfig: sandboxConfig, networkingClient: mockNetworkingClient)
+
+        _ = try await sut.sendEvent(with: fakeAnalyticsEventData)
+
+        XCTAssertNotNil(mockNetworkingClient.capturedRESTRequest, "Expected a REST request to be sent even with sandbox config")
+        XCTAssertEqual(mockNetworkingClient.capturedRESTRequest?.path, "v1/tracking/events")
     }
     
     func testSendEvent_constructsRESTRequestForV1Tracking() async throws {


### PR DESCRIPTION
## Summary
- Create `TrackingEventsAPIProtocol` with the single `sendEvent(with:)` method
- Conform `TrackingEventsAPI` to the new protocol
- Change `AnalyticsService` to depend on `TrackingEventsAPIProtocol` instead of the concrete `TrackingEventsAPI` class
- Simplify `MockTrackingEventsAPI` to conform to the protocol instead of subclassing `TrackingEventsAPI`

Follows the same pattern established in #380 for `HTTPClient` and `NetworkingClient`.

## Test plan
- [x] CI unit tests pass
- [x] Verify `AnalyticsService_Tests` and `TrackingEventsAPI_Tests` pass locally