### PR TITLE
v3: Extract WebAuthenticating protocol (POP)

### DIFF
--- a/PayPal.xcodeproj/project.pbxproj
+++ b/PayPal.xcodeproj/project.pbxproj
@@ -142,6 +142,7 @@
 		CB22C018291049500097E592 /* PayPalPayLaterButton_Tests.swift in Sources */ = {isa = PBXBuildFile; fileRef = CB22C017291049500097E592 /* PayPalPayLaterButton_Tests.swift */; };
 		CB4BE27D2847AF6F00EA2DD1 /* SCA.swift in Sources */ = {isa = PBXBuildFile; fileRef = CB4BE27C2847AF6F00EA2DD1 /* SCA.swift */; };
 		CB4BE27E2847EA7D00EA2DD1 /* WebAuthenticationSession.swift in Sources */ = {isa = PBXBuildFile; fileRef = BE4F784827EB629100FF4C0E /* WebAuthenticationSession.swift */; };
+		BE00000D2E1D000000000004 /* WebAuthenticating.swift in Sources */ = {isa = PBXBuildFile; fileRef = BE00000C2E1D000000000004 /* WebAuthenticating.swift */; };
 		CB4BE28A28512A9800EA2DD1 /* MockQuededURLSession.swift in Sources */ = {isa = PBXBuildFile; fileRef = CB4BE28928512A9800EA2DD1 /* MockQuededURLSession.swift */; };
 		CB4BE28B2851423900EA2DD1 /* MockWebAuthenticationSession.swift in Sources */ = {isa = PBXBuildFile; fileRef = BCE8A7F627EA54A000AC301B /* MockWebAuthenticationSession.swift */; };
 		CB4BE28C2851427600EA2DD1 /* MockViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = BCE8A7F427EA544000AC301B /* MockViewController.swift */; };
@@ -313,6 +314,7 @@
 		BE4F784527EB629100FF4C0E /* PayPalWebCheckoutRequest.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = PayPalWebCheckoutRequest.swift; sourceTree = "<group>"; };
 		BE4F784627EB629100FF4C0E /* PayPalWebCheckoutClient.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = PayPalWebCheckoutClient.swift; sourceTree = "<group>"; };
 		BE4F784727EB629100FF4C0E /* PayPalWebCheckoutResult.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = PayPalWebCheckoutResult.swift; sourceTree = "<group>"; };
+		BE00000C2E1D000000000004 /* WebAuthenticating.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WebAuthenticating.swift; sourceTree = "<group>"; };
 		BE4F784827EB629100FF4C0E /* WebAuthenticationSession.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = WebAuthenticationSession.swift; sourceTree = "<group>"; };
 		BE9F36DE274859A000AFC7DA /* PaymentButtonColor.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PaymentButtonColor.swift; sourceTree = "<group>"; };
 		BE9F36E3275520E700AFC7DA /* PayPalCreditButton_Tests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PayPalCreditButton_Tests.swift; sourceTree = "<group>"; };
@@ -544,6 +546,7 @@
 		80B9F85226B8750000D67843 /* CorePayments */ = {
 			isa = PBXGroup;
 			children = (
+				BE00000C2E1D000000000004 /* WebAuthenticating.swift */,
 				BE4F784827EB629100FF4C0E /* WebAuthenticationSession.swift */,
 				06CE009826F3D1660000CC46 /* CoreConfig.swift */,
 				065A4DBB26FCD8080007014A /* CoreSDKError.swift */,
@@ -1223,6 +1226,7 @@
 				06CE009926F3D1660000CC46 /* CoreConfig.swift in Sources */,
 				BEA100EC26EFA7790036A6A5 /* HTTPMethod.swift in Sources */,
 				BEA100EE26EFA7990036A6A5 /* HTTPHeader.swift in Sources */,
+				BE00000D2E1D000000000004 /* WebAuthenticating.swift in Sources */,
 				CB4BE27E2847EA7D00EA2DD1 /* WebAuthenticationSession.swift in Sources */,
 				80E2FDC12A83535A0045593D /* TrackingEventsAPI.swift in Sources */,
 				BE0000052E1B000000000001 /* AnalyticsEventTracking.swift in Sources */,

--- a/Sources/CardPayments/CardClient.swift
+++ b/Sources/CardPayments/CardClient.swift
@@ -11,7 +11,7 @@ public class CardClient: NSObject {
     private let clientConfigAPI: ClientConfigUpdating
 
     private let config: CoreConfig
-    private let webAuthenticationSession: WebAuthenticationSession
+    private let webAuthenticationSession: WebAuthenticating
     private let analytics: AnalyticsService
 
     /// Initialize a CardClient to process card payment
@@ -32,7 +32,7 @@ public class CardClient: NSObject {
         checkoutOrdersAPI: CheckoutOrderConfirming,
         vaultAPI: VaultedTokenSaving,
         clientConfigAPI: ClientConfigUpdating,
-        webAuthenticationSession: WebAuthenticationSession
+        webAuthenticationSession: WebAuthenticating
     ) {
         self.config = config
         self.checkoutOrdersAPI = checkoutOrdersAPI

--- a/Sources/CorePayments/WebAuthenticating.swift
+++ b/Sources/CorePayments/WebAuthenticating.swift
@@ -1,0 +1,14 @@
+import Foundation
+import AuthenticationServices
+
+/// Protocol defining the interface for starting a web authentication session.
+@_documentation(visibility: private)
+public protocol WebAuthenticating {
+
+    func start(
+        url: URL,
+        context: ASWebAuthenticationPresentationContextProviding,
+        sessionDidDisplay: @escaping (Bool) -> Void,
+        sessionDidComplete: @escaping (URL?, Error?) -> Void
+    )
+}

--- a/Sources/CorePayments/WebAuthenticationSession.swift
+++ b/Sources/CorePayments/WebAuthenticationSession.swift
@@ -2,7 +2,7 @@ import Foundation
 import AuthenticationServices
 
 @_documentation(visibility: private)
-public class WebAuthenticationSession: NSObject {
+public class WebAuthenticationSession: NSObject, WebAuthenticating {
 
     public func start(
         url: URL,

--- a/Sources/PayPalWebPayments/PayPalWebCheckoutClient.swift
+++ b/Sources/PayPalWebPayments/PayPalWebCheckoutClient.swift
@@ -9,27 +9,28 @@ public class PayPalWebCheckoutClient: NSObject {
     let config: CoreConfig
 
     private let clientConfigAPI: ClientConfigUpdating
-    private let webAuthenticationSession: WebAuthenticationSession
+    private let webAuthenticationSession: WebAuthenticating
     private let networkingClient: NetworkingClient
     private let analytics: AnalyticsService
 
     /// Initialize a PayPalWebCheckoutClient to process PayPal transaction
     /// - Parameters:
     ///   - config: The CoreConfig object
-    public init(config: CoreConfig) {
-        self.config = config
-        self.webAuthenticationSession = WebAuthenticationSession()
-        self.networkingClient = HTTPNetworkingClient(coreConfig: config)
-        self.clientConfigAPI = UpdateClientConfigAPI(coreConfig: config)
-        self.analytics = AnalyticsService(coreConfig: config)
+    public convenience init(config: CoreConfig) {
+        self.init(
+            config: config,
+            networkingClient: HTTPNetworkingClient(coreConfig: config),
+            clientConfigAPI: UpdateClientConfigAPI(coreConfig: config),
+            webAuthenticationSession: WebAuthenticationSession()
+        )
     }
-    
+
     /// For internal use for testing/mocking purpose
     init(
         config: CoreConfig,
         networkingClient: NetworkingClient,
         clientConfigAPI: ClientConfigUpdating,
-        webAuthenticationSession: WebAuthenticationSession
+        webAuthenticationSession: WebAuthenticating
     ) {
         self.config = config
         self.webAuthenticationSession = webAuthenticationSession

--- a/UnitTests/CardPaymentsTests/CardClient_Tests.swift
+++ b/UnitTests/CardPaymentsTests/CardClient_Tests.swift
@@ -381,6 +381,22 @@ class CardClient_Tests: XCTestCase {
         waitForExpectations(timeout: 2, handler: nil)
     }
 
+    func testApproveOrder_withThreeDSecure_callsWebAuthSessionWithCorrectURL() {
+        mockCheckoutOrdersAPI.stubConfirmResponse = FakeConfirmPaymentResponse.withValid3DSURL
+        mockWebAuthSession.cannedResponseURL = .init(string: "sdk.ios.paypal://card/success")
+
+        let expectation = expectation(description: "approveOrder() completed")
+
+        sut.approveOrder(request: cardRequest) { _ in
+            expectation.fulfill()
+        }
+
+        waitForExpectations(timeout: 2, handler: nil)
+
+        XCTAssertEqual(mockWebAuthSession.startCallCount, 1)
+        XCTAssertEqual(mockWebAuthSession.lastLaunchedURL?.absoluteString, "https://fakeURL/helios?flow=3ds")
+    }
+
     func testApproveOrder_withThreeDSecure_browserSwitchLaunches_getOrderReturnsSuccess() {
         mockCheckoutOrdersAPI.stubConfirmResponse = FakeConfirmPaymentResponse.withValid3DSURL
 

--- a/UnitTests/PayPalWebPaymentsTests/PayPalWebCheckoutClient_Tests.swift
+++ b/UnitTests/PayPalWebPaymentsTests/PayPalWebCheckoutClient_Tests.swift
@@ -40,9 +40,10 @@ class PayPalClient_Tests: XCTestCase {
         payPalClient.vault(vaultRequest) { _ in }
         wait(for: [started], timeout: 1.0)
 
+        XCTAssertEqual(mockWebAuthenticationSession.startCallCount, 1)
         XCTAssertEqual(mockWebAuthenticationSession.lastLaunchedURL?.absoluteString, "https://sandbox.paypal.com/agreements/approve?approval_session_id=fake-token&integration_artifact=MOBILE_SDK")
     }
-    
+
     func testVault_whenLive_launchesCorrectURLInWebSession() {
         config = CoreConfig(clientID: "testClientID", environment: .live)
         mockClientConfigAPI.stubUpdateClientConfigResponse = ClientConfigResponse(updateClientConfig: true)

--- a/UnitTests/TestShared/MockWebAuthenticationSession.swift
+++ b/UnitTests/TestShared/MockWebAuthenticationSession.swift
@@ -2,24 +2,26 @@ import Foundation
 import AuthenticationServices
 @testable import CorePayments
 
-class MockWebAuthenticationSession: WebAuthenticationSession {
+class MockWebAuthenticationSession: WebAuthenticating {
 
     var cannedResponseURL: URL?
     var cannedErrorResponse: Error?
     var cannedDidDisplayResult = true
     var lastLaunchedURL: URL?
+    private(set) var startCallCount = 0
 
     var onStart: (() -> Void)?
 
-    override func start(
+    func start(
         url: URL,
         context: ASWebAuthenticationPresentationContextProviding,
         sessionDidDisplay: @escaping (Bool) -> Void,
         sessionDidComplete: @escaping (URL?, Error?) -> Void
     ) {
+        startCallCount += 1
         lastLaunchedURL = url
         onStart?()
-        
+
         sessionDidDisplay(cannedDidDisplayResult)
         sessionDidComplete(cannedResponseURL, cannedErrorResponse)
     }


### PR DESCRIPTION
## Summary
- Extract `WebAuthenticating` protocol from `WebAuthenticationSession`, following the same POP pattern as #387, #388, #389
- `CardClient` and `PayPalWebCheckoutClient` now depend on the `WebAuthenticating` protocol instead of the concrete `WebAuthenticationSession` class
- Rewrote `MockWebAuthenticationSession` to conform to the protocol directly (no subclassing of Apple framework types), with `startCallCount` and `lastLaunchedURL` tracking
- Converted public inits to `convenience init` delegating to designated initializers accepting the protocol
- Protocol is `public` with `@_documentation(visibility: private)` since consumers span multiple modules (`CardPayments`, `PayPalWebPayments`), matching the existing `WebAuthenticationSession` visibility

Jira: DTPPMOBILE-465

## Test plan
- [x] All 88 unit tests pass locally (28 CardPayments + 18 PayPalWebPayments + 42 CorePayments, 0 failures)
- [x] New test `testApproveOrder_withThreeDSecure_callsWebAuthSessionWithCorrectURL` verifies captured URL in CardClient
- [x] Added `startCallCount` assertion to existing `testVault_whenSandbox_launchesCorrectURLInWebSession` in PayPalWebCheckoutClient
- [ ] Verify CI passes on all test targets