### PR TITLE
[Patch] Analytics — app-switch-open:succeeded  can be lost on app suspension 

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,13 @@
 
 # PayPal iOS SDK Release Notes
 
+## UNRELEASED
+
+* CorePayments
+  * Add `sendEventWithBackgroundProtection(_:correlationID:buttonType:)` to `AnalyticsService` to request additional runtime via `beginBackgroundTask` when sending analytics during app backgrounding
+* PayPalWebPayments
+  * Use background-protected analytics delivery for the App Switch open success event to improve delivery when the merchant app transitions to the background
+
 ## 2.0.1 (2025-11-03)
 
 * PayPalWebPayments

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,13 +1,6 @@
 
 # PayPal iOS SDK Release Notes
 
-## UNRELEASED
-
-* CorePayments
-  * Add `sendEventWithBackgroundProtection(_:correlationID:buttonType:)` to `AnalyticsService` to request additional runtime via `beginBackgroundTask` when sending analytics during app backgrounding
-* PayPalWebPayments
-  * Use background-protected analytics delivery for the App Switch open success event to improve delivery when the merchant app transitions to the background
-
 ## 2.0.1 (2025-11-03)
 
 * PayPalWebPayments

--- a/Sources/CorePayments/Networking/AnalyticsService.swift
+++ b/Sources/CorePayments/Networking/AnalyticsService.swift
@@ -120,6 +120,7 @@ public struct AnalyticsService {
             var bgTaskID: UIBackgroundTaskIdentifier = .invalid
             var eventTask: Task<Void, Never>?
 
+            @MainActor
             func endBackgroundTaskIfNeeded() {
                 guard bgTaskID != .invalid else { return }
                 UIApplication.shared.endBackgroundTask(bgTaskID)

--- a/Sources/CorePayments/Networking/AnalyticsService.swift
+++ b/Sources/CorePayments/Networking/AnalyticsService.swift
@@ -43,15 +43,25 @@ public struct AnalyticsService {
     /// - Parameter name: Event name string used to identify this unique event in FPTI.
     /// - Parameter correlationID: correlation ID associated with the request
     /// - Parameter buttonType: The type of button
-    public func sendEvent(_ name: String, correlationID: String? = nil, buttonType: String? = nil) {
+    /// - Parameter withBackgroundProtection: When `true`, requests additional runtime if the app enters
+    ///   the background before the network request completes. Delivery is best-effort and not guaranteed.
+    public func sendEvent(
+        _ name: String,
+        correlationID: String? = nil,
+        buttonType: String? = nil,
+        withBackgroundProtection: Bool = false
+    ) {
+        guard !withBackgroundProtection else {
+            sendEventWithBackgroundProtection(name, correlationID: correlationID, buttonType: buttonType)
+            return
+        }
+
         Task(priority: .background) {
             await performEventRequest(name, correlationID: correlationID, buttonType: buttonType)
         }
     }
 
-    /// Sends an analytics event and requests additional runtime if the app enters the background before
-    /// the network request completes. Delivery is best-effort and not guaranteed.
-    public func sendEventWithBackgroundProtection(
+    private func sendEventWithBackgroundProtection(
         _ name: String,
         correlationID: String? = nil,
         buttonType: String? = nil

--- a/Sources/CorePayments/Networking/AnalyticsService.swift
+++ b/Sources/CorePayments/Networking/AnalyticsService.swift
@@ -77,7 +77,17 @@ public struct AnalyticsService {
         startTime: Int? = nil
     ) {
         if withBackgroundProtection {
-            sendEventWithBackgroundProtection(name, correlationID: correlationID, buttonType: buttonType, appSwitchURL: appSwitchURL, errorDescription: errorDescription, isCachedSession: isCachedSession, isVaultRequest: isVaultRequest, shopperSessionId: shopperSessionId, startTime: startTime)
+            sendEventWithBackgroundProtection(
+                name,
+                correlationID: correlationID,
+                buttonType: buttonType,
+                appSwitchURL: appSwitchURL,
+                errorDescription: errorDescription,
+                isCachedSession: isCachedSession,
+                isVaultRequest: isVaultRequest,
+                shopperSessionId: shopperSessionId,
+                startTime: startTime
+            )
             return
         }
         Task(priority: .background) {
@@ -125,16 +135,16 @@ public struct AnalyticsService {
 
             eventTask = Task(priority: .utility) {
                 await performEventRequest(
-                  name,
-                  correlationID: correlationID,
-                  buttonType: buttonType,
-                  appSwitchURL: appSwitchURL,
-                  errorDescription: errorDescription,
-                  isCachedSession: isCachedSession,
-                  isVaultRequest: isVaultRequest,
-                  shopperSessionId: shopperSessionId,
-                  startTime: startTime
-              )
+                    name,
+                    correlationID: correlationID,
+                    buttonType: buttonType,
+                    appSwitchURL: appSwitchURL,
+                    errorDescription: errorDescription,
+                    isCachedSession: isCachedSession,
+                    isVaultRequest: isVaultRequest,
+                    shopperSessionId: shopperSessionId,
+                    startTime: startTime
+                )
             }
 
             await eventTask?.value
@@ -166,8 +176,8 @@ public struct AnalyticsService {
         shopperSessionId: String? = nil,
         startTime: Int? = nil
     ) async {
-      guard !Task.isCancelled else { return }  
-      do {
+        guard !Task.isCancelled else { return }
+        do {
             let clientID = coreConfig.clientID
 
             let eventData = AnalyticsEventData(

--- a/Sources/CorePayments/Networking/AnalyticsService.swift
+++ b/Sources/CorePayments/Networking/AnalyticsService.swift
@@ -1,4 +1,4 @@
-import Foundation
+import UIKit
 
 /// Constructs `AnalyticsEventData` models and sends FPTI analytics events.
 @_documentation(visibility: private)
@@ -49,14 +49,47 @@ public struct AnalyticsService {
         }
     }
 
+    /// Sends an analytics event and requests additional runtime if the app enters the background before
+    /// the network request completes. Delivery is best-effort and not guaranteed.
+    public func sendEventWithBackgroundProtection(
+        _ name: String,
+        correlationID: String? = nil,
+        buttonType: String? = nil
+    ) {
+        Task { @MainActor in
+            var bgTaskID: UIBackgroundTaskIdentifier = .invalid
+            var eventTask: Task<Void, Never>?
+
+            func endBackgroundTaskIfNeeded() {
+                guard bgTaskID != .invalid else { return }
+                UIApplication.shared.endBackgroundTask(bgTaskID)
+                bgTaskID = .invalid
+            }
+
+            bgTaskID = UIApplication.shared.beginBackgroundTask(withName: "fpti-event") {
+                eventTask?.cancel()
+                endBackgroundTaskIfNeeded()
+            }
+
+            eventTask = Task(priority: .utility) {
+                await performEventRequest(name, correlationID: correlationID, buttonType: buttonType)
+            }
+
+            await eventTask?.value
+            endBackgroundTaskIfNeeded()
+        }
+    }
+
     // MARK: - Internal Methods
-    
+
     /// Exposed to be able to execute this function synchronously in unit tests
     /// - Parameters:
     ///   - name: Event name string used to identify this unique event in FPTI
     ///   - correlationID: correlation ID associated with the request
     ///   - buttonType: The type of button
     func performEventRequest(_ name: String, correlationID: String? = nil, buttonType: String? = nil) async {
+        guard !Task.isCancelled else { return }
+
         do {
             let clientID = coreConfig.clientID
             
@@ -72,6 +105,9 @@ public struct AnalyticsService {
             
             let (_) = try await trackingEventsAPI.sendEvent(with: eventData)
         } catch {
+            if Task.isCancelled || error is CancellationError {
+                return
+            }
             NSLog("[PayPal SDK] Failed to send analytics: %@", error.localizedDescription)
         }
     }

--- a/Sources/CorePayments/Networking/AnalyticsService.swift
+++ b/Sources/CorePayments/Networking/AnalyticsService.swift
@@ -118,7 +118,9 @@ public struct AnalyticsService {
 
             bgTaskID = UIApplication.shared.beginBackgroundTask(withName: "fpti-event") {
                 eventTask?.cancel()
-                endBackgroundTaskIfNeeded()
+                Task { @MainActor in
+                    endBackgroundTaskIfNeeded()
+                }
             }
 
             eventTask = Task(priority: .utility) {

--- a/Sources/PayPalWebPayments/PayPalWebCheckoutClient.swift
+++ b/Sources/PayPalWebPayments/PayPalWebCheckoutClient.swift
@@ -194,7 +194,7 @@ public class PayPalWebCheckoutClient: NSObject {
 
             if opened {
                 // TODO: align with android on app switch event names, communicate with analytics team on new events
-                analyticsService?.sendEvent("paypal-web-payments:checkout:app-switch-open:succeeded")
+                analyticsService?.sendEventWithBackgroundProtection("paypal-web-payments:checkout:app-switch-open:succeeded")
                 return .launched
             } else {
                 analyticsService?.sendEvent("paypal-web-payments:checkout:app-switch-open:failed")

--- a/Sources/PayPalWebPayments/PayPalWebCheckoutClient.swift
+++ b/Sources/PayPalWebPayments/PayPalWebCheckoutClient.swift
@@ -194,7 +194,7 @@ public class PayPalWebCheckoutClient: NSObject {
 
             if opened {
                 // TODO: align with android on app switch event names, communicate with analytics team on new events
-                analyticsService?.sendEventWithBackgroundProtection("paypal-web-payments:checkout:app-switch-open:succeeded")
+                analyticsService?.sendEvent("paypal-web-payments:checkout:app-switch-open:succeeded", withBackgroundProtection: true)
                 return .launched
             } else {
                 analyticsService?.sendEvent("paypal-web-payments:checkout:app-switch-open:failed")

--- a/Sources/PayPalWebPayments/PayPalWebCheckoutClient.swift
+++ b/Sources/PayPalWebPayments/PayPalWebCheckoutClient.swift
@@ -620,8 +620,9 @@ public class PayPalWebCheckoutClient: NSObject {
         if opened {
             analyticsService?.sendEvent(
                 "\(handlers.eventPrefix):app-switch:succeeded",
+                withBackgroundProtection: true,
                 appSwitchURL: url,
-                shopperSessionId: shopperSessionID
+                shopperSessionId: shopperSessionID,
             )
             return .launched
         } else {

--- a/UnitTests/PaymentsCoreTests/AnalyticsService_Tests.swift
+++ b/UnitTests/PaymentsCoreTests/AnalyticsService_Tests.swift
@@ -23,11 +23,8 @@ class AnalyticsService_Tests: XCTestCase {
 
     func testSendEvent_dispatchesAnalyticsEvent() async {
         mockTrackingEventsAPI.stubHTTPResponse = HTTPResponse(status: 200, body: nil)
-        let expectation = expectation(description: "analytics sent")
-        mockTrackingEventsAPI.onSendEvent = { expectation.fulfill() }
 
-        sut.sendEvent("some-event", correlationID: "fake-correlation-id")
-        await fulfillment(of: [expectation], timeout: 2.0)
+        await sut.performEventRequest("some-event", correlationID: "fake-correlation-id")
 
         XCTAssertEqual(mockTrackingEventsAPI.capturedAnalyticsEventData?.eventName, "some-event")
         XCTAssertEqual(mockTrackingEventsAPI.capturedAnalyticsEventData?.correlationID, "fake-correlation-id")

--- a/UnitTests/PaymentsCoreTests/AnalyticsService_Tests.swift
+++ b/UnitTests/PaymentsCoreTests/AnalyticsService_Tests.swift
@@ -20,6 +20,49 @@ class AnalyticsService_Tests: XCTestCase {
     }
 
     // MARK: - sendEvent()
+
+    func testSendEvent_dispatchesAnalyticsEvent() async {
+        mockTrackingEventsAPI.stubHTTPResponse = HTTPResponse(status: 200, body: nil)
+        let expectation = expectation(description: "analytics sent")
+        mockTrackingEventsAPI.onSendEvent = { expectation.fulfill() }
+
+        sut.sendEvent("some-event", correlationID: "fake-correlation-id")
+        await fulfillment(of: [expectation], timeout: 2.0)
+
+        XCTAssertEqual(mockTrackingEventsAPI.capturedAnalyticsEventData?.eventName, "some-event")
+        XCTAssertEqual(mockTrackingEventsAPI.capturedAnalyticsEventData?.correlationID, "fake-correlation-id")
+    }
+
+    func testSendEvent_withBackgroundProtection_dispatchesAnalyticsEvent() async {
+        mockTrackingEventsAPI.stubHTTPResponse = HTTPResponse(status: 200, body: nil)
+        let expectation = expectation(description: "background-protected analytics sent")
+        mockTrackingEventsAPI.onSendEvent = { expectation.fulfill() }
+
+        sut.sendEvent("bg-event", withBackgroundProtection: true)
+        await fulfillment(of: [expectation], timeout: 2.0)
+
+        XCTAssertEqual(mockTrackingEventsAPI.capturedAnalyticsEventData?.eventName, "bg-event")
+    }
+
+    func testPerformEventRequest_whenTaskCancelled_doesNotCallAPI() async {
+        mockTrackingEventsAPI.stubHTTPResponse = HTTPResponse(status: 200, body: nil)
+        mockTrackingEventsAPI.sendEventDelay = 500_000_000
+
+        let task = Task {
+            await sut.performEventRequest("cancelled-event")
+        }
+        try? await Task.sleep(nanoseconds: 50_000_000)
+        task.cancel()
+        await task.value
+
+        XCTAssertNil(mockTrackingEventsAPI.capturedAnalyticsEventData)
+    }
+
+    func testPerformEventRequest_whenAPIThrowsCancellationError_doesNotThrow() async {
+        mockTrackingEventsAPI.stubError = CancellationError()
+
+        await sut.performEventRequest("some-event")
+    }
         
     func testSendEvent_sendsAppropriateAnalyticsEventData() async {
         await sut.performEventRequest("some-event", correlationID: "fake-correlation-id")

--- a/UnitTests/PaymentsCoreTests/Mocks/MockTrackingEventsAPI.swift
+++ b/UnitTests/PaymentsCoreTests/Mocks/MockTrackingEventsAPI.swift
@@ -5,11 +5,18 @@ class MockTrackingEventsAPI: TrackingEventsAPI {
     
     var stubHTTPResponse: HTTPResponse?
     var stubError: Error?
+    var sendEventDelay: UInt64 = 0
+    var onSendEvent: (() -> Void)?
     
     var capturedAnalyticsEventData: AnalyticsEventData?
     
     override func sendEvent(with analyticsEventData: AnalyticsEventData) async throws -> HTTPResponse {
+        if sendEventDelay > 0 {
+            try await Task.sleep(nanoseconds: sendEventDelay)
+        }
+
         capturedAnalyticsEventData = analyticsEventData
+        onSendEvent?()
         
         if let stubError {
             throw stubError


### PR DESCRIPTION
### Reason for changes

The problem: `AnalyticsService.sendEvent()` wraps its HTTP request in a Swift `Task(priority: .background)`.
`Task(priority: .background)` sets Swift concurrency thread priority — it is **not** an iOS background task. When the app is suspended by the OS (which happens immediately after UIApplication.open() successfully launches the PayPal app), all Swift tasks are frozen and the network request is never sent.

Analytics events at risk: `"paypal-web-payments:checkout:app-switch-open:succeeded"`

### Summary of changes

- Add `sendEventWithBackgroundProtection` method that protects Analytics events with an iOS background task.

### Checklist

- [x] Added a changelog entry

### Authors
> List GitHub usernames for everyone who contributed to this pull request.

- NastassiaRodzik

### Evidence

When using `sendEventWithBackgroundProtection`:

App Switch flow:
https://github.com/user-attachments/assets/0f6d82b6-933c-4cd3-8fe7-d98d84564256

Analytics: 
```
paypal-web-payments:checkout:started - sent ✅ 
paypal-web-payments:checkout:app-switch-open:succeeded - sent with BG Protection ✅ 
```
