### PR TITLE
[Patch] App Switch — URL Opening Reliability

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,11 @@
 
 # PayPal iOS SDK Release Notes
 
+## unreleased
+
+* CorePayments
+  * Add `options` parameter to `URLOpener openURL()` method
+
 ## 2.0.1 (2025-11-03)
 
 * PayPalWebPayments

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,8 +3,6 @@
 
 ## unreleased
 
-* CorePayments
-  * Add `options` parameter to `URLOpener openURL()` method
 
 ## 2.0.1 (2025-11-03)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,9 +1,6 @@
 
 # PayPal iOS SDK Release Notes
 
-## unreleased
-
-
 ## 2.0.1 (2025-11-03)
 
 * PayPalWebPayments

--- a/Sources/CorePayments/UIApplication+URLOpener.swift
+++ b/Sources/CorePayments/UIApplication+URLOpener.swift
@@ -2,20 +2,35 @@ import UIKit
 
 @_documentation(visibility: private)
 public protocol URLOpener {
-    func open(_ url: URL, completionHandler completion: ((Bool) -> Void)?)
+    func open(
+        _ url: URL,
+        options: [UIApplication.OpenExternalURLOptionsKey: Any],
+        completionHandler completion: ((Bool) -> Void)?
+    )
     func isPayPalAppInstalled() -> Bool
 }
 
-extension UIApplication: URLOpener {
+@_documentation(visibility: private)
+public struct DefaultURLOpener: URLOpener {
+
+    private let application: UIApplication
+
+    public init(application: UIApplication = .shared) {
+        self.application = application
+    }
+
+    public func open(
+        _ url: URL,
+        options: [UIApplication.OpenExternalURLOptionsKey: Any],
+        completionHandler completion: ((Bool) -> Void)?
+    ) {
+        application.open(url, options: options, completionHandler: completion)
+    }
 
     public func isPayPalAppInstalled() -> Bool {
         guard let payPalURL = URL(string: "paypal://") else {
             return false
         }
-        return canOpenURL(payPalURL)
-    }
-
-    public func open(_ url: URL, completionHandler completion: ((Bool) -> Void)?) {
-        UIApplication.shared.open(url, options: [:], completionHandler: completion)
+        return application.canOpenURL(payPalURL)
     }
 }

--- a/Sources/CorePayments/UIApplication+URLOpener.swift
+++ b/Sources/CorePayments/UIApplication+URLOpener.swift
@@ -10,6 +10,12 @@ public protocol URLOpener {
     func isPayPalAppInstalled() -> Bool
 }
 
+public extension URLOpener {
+    func open(_ url: URL, completionHandler: ((Bool) -> Void)? = nil) {
+        open(url, universalLinksOnly: true, completionHandler: completionHandler)
+    }
+}
+
 extension UIApplication: URLOpener {
 
     public func isPayPalAppInstalled() -> Bool {
@@ -21,7 +27,7 @@ extension UIApplication: URLOpener {
 
     public func open(
         _ url: URL,
-        universalLinksOnly: Bool,
+        universalLinksOnly: Bool = true,
         completionHandler completion: ((Bool) -> Void)?
     ) {
         let options: [UIApplication.OpenExternalURLOptionsKey: Any] = universalLinksOnly ? [.universalLinksOnly: true] : [:]

--- a/Sources/CorePayments/UIApplication+URLOpener.swift
+++ b/Sources/CorePayments/UIApplication+URLOpener.swift
@@ -11,7 +11,7 @@ public protocol URLOpener {
 }
 
 @_documentation(visibility: private)
-public struct DefaultURLOpener: URLOpener {
+internal struct DefaultURLOpener: URLOpener {
 
     private let application: UIApplication
 

--- a/Sources/CorePayments/UIApplication+URLOpener.swift
+++ b/Sources/CorePayments/UIApplication+URLOpener.swift
@@ -4,33 +4,27 @@ import UIKit
 public protocol URLOpener {
     func open(
         _ url: URL,
-        options: [UIApplication.OpenExternalURLOptionsKey: Any],
+        universalLinksOnly: Bool,
         completionHandler completion: ((Bool) -> Void)?
     )
     func isPayPalAppInstalled() -> Bool
 }
 
-@_documentation(visibility: private)
-internal struct DefaultURLOpener: URLOpener {
-
-    private let application: UIApplication
-
-    public init(application: UIApplication = .shared) {
-        self.application = application
-    }
-
-    public func open(
-        _ url: URL,
-        options: [UIApplication.OpenExternalURLOptionsKey: Any],
-        completionHandler completion: ((Bool) -> Void)?
-    ) {
-        application.open(url, options: options, completionHandler: completion)
-    }
+extension UIApplication: URLOpener {
 
     public func isPayPalAppInstalled() -> Bool {
         guard let payPalURL = URL(string: "paypal://") else {
             return false
         }
-        return application.canOpenURL(payPalURL)
+        return canOpenURL(payPalURL)
+    }
+
+    public func open(
+        _ url: URL,
+        universalLinksOnly: Bool,
+        completionHandler completion: ((Bool) -> Void)?
+    ) {
+        let options: [UIApplication.OpenExternalURLOptionsKey: Any] = universalLinksOnly ? [.universalLinksOnly: true] : [:]
+        open(url, options: options, completionHandler: completion)
     }
 }

--- a/Sources/PayPalWebPayments/PayPalWebCheckoutClient.swift
+++ b/Sources/PayPalWebPayments/PayPalWebCheckoutClient.swift
@@ -14,7 +14,7 @@ public class PayPalWebCheckoutClient: NSObject {
 
     var appSwitchCompletion: ((Result<PayPalWebCheckoutResult, CoreSDKError>) -> Void)?
     var vaultAppSwitchCompletion: ((Result<PayPalVaultResult, CoreSDKError>) -> Void)?
-    var application: URLOpener = UIApplication.shared
+    var application: URLOpener = DefaultURLOpener()
 
     private let clientConfigAPI: UpdateClientConfigAPI
     private let webAuthenticationSession: WebAuthenticationSession
@@ -397,7 +397,7 @@ public class PayPalWebCheckoutClient: NSObject {
     @MainActor
     private func openURL(_ url: URL) async -> Bool {
         await withCheckedContinuation { continuation in
-            application.open(url) { success in
+            application.open(url, options: [:]) { success in
                 continuation.resume(returning: success)
             }
         }

--- a/Sources/PayPalWebPayments/PayPalWebCheckoutClient.swift
+++ b/Sources/PayPalWebPayments/PayPalWebCheckoutClient.swift
@@ -190,13 +190,14 @@ public class PayPalWebCheckoutClient: NSObject {
             }
 
             // Try to open the PayPal app (or deep link). If opening fails, fall back.
-            let opened = await openURL(url)
+            let opened = await openURLAppSwitchOnly(url)
 
             if opened {
                 // TODO: align with android on app switch event names, communicate with analytics team on new events
                 analyticsService?.sendEvent("paypal-web-payments:checkout:app-switch-open:succeeded")
                 return .launched
             } else {
+                // Universal Link cannot be resolved
                 analyticsService?.sendEvent("paypal-web-payments:checkout:app-switch-open:failed")
                 // We attempted to launch but couldn't. Clear the saved completion so a stray return URL can't complete.
                 await MainActor.run { [weak self] in
@@ -395,9 +396,9 @@ public class PayPalWebCheckoutClient: NSObject {
     }
 
     @MainActor
-    private func openURL(_ url: URL) async -> Bool {
+    private func openURLAppSwitchOnly(_ url: URL) async -> Bool {
         await withCheckedContinuation { continuation in
-            application.open(url, options: [:]) { success in
+            application.open(url, options: [.universalLinksOnly: true]) { success in
                 continuation.resume(returning: success)
             }
         }

--- a/Sources/PayPalWebPayments/PayPalWebCheckoutClient.swift
+++ b/Sources/PayPalWebPayments/PayPalWebCheckoutClient.swift
@@ -398,7 +398,7 @@ public class PayPalWebCheckoutClient: NSObject {
     @MainActor
     private func openURLAppSwitchOnly(_ url: URL) async -> Bool {
         await withCheckedContinuation { continuation in
-            urlOpener.open(url, universalLinksOnly: true) { success in
+            urlOpener.open(url) { success in
                 continuation.resume(returning: success)
             }
         }

--- a/Sources/PayPalWebPayments/PayPalWebCheckoutClient.swift
+++ b/Sources/PayPalWebPayments/PayPalWebCheckoutClient.swift
@@ -65,7 +65,7 @@ public class PayPalWebCheckoutClient: NSObject {
         analyticsService?.sendEvent("paypal-web-payments:checkout:started")
 
         let completionOnce = makeCompletionOnce(completion)
-        let appInstalled = self.urlOpener.isPayPalAppInstalled()
+        let appInstalled = urlOpener.isPayPalAppInstalled()
 
         Task {
             if request.appSwitchIfEligible && appInstalled {
@@ -190,7 +190,7 @@ public class PayPalWebCheckoutClient: NSObject {
             }
 
             // Try to open the PayPal app (or deep link). If opening fails, fall back.
-            let opened = await openURLAppSwitchOnly(url)
+            let opened = await attemptAppSwitch(with: url)
 
             if opened {
                 // TODO: align with android on app switch event names, communicate with analytics team on new events
@@ -396,7 +396,7 @@ public class PayPalWebCheckoutClient: NSObject {
     }
 
     @MainActor
-    private func openURLAppSwitchOnly(_ url: URL) async -> Bool {
+    private func attemptAppSwitch(with url: URL) async -> Bool {
         await withCheckedContinuation { continuation in
             urlOpener.open(url) { success in
                 continuation.resume(returning: success)

--- a/Sources/PayPalWebPayments/PayPalWebCheckoutClient.swift
+++ b/Sources/PayPalWebPayments/PayPalWebCheckoutClient.swift
@@ -14,7 +14,7 @@ public class PayPalWebCheckoutClient: NSObject {
 
     var appSwitchCompletion: ((Result<PayPalWebCheckoutResult, CoreSDKError>) -> Void)?
     var vaultAppSwitchCompletion: ((Result<PayPalVaultResult, CoreSDKError>) -> Void)?
-    var application: URLOpener = DefaultURLOpener()
+    var urlOpener: URLOpener = DefaultURLOpener()
 
     private let clientConfigAPI: UpdateClientConfigAPI
     private let webAuthenticationSession: WebAuthenticationSession
@@ -65,7 +65,7 @@ public class PayPalWebCheckoutClient: NSObject {
         analyticsService?.sendEvent("paypal-web-payments:checkout:started")
 
         let completionOnce = makeCompletionOnce(completion)
-        let appInstalled = self.application.isPayPalAppInstalled()
+        let appInstalled = self.urlOpener.isPayPalAppInstalled()
 
         Task {
             if request.appSwitchIfEligible && appInstalled {
@@ -398,7 +398,7 @@ public class PayPalWebCheckoutClient: NSObject {
     @MainActor
     private func openURLAppSwitchOnly(_ url: URL) async -> Bool {
         await withCheckedContinuation { continuation in
-            application.open(url, options: [.universalLinksOnly: true]) { success in
+            urlOpener.open(url, options: [.universalLinksOnly: true]) { success in
                 continuation.resume(returning: success)
             }
         }

--- a/Sources/PayPalWebPayments/PayPalWebCheckoutClient.swift
+++ b/Sources/PayPalWebPayments/PayPalWebCheckoutClient.swift
@@ -14,7 +14,7 @@ public class PayPalWebCheckoutClient: NSObject {
 
     var appSwitchCompletion: ((Result<PayPalWebCheckoutResult, CoreSDKError>) -> Void)?
     var vaultAppSwitchCompletion: ((Result<PayPalVaultResult, CoreSDKError>) -> Void)?
-    var urlOpener: URLOpener = DefaultURLOpener()
+    var urlOpener: URLOpener = UIApplication.shared
 
     private let clientConfigAPI: UpdateClientConfigAPI
     private let webAuthenticationSession: WebAuthenticationSession
@@ -398,7 +398,7 @@ public class PayPalWebCheckoutClient: NSObject {
     @MainActor
     private func openURLAppSwitchOnly(_ url: URL) async -> Bool {
         await withCheckedContinuation { continuation in
-            urlOpener.open(url, options: [.universalLinksOnly: true]) { success in
+            urlOpener.open(url, universalLinksOnly: true) { success in
                 continuation.resume(returning: success)
             }
         }

--- a/UnitTests/PayPalWebPaymentsTests/PayPalClients_CheckoutAppSwitch_Toggle_Tests.swift
+++ b/UnitTests/PayPalWebPaymentsTests/PayPalClients_CheckoutAppSwitch_Toggle_Tests.swift
@@ -124,6 +124,32 @@ class PayPalClient_CheckoutAppSwitch_Toggle_tests: XCTestCase {
         await fulfillment(of: [expectation], timeout: 1.0)
     }
 
+    func test_AppSwitch_Eligible_OpensURLWithUniversalLinksOnly() async throws {
+        mockURLOpener.mockIsPayPalAppInstalled = true
+
+        let request = PayPalWebCheckoutRequest(orderID: "test-order-id", appSwitchIfEligible: true)
+
+        let eligibleResponse = AppSwitchEligibility(
+            appSwitchEligible: true,
+            redirectURL: "https://www.sandbox.paypal.com/app-switch-checkout?appSwitchEligible=true&token=test-order-id&tokenType=ORDER_ID",
+            ineligibleReason: nil
+        )
+        mockPatchCCOAPI.stubEligibilityResponse = eligibleResponse
+        mockURLOpener.mockOpenURLSuccess = true
+
+        let urlOpenedExpectation = XCTestExpectation(description: "URL opened")
+        mockURLOpener.didOpenURLHandler = {
+            urlOpenedExpectation.fulfill()
+        }
+
+        payPalClient.start(request: request) { _ in }
+
+        await fulfillment(of: [urlOpenedExpectation], timeout: 1.0)
+
+        XCTAssertNotNil(mockURLOpener.lastOpenedURL)
+        XCTAssertEqual(mockURLOpener.lastUniversalLinksOnly, true)
+    }
+
     func test_AppSwitch_Failure_Invokes_WebFlow() async throws {
         mockURLOpener.mockIsPayPalAppInstalled = true
 

--- a/UnitTests/PayPalWebPaymentsTests/PayPalClients_CheckoutAppSwitch_Toggle_Tests.swift
+++ b/UnitTests/PayPalWebPaymentsTests/PayPalClients_CheckoutAppSwitch_Toggle_Tests.swift
@@ -33,7 +33,7 @@ class PayPalClient_CheckoutAppSwitch_Toggle_tests: XCTestCase {
             patchCCOAPI: mockPatchCCOAPI,
             webAuthenticationSession: mockWebAuthenticationSession
         )
-        payPalClient.application = mockURLOpener
+        payPalClient.urlOpener = mockURLOpener
     }
 
     func test_AppSwitchIfEligible_IsFalseByDefault() {

--- a/UnitTests/TestShared/MockURLOpener.swift
+++ b/UnitTests/TestShared/MockURLOpener.swift
@@ -13,7 +13,7 @@ class MockURLOpener: URLOpener {
         return mockIsPayPalAppInstalled
     }
 
-    func open(_ url: URL, options: [UIApplication.OpenExternalURLOptionsKey: Any], completionHandler completion: ((Bool) -> Void)?) {
+    func open(_ url: URL, universalLinksOnly: Bool, completionHandler completion: ((Bool) -> Void)?) {
         lastOpenedURL = url
         completion?(mockOpenURLSuccess)
         didOpenURLHandler?()

--- a/UnitTests/TestShared/MockURLOpener.swift
+++ b/UnitTests/TestShared/MockURLOpener.swift
@@ -1,4 +1,4 @@
-import Foundation
+import UIKit
 @testable import CorePayments
 
 class MockURLOpener: URLOpener {
@@ -13,7 +13,7 @@ class MockURLOpener: URLOpener {
         return mockIsPayPalAppInstalled
     }
 
-    func open(_ url: URL, completionHandler completion: ((Bool) -> Void)?) {
+    func open(_ url: URL, options: [UIApplication.OpenExternalURLOptionsKey: Any], completionHandler completion: ((Bool) -> Void)?) {
         lastOpenedURL = url
         completion?(mockOpenURLSuccess)
         didOpenURLHandler?()

--- a/UnitTests/TestShared/MockURLOpener.swift
+++ b/UnitTests/TestShared/MockURLOpener.swift
@@ -1,4 +1,4 @@
-import UIKit
+import Foundation
 @testable import CorePayments
 
 class MockURLOpener: URLOpener {
@@ -6,6 +6,7 @@ class MockURLOpener: URLOpener {
     var mockIsPayPalAppInstalled = false
     var mockOpenURLSuccess = true
     var lastOpenedURL: URL?
+    var lastUniversalLinksOnly: Bool?
 
     var didOpenURLHandler: (() -> Void)?
 
@@ -15,6 +16,7 @@ class MockURLOpener: URLOpener {
 
     func open(_ url: URL, universalLinksOnly: Bool, completionHandler completion: ((Bool) -> Void)?) {
         lastOpenedURL = url
+        lastUniversalLinksOnly = universalLinksOnly
         completion?(mockOpenURLSuccess)
         didOpenURLHandler?()
     }


### PR DESCRIPTION
### Reason for changes

AppSwitch must open the PayPal app via Universal Link, not fall back to Safari. This requires passing `universalLinksOnly: true` to `UIApplication.open(_:options:completionHandler:)`.
Not doing so will result in sending false positive `paypal-web-payments:checkout:app-switch-open:succeeded` analytics event, instead of expected `paypal-web-payments:checkout:app-switch-open:failed`. 

### Summary of changes

- Add `options` parameter to URLOpener `open(_ url)` method.
- Replace the `UIApplication: URLOpener` extension with a `DefaultURLOpener` wrapper that forwards to UIApplication without method shadowing.

### Checklist

- [x] Added a changelog entry

### Authors
> List GitHub usernames for everyone who contributed to this pull request.

- NastassiaRodzik

### Screenshots / Video

**Happy Path:** 

Video:
https://github.com/user-attachments/assets/2589ab1c-dcf4-43cb-b65e-d99299a0fa28

Analytics: 
```
paypal-web-payments:checkout:started 
paypal-web-payments:checkout:app-switch-open:succeeded 
paypal-web-payments:checkout:succeeded 
```

**Universal link cannot be opened scenario:** 

Video: 

https://github.com/user-attachments/assets/b7c10173-aada-407b-9a4a-e39f67cbdffc

Analytics **before** the fix: 

```
paypal-web-payments:checkout:started
paypal-web-payments:checkout:app-switch-open:succeeded  // despite App Switch failure
paypal-web-payments:checkout:succeeded
```

Analytics **after** the fix: 

```
paypal-web-payments:checkout:started 
paypal-web-payments:checkout:app-switch-open:failed 
paypal-web-payments:checkout:fallback-to-web:cannot_open_url  // fallback to web event is sent, as expected 
paypal-web-payments:checkout:succeeded 
```

