### PR TITLE
v3: Extract VaultedTokenSaving protocol (POP)

### DIFF
--- a/PayPal.xcodeproj/project.pbxproj
+++ b/PayPal.xcodeproj/project.pbxproj
@@ -60,7 +60,7 @@
 		807D56AE2A869064009E591D /* GraphQLRequest.swift in Sources */ = {isa = PBXBuildFile; fileRef = 807D56AD2A869064009E591D /* GraphQLRequest.swift */; };
 		807D56B02A869F97009E591D /* GraphQLErrorResponse.swift in Sources */ = {isa = PBXBuildFile; fileRef = 807D56AF2A869F97009E591D /* GraphQLErrorResponse.swift */; };
 		808E3EDD2A981F240017FE46 /* MockCheckoutOrderConfirmingAPI.swift in Sources */ = {isa = PBXBuildFile; fileRef = 808E3EDC2A981F240017FE46 /* MockCheckoutOrderConfirmingAPI.swift */; };
-		808E3EDF2A981F390017FE46 /* MockVaultPaymentTokensAPI.swift in Sources */ = {isa = PBXBuildFile; fileRef = 808E3EDE2A981F390017FE46 /* MockVaultPaymentTokensAPI.swift */; };
+		BE0000112E1D000000000003 /* MockVaultedTokenSavingAPI.swift in Sources */ = {isa = PBXBuildFile; fileRef = BE0000102E1D000000000003 /* MockVaultedTokenSavingAPI.swift */; };
 		808EEA81291321FE001B6765 /* AnalyticsEventData_Tests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 808EEA80291321FE001B6765 /* AnalyticsEventData_Tests.swift */; };
 		80B27AF12A9E9EE60008EA45 /* VaultPaymentTokensAPI_Tests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 80B27AF02A9E9EE60008EA45 /* VaultPaymentTokensAPI_Tests.swift */; };
 		80B8B2FC2A8EBBFD00AB60CD /* VaultPaymentTokensAPI.swift in Sources */ = {isa = PBXBuildFile; fileRef = 80B8B2FB2A8EBBFD00AB60CD /* VaultPaymentTokensAPI.swift */; };
@@ -70,6 +70,7 @@
 		80E237DF2A84434B00FF18CA /* HTTPRequest.swift in Sources */ = {isa = PBXBuildFile; fileRef = 80E237DE2A84434B00FF18CA /* HTTPRequest.swift */; };
 		80E2FDBE2A83528B0045593D /* CheckoutOrdersAPI.swift in Sources */ = {isa = PBXBuildFile; fileRef = 80E2FDBD2A83528B0045593D /* CheckoutOrdersAPI.swift */; };
 		BE0000092E1D000000000001 /* CheckoutOrderConfirming.swift in Sources */ = {isa = PBXBuildFile; fileRef = BE0000082E1D000000000001 /* CheckoutOrderConfirming.swift */; };
+		BE00000B2E1D000000000002 /* VaultedTokenSaving.swift in Sources */ = {isa = PBXBuildFile; fileRef = BE00000A2E1D000000000002 /* VaultedTokenSaving.swift */; };
 		80E2FDC12A83535A0045593D /* TrackingEventsAPI.swift in Sources */ = {isa = PBXBuildFile; fileRef = 80E2FDBF2A8353550045593D /* TrackingEventsAPI.swift */; };
 		80E2FDC32A8354AD0045593D /* RESTRequest.swift in Sources */ = {isa = PBXBuildFile; fileRef = 80E2FDC22A8354AD0045593D /* RESTRequest.swift */; };
 		80E643832A1EBBD2008FD705 /* HTTPResponse.swift in Sources */ = {isa = PBXBuildFile; fileRef = 80E643822A1EBBD2008FD705 /* HTTPResponse.swift */; };
@@ -247,7 +248,7 @@
 		807D56AD2A869064009E591D /* GraphQLRequest.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = GraphQLRequest.swift; sourceTree = "<group>"; };
 		807D56AF2A869F97009E591D /* GraphQLErrorResponse.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = GraphQLErrorResponse.swift; sourceTree = "<group>"; };
 		808E3EDC2A981F240017FE46 /* MockCheckoutOrderConfirmingAPI.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MockCheckoutOrderConfirmingAPI.swift; sourceTree = "<group>"; };
-		808E3EDE2A981F390017FE46 /* MockVaultPaymentTokensAPI.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MockVaultPaymentTokensAPI.swift; sourceTree = "<group>"; };
+		BE0000102E1D000000000003 /* MockVaultedTokenSavingAPI.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MockVaultedTokenSavingAPI.swift; sourceTree = "<group>"; };
 		808EEA80291321FE001B6765 /* AnalyticsEventData_Tests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AnalyticsEventData_Tests.swift; sourceTree = "<group>"; };
 		80B27AF02A9E9EE60008EA45 /* VaultPaymentTokensAPI_Tests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = VaultPaymentTokensAPI_Tests.swift; sourceTree = "<group>"; };
 		80B8B2FB2A8EBBFD00AB60CD /* VaultPaymentTokensAPI.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = VaultPaymentTokensAPI.swift; sourceTree = "<group>"; };
@@ -257,6 +258,7 @@
 		80E237DE2A84434B00FF18CA /* HTTPRequest.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = HTTPRequest.swift; sourceTree = "<group>"; };
 		80E2FDBD2A83528B0045593D /* CheckoutOrdersAPI.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CheckoutOrdersAPI.swift; sourceTree = "<group>"; };
 		BE0000082E1D000000000001 /* CheckoutOrderConfirming.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CheckoutOrderConfirming.swift; sourceTree = "<group>"; };
+		BE00000A2E1D000000000002 /* VaultedTokenSaving.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = VaultedTokenSaving.swift; sourceTree = "<group>"; };
 		80E2FDBF2A8353550045593D /* TrackingEventsAPI.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TrackingEventsAPI.swift; sourceTree = "<group>"; };
 		80E2FDC22A8354AD0045593D /* RESTRequest.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RESTRequest.swift; sourceTree = "<group>"; };
 		80E643822A1EBBD2008FD705 /* HTTPResponse.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = HTTPResponse.swift; sourceTree = "<group>"; };
@@ -525,7 +527,7 @@
 			children = (
 				CB16E6D7285B7A2B00FD6F52 /* FakeConfirmPaymentResponse.swift */,
 				808E3EDC2A981F240017FE46 /* MockCheckoutOrderConfirmingAPI.swift */,
-				808E3EDE2A981F390017FE46 /* MockVaultPaymentTokensAPI.swift */,
+				BE0000102E1D000000000003 /* MockVaultedTokenSavingAPI.swift */,
 				3B783DC22B7A69C2004623DB /* FakeUpdateSetupTokenResponse.swift */,
 			);
 			path = Mocks;
@@ -565,6 +567,7 @@
 				80E2FDBD2A83528B0045593D /* CheckoutOrdersAPI.swift */,
 				BE0000082E1D000000000001 /* CheckoutOrderConfirming.swift */,
 				3BD82DBA2A835AF900CBE764 /* UpdateSetupTokenResponse.swift */,
+				BE00000A2E1D000000000002 /* VaultedTokenSaving.swift */,
 				80B8B2FB2A8EBBFD00AB60CD /* VaultPaymentTokensAPI.swift */,
 			);
 			path = APIRequests;
@@ -1267,6 +1270,7 @@
 				06CE009B26F3D5A40000CC46 /* CardClient.swift in Sources */,
 				80E2FDBE2A83528B0045593D /* CheckoutOrdersAPI.swift in Sources */,
 				BE0000092E1D000000000001 /* CheckoutOrderConfirming.swift in Sources */,
+				BE00000B2E1D000000000002 /* VaultedTokenSaving.swift in Sources */,
 				3B79E4F72A8503CA00C01D06 /* UpdateVaultVariables.swift in Sources */,
 				8048D28C270B9DE00072214A /* ConfirmPaymentSourceResponse.swift in Sources */,
 				3D1763A22720722A00652E1C /* CardResult.swift in Sources */,
@@ -1296,7 +1300,7 @@
 				3B783DC32B7A69C2004623DB /* FakeUpdateSetupTokenResponse.swift in Sources */,
 				BC0A82A6270B9954006E9A21 /* ConfirmPaymentSourceRequest_Tests.swift in Sources */,
 				808E3EDD2A981F240017FE46 /* MockCheckoutOrderConfirmingAPI.swift in Sources */,
-				808E3EDF2A981F390017FE46 /* MockVaultPaymentTokensAPI.swift in Sources */,
+				BE0000112E1D000000000003 /* MockVaultedTokenSavingAPI.swift in Sources */,
 				AE8A7766634621232904A26D /* CardAnalyticsEvent_Tests.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;

--- a/Sources/CardPayments/APIRequests/VaultPaymentTokensAPI.swift
+++ b/Sources/CardPayments/APIRequests/VaultPaymentTokensAPI.swift
@@ -4,7 +4,7 @@ import CorePayments
 #endif
 
 /// This class coordinates networking logic for communicating with the /graphql?UpdateVaultSetupToken API.
-class VaultPaymentTokensAPI {
+class VaultPaymentTokensAPI: VaultedTokenSaving {
     
     // MARK: - Private Properties
     
@@ -12,12 +12,11 @@ class VaultPaymentTokensAPI {
     private let networkingClient: NetworkingClient
     
     // MARK: - Initializer
-    
-    init(coreConfig: CoreConfig) {
-        self.coreConfig = coreConfig
-        self.networkingClient = HTTPNetworkingClient(coreConfig: coreConfig)
+
+    convenience init(coreConfig: CoreConfig) {
+        self.init(coreConfig: coreConfig, networkingClient: HTTPNetworkingClient(coreConfig: coreConfig))
     }
-    
+
     /// Exposed for injecting MockNetworkingClient in tests
     init(coreConfig: CoreConfig, networkingClient: NetworkingClient) {
         self.coreConfig = coreConfig

--- a/Sources/CardPayments/APIRequests/VaultedTokenSaving.swift
+++ b/Sources/CardPayments/APIRequests/VaultedTokenSaving.swift
@@ -1,0 +1,10 @@
+import Foundation
+#if canImport(CorePayments)
+import CorePayments
+#endif
+
+/// Protocol defining the interface for updating vault setup tokens.
+protocol VaultedTokenSaving {
+
+    func updateSetupToken(cardVaultRequest: CardVaultRequest) async throws -> UpdateSetupTokenResponse
+}

--- a/Sources/CardPayments/CardClient.swift
+++ b/Sources/CardPayments/CardClient.swift
@@ -7,7 +7,7 @@ import CorePayments
 public class CardClient: NSObject {
     
     private let checkoutOrdersAPI: CheckoutOrderConfirming
-    private let vaultAPI: VaultPaymentTokensAPI
+    private let vaultAPI: VaultedTokenSaving
     private let clientConfigAPI: ClientConfigUpdating
 
     private let config: CoreConfig
@@ -16,20 +16,21 @@ public class CardClient: NSObject {
 
     /// Initialize a CardClient to process card payment
     /// - Parameter config: The CoreConfig object
-    public init(config: CoreConfig) {
-        self.config = config
-        self.checkoutOrdersAPI = CheckoutOrdersAPI(coreConfig: config)
-        self.vaultAPI = VaultPaymentTokensAPI(coreConfig: config)
-        self.webAuthenticationSession = WebAuthenticationSession()
-        self.clientConfigAPI = UpdateClientConfigAPI(coreConfig: config)
-        self.analytics = AnalyticsService(coreConfig: config)
+    public convenience init(config: CoreConfig) {
+        self.init(
+            config: config,
+            checkoutOrdersAPI: CheckoutOrdersAPI(coreConfig: config),
+            vaultAPI: VaultPaymentTokensAPI(coreConfig: config),
+            clientConfigAPI: UpdateClientConfigAPI(coreConfig: config),
+            webAuthenticationSession: WebAuthenticationSession()
+        )
     }
 
     /// For internal use for testing/mocking purpose
     init(
         config: CoreConfig,
         checkoutOrdersAPI: CheckoutOrderConfirming,
-        vaultAPI: VaultPaymentTokensAPI,
+        vaultAPI: VaultedTokenSaving,
         clientConfigAPI: ClientConfigUpdating,
         webAuthenticationSession: WebAuthenticationSession
     ) {

--- a/UnitTests/CardPaymentsTests/CardClient_Tests.swift
+++ b/UnitTests/CardPaymentsTests/CardClient_Tests.swift
@@ -24,7 +24,7 @@ class CardClient_Tests: XCTestCase {
     let mockWebAuthSession = MockWebAuthenticationSession()
     var mockNetworkingClient: MockNetworkingClient!
     var mockCheckoutOrdersAPI: MockCheckoutOrderConfirmingAPI!
-    var mockVaultAPI: MockVaultPaymentTokensAPI!
+    var mockVaultAPI: MockVaultedTokenSavingAPI!
     var mockClientConfigAPI: MockClientConfigUpdatingAPI!
 
     var sut: CardClient!
@@ -38,7 +38,7 @@ class CardClient_Tests: XCTestCase {
         cardVaultRequest = CardVaultRequest(card: card, setupTokenID: "testSetupTokenId")
 
         mockCheckoutOrdersAPI = MockCheckoutOrderConfirmingAPI()
-        mockVaultAPI = MockVaultPaymentTokensAPI(coreConfig: config, networkingClient: mockNetworkingClient)
+        mockVaultAPI = MockVaultedTokenSavingAPI()
         mockClientConfigAPI = MockClientConfigUpdatingAPI()
         
         sut = CardClient(
@@ -170,6 +170,29 @@ class CardClient_Tests: XCTestCase {
         }
 
         waitForExpectations(timeout: 2, handler: nil)
+    }
+
+    func testVault_callsUpdateSetupTokenWithCorrectRequest() {
+        let setupTokenID = "testSetupTokenId"
+        let vaultRequest = CardVaultRequest(card: card, setupTokenID: setupTokenID)
+        mockVaultAPI.stubSetupTokenResponse = UpdateSetupTokenResponse(
+            updateVaultSetupToken: TokenDetails(
+                id: setupTokenID,
+                status: "APPROVED",
+                links: [TokenDetails.Link(rel: "self", href: "https://example.com")]
+            )
+        )
+
+        let expectation = expectation(description: "vault() completed")
+
+        sut.vault(vaultRequest) { _ in
+            expectation.fulfill()
+        }
+
+        waitForExpectations(timeout: 2, handler: nil)
+
+        XCTAssertEqual(mockVaultAPI.updateSetupTokenCallCount, 1)
+        XCTAssertEqual(mockVaultAPI.capturedCardVaultRequest?.setupTokenID, setupTokenID)
     }
 
     func test_vault_withThreeDSecure_browserSwitchLaunches_vaultReturnsSuccess() {

--- a/UnitTests/CardPaymentsTests/Mocks/MockVaultedTokenSavingAPI.swift
+++ b/UnitTests/CardPaymentsTests/Mocks/MockVaultedTokenSavingAPI.swift
@@ -2,24 +2,25 @@ import Foundation
 @testable import CardPayments
 @testable import CorePayments
 
-class MockVaultPaymentTokensAPI: VaultPaymentTokensAPI {
-    
+class MockVaultedTokenSavingAPI: VaultedTokenSaving {
+
     var stubSetupTokenResponse: UpdateSetupTokenResponse?
     var stubError: Error?
-
+    private(set) var updateSetupTokenCallCount = 0
     var capturedCardVaultRequest: CardVaultRequest?
-    
-    override func updateSetupToken(cardVaultRequest: CardVaultRequest) async throws -> UpdateSetupTokenResponse {
+
+    func updateSetupToken(cardVaultRequest: CardVaultRequest) async throws -> UpdateSetupTokenResponse {
+        updateSetupTokenCallCount += 1
         capturedCardVaultRequest = cardVaultRequest
-        
+
         if let stubError {
             throw stubError
         }
-        
+
         if let stubSetupTokenResponse {
             return stubSetupTokenResponse
         }
-        
+
         throw CoreSDKError(code: 0, domain: "", errorDescription: "Stubbed responses not implemented for this mock.")
     }
 }


### PR DESCRIPTION
## Summary
- Extract `VaultedTokenSaving` protocol from `VaultPaymentTokensAPI`, following the same POP pattern as #387, #388, #389
- `CardClient` now depends on the `VaultedTokenSaving` protocol instead of the concrete `VaultPaymentTokensAPI` class
- Rewrote mock as `MockVaultedTokenSavingAPI` conforming to the protocol directly (no subclassing), with `updateSetupTokenCallCount` and `capturedCardVaultRequest` tracking
- Renamed mock file to match class name (`MockVaultedTokenSavingAPI.swift`)
- Converted init to `convenience init` delegating to the designated initializer
- Internal-only change — protocol is not publicly exposed since both the API and its consumer live in the `CardPayments` module

Jira: DTPPMOBILE-465

## Test plan
- [x] All 28 unit tests pass locally (0 failures)
- [x] New test `testVault_callsUpdateSetupTokenWithCorrectRequest` verifies captured parameters
- [ ] Verify CI passes on all test targets