### PR TITLE
Payment button analytics fix

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,14 @@
 
 # PayPal iOS SDK Release Notes
 
+## Unreleased
+
+* PaymentButtons
+  * Add `configure(coreConfig:orderID:)` to `PaymentButton` to initialize button analytics with a real `CoreConfig` and optional `orderID`, replacing the placeholder configuration
+  * Add optional `coreConfig` and `orderID` parameters to the SwiftUI `Representable` initializers for `PayPalButton`, `PayPalCreditButton`, and `PayPalPayLaterButton`
+* CorePayments
+  * Update `AnalyticsService.init(coreConfig:orderID:)` to accept an optional `orderID`
+
 ## 2.0.1 (2025-11-03)
 
 * PayPalWebPayments

--- a/Demo/Demo/PayPalWebPayments/PayPalWebPaymentsView/PayPalWebButtonsView.swift
+++ b/Demo/Demo/PayPalWebPayments/PayPalWebPaymentsView/PayPalWebButtonsView.swift
@@ -27,15 +27,31 @@ struct PayPalWebButtonsView: View {
                 ZStack {
                     switch selectedFundingSource {
                     case .paypalCredit:
-                        PayPalCreditButton.Representable(color: .black, size: .full) {
+                        PayPalCreditButton.Representable(
+                            color: .black,
+                            size: .full,
+                            coreConfig: payPalWebViewModel.coreConfig,
+                            orderID: payPalWebViewModel.orderID
+                        ) {
                             payPalWebViewModel.paymentButtonTapped(funding: .paypalCredit)
                         }
                     case .paylater:
-                        PayPalPayLaterButton.Representable(color: .silver, edges: .softEdges, size: .full) {
+                        PayPalPayLaterButton.Representable(
+                            color: .silver,
+                            edges: .softEdges,
+                            size: .full,
+                            coreConfig: payPalWebViewModel.coreConfig,
+                            orderID: payPalWebViewModel.orderID
+                        ) {
                             payPalWebViewModel.paymentButtonTapped(funding: .paylater)
                         }
                     case .paypal:
-                        PayPalButton.Representable(color: .blue, size: .full) {
+                        PayPalButton.Representable(
+                            color: .blue,
+                            size: .full,
+                            coreConfig: payPalWebViewModel.coreConfig,
+                            orderID: payPalWebViewModel.orderID
+                        ) {
                             payPalWebViewModel.paymentButtonTapped(funding: .paypal)
                         }
                     }

--- a/Demo/Demo/PayPalWebPayments/PayPalWebViewModel/PayPalWebViewModel.swift
+++ b/Demo/Demo/PayPalWebPayments/PayPalWebViewModel/PayPalWebViewModel.swift
@@ -66,7 +66,7 @@ class PayPalWebViewModel: ObservableObject {
                 self.order = order
                 self.state.createdOrderResponse = .loaded(order)
             }
-            coreConfig = try? await configManager.getCoreConfig()
+            coreConfig = try? await resolvedCoreConfig()
             print("✅ fetched orderID: \(order.id) with status: \(order.status)")
         } catch {
             DispatchQueue.main.async {
@@ -121,10 +121,19 @@ class PayPalWebViewModel: ObservableObject {
         }
     }
 
+    /// Returns the cached `CoreConfig` if available, otherwise fetches it once and caches it.
+    func resolvedCoreConfig() async throws -> CoreConfig {
+        if let coreConfig {
+            return coreConfig
+        }
+        let config = try await configManager.getCoreConfig()
+        coreConfig = config
+        return config
+    }
+
     func getPayPalClient() async throws -> PayPalWebCheckoutClient? {
         do {
-            let config = try await configManager.getCoreConfig()
-            coreConfig = config
+            let config = try await resolvedCoreConfig()
             let payPalClient = PayPalWebCheckoutClient(config: config)
             payPalDataCollector = PayPalDataCollector(config: config)
             return payPalClient

--- a/Demo/Demo/PayPalWebPayments/PayPalWebViewModel/PayPalWebViewModel.swift
+++ b/Demo/Demo/PayPalWebPayments/PayPalWebViewModel/PayPalWebViewModel.swift
@@ -16,6 +16,8 @@ class PayPalWebViewModel: ObservableObject {
 
     var payPalWebCheckoutClient: PayPalWebCheckoutClient?
 
+    @Published var coreConfig: CoreConfig?
+
     var orderID: String? {
         order?.id
     }
@@ -64,6 +66,7 @@ class PayPalWebViewModel: ObservableObject {
                 self.order = order
                 self.state.createdOrderResponse = .loaded(order)
             }
+            coreConfig = try? await configManager.getCoreConfig()
             print("✅ fetched orderID: \(order.id) with status: \(order.status)")
         } catch {
             DispatchQueue.main.async {
@@ -121,6 +124,7 @@ class PayPalWebViewModel: ObservableObject {
     func getPayPalClient() async throws -> PayPalWebCheckoutClient? {
         do {
             let config = try await configManager.getCoreConfig()
+            coreConfig = config
             let payPalClient = PayPalWebCheckoutClient(config: config)
             payPalDataCollector = PayPalDataCollector(config: config)
             return payPalClient
@@ -188,6 +192,7 @@ class PayPalWebViewModel: ObservableObject {
         self.state = PayPalPaymentState()
         order = nil
         checkoutResult = nil
+        coreConfig = nil
     }
 
     // for testing until singleton router class is implemented

--- a/Sources/CorePayments/Networking/AnalyticsService.swift
+++ b/Sources/CorePayments/Networking/AnalyticsService.swift
@@ -29,10 +29,10 @@ public struct AnalyticsService {
     // MARK: - Internal Initializer
 
     /// Exposed for testing
-    init(coreConfig: CoreConfig, orderID: String?, trackingEventsAPI: TrackingEventsAPI) {
+    init(coreConfig: CoreConfig, trackingEventsAPI: TrackingEventsAPI) {
         self.coreConfig = coreConfig
         self.trackingEventsAPI = trackingEventsAPI
-        self.orderID = orderID
+        self.orderID = nil
         self.setupToken = nil
     }
     

--- a/Sources/CorePayments/Networking/AnalyticsService.swift
+++ b/Sources/CorePayments/Networking/AnalyticsService.swift
@@ -12,7 +12,7 @@ public struct AnalyticsService {
     private let setupToken: String?
     // MARK: - Initializer
     
-    public init(coreConfig: CoreConfig, orderID: String) {
+    public init(coreConfig: CoreConfig, orderID: String?) {
         self.coreConfig = coreConfig
         self.trackingEventsAPI = TrackingEventsAPI(coreConfig: coreConfig)
         self.orderID = orderID

--- a/Sources/CorePayments/Networking/AnalyticsService.swift
+++ b/Sources/CorePayments/Networking/AnalyticsService.swift
@@ -29,7 +29,7 @@ public struct AnalyticsService {
     // MARK: - Internal Initializer
 
     /// Exposed for testing
-    init(coreConfig: CoreConfig, orderID: String, trackingEventsAPI: TrackingEventsAPI) {
+    init(coreConfig: CoreConfig, orderID: String?, trackingEventsAPI: TrackingEventsAPI) {
         self.coreConfig = coreConfig
         self.trackingEventsAPI = trackingEventsAPI
         self.orderID = orderID

--- a/Sources/PaymentButtons/PayPalButton.swift
+++ b/Sources/PaymentButtons/PayPalButton.swift
@@ -1,3 +1,4 @@
+import CorePayments
 import UIKit
 import SwiftUI
 
@@ -71,7 +72,9 @@ public extension PayPalButton {
         private var action: () -> Void = { }
     
         private let button: PayPalButton
-        
+        private let coreConfig: CoreConfig?
+        private let orderID: String?
+
         /// Initialize a PayPalButton
         /// - Parameters:
         ///   - insets: Edge insets of the button, defining the spacing of the button's edges relative to its content.
@@ -79,12 +82,16 @@ public extension PayPalButton {
         ///   - edges: Edges of the button. Default to softEdges if not provided.
         ///   - size: Size of the button. Default to collapsed if not provided.
         ///   - label: Label displayed next to the button's logo. Default to no label.
+        ///   - coreConfig: SDK configuration used to initialize button analytics. Omit if unavailable.
+        ///   - orderID: Order ID associated with this button session, if available.
         public init(
             insets: NSDirectionalEdgeInsets? = nil,
             color: PayPalButton.Color = .gold,
             edges: PaymentButtonEdges = .softEdges,
             size: PaymentButtonSize = .collapsed,
             label: PayPalButton.Label? = nil,
+            coreConfig: CoreConfig? = nil,
+            orderID: String? = nil,
             _ action: @escaping () -> Void = { }
         ) {
             button = PayPalButton(
@@ -95,6 +102,8 @@ public extension PayPalButton {
                 insets: insets,
                 label: label?.label
             )
+            self.coreConfig = coreConfig
+            self.orderID = orderID
             self.action = action
         }
        
@@ -107,11 +116,17 @@ public extension PayPalButton {
 
         public func makeUIView(context: Context) -> PaymentButton {
             button.addTarget(context.coordinator, action: #selector(Coordinator.onAction(_:)), for: .touchUpInside)
+            if let coreConfig {
+                button.configure(coreConfig: coreConfig, orderID: orderID)
+            }
             return button
         }
 
         public func updateUIView(_ uiView: PaymentButton, context: Context) {
             context.coordinator.action = action
+            if let coreConfig {
+                uiView.configure(coreConfig: coreConfig, orderID: orderID)
+            }
         }
     }
 }

--- a/Sources/PaymentButtons/PayPalCreditButton.swift
+++ b/Sources/PaymentButtons/PayPalCreditButton.swift
@@ -1,3 +1,4 @@
+import CorePayments
 import UIKit
 import SwiftUI
 
@@ -49,7 +50,9 @@ public extension PayPalCreditButton {
         
         private let button: PayPalCreditButton
         private var action: () -> Void = { }
-            
+        private let coreConfig: CoreConfig?
+        private let orderID: String?
+
         /// Initialize a PayPalCreditButton
         /// - Parameters:
         ///   - insets: Edge insets of the button, defining the spacing of the button's edges relative to its content.
@@ -61,6 +64,8 @@ public extension PayPalCreditButton {
             color: PayPalCreditButton.Color = .darkBlue,
             edges: PaymentButtonEdges = .softEdges,
             size: PaymentButtonSize = .collapsed,
+            coreConfig: CoreConfig? = nil,
+            orderID: String? = nil,
             _ action: @escaping () -> Void = { }
         ) {
             self.button = PayPalCreditButton(
@@ -71,6 +76,8 @@ public extension PayPalCreditButton {
                 insets: insets,
                 label: nil
             )
+            self.coreConfig = coreConfig
+            self.orderID = orderID
             self.action = action
         }
         
@@ -83,11 +90,17 @@ public extension PayPalCreditButton {
 
         public func makeUIView(context: Context) -> PaymentButton {
             button.addTarget(context.coordinator, action: #selector(Coordinator.onAction(_:)), for: .touchUpInside)
+            if let coreConfig {
+                button.configure(coreConfig: coreConfig, orderID: orderID)
+            }
             return button
         }
 
         public func updateUIView(_ uiView: PaymentButton, context: Context) {
             context.coordinator.action = action
+            if let coreConfig {
+                uiView.configure(coreConfig: coreConfig, orderID: orderID)
+            }
         }
     }
 }

--- a/Sources/PaymentButtons/PayPalPayLaterButton.swift
+++ b/Sources/PaymentButtons/PayPalPayLaterButton.swift
@@ -1,3 +1,4 @@
+import CorePayments
 import UIKit
 import SwiftUI
 
@@ -48,7 +49,9 @@ public extension PayPalPayLaterButton {
         
         private let button: PayPalPayLaterButton
         private var action: () -> Void = { }
-        
+        private let coreConfig: CoreConfig?
+        private let orderID: String?
+
         /// Initialize a PayPalPayLaterButton
         /// - Parameters:
         ///   - insets: Edge insets of the button, defining the spacing of the button's edges relative to its content.
@@ -60,6 +63,8 @@ public extension PayPalPayLaterButton {
             color: PayPalPayLaterButton.Color = .gold,
             edges: PaymentButtonEdges = .softEdges,
             size: PaymentButtonSize = .collapsed,
+            coreConfig: CoreConfig? = nil,
+            orderID: String? = nil,
             _ action: @escaping () -> Void = { }
         ) {
             self.button = PayPalPayLaterButton(
@@ -70,6 +75,8 @@ public extension PayPalPayLaterButton {
                 insets: insets,
                 label: .payLater
             )
+            self.coreConfig = coreConfig
+            self.orderID = orderID
             self.action = action
         }
 
@@ -82,11 +89,17 @@ public extension PayPalPayLaterButton {
 
         public func makeUIView(context: Context) -> PaymentButton {
             button.addTarget(context.coordinator, action: #selector(Coordinator.onAction(_:)), for: .touchUpInside)
+            if let coreConfig {
+                button.configure(coreConfig: coreConfig, orderID: orderID)
+            }
             return button
         }
 
         public func updateUIView(_ uiView: PaymentButton, context: Context) {
             context.coordinator.action = action
+            if let coreConfig {
+                uiView.configure(coreConfig: coreConfig, orderID: orderID)
+            }
         }
     }
 }

--- a/Sources/PaymentButtons/PaymentButton.swift
+++ b/Sources/PaymentButtons/PaymentButton.swift
@@ -24,8 +24,8 @@ public class PaymentButton: UIButton {
     static let bundle = Bundle(for: PaymentButton.self)
     #endif
 
-    // Defer AnalyticsService creation until a real CoreConfig and orderID are available
     private var analyticsService: AnalyticsService?
+    private var didConfigureAnalytics = false
 
     // MARK: - Init
 
@@ -43,7 +43,6 @@ public class PaymentButton: UIButton {
         self.size = size
         self.insets = insets
         self.label = label
-        self.analyticsService?.sendEvent("payment-button:initialized", buttonType: fundingSource.rawValue)
         super.init(frame: .zero)
         UIFont.registerFont()
         customizeAppearance()
@@ -120,6 +119,18 @@ public class PaymentButton: UIButton {
 
     /// The label displayed next to the button's logo.
     public private(set) var label: PaymentButtonLabel?
+
+    /// Configures the button's analytics once a `CoreConfig` is available.
+    /// Only the first call has an effect, guaranteeing `payment-button:initialized` is sent at most once.
+    /// - Parameters:
+    ///   - coreConfig: SDK configuration used for checkout.
+    ///   - orderID: PayPal order ID associated with this button session, if available.
+    public func configure(coreConfig: CoreConfig, orderID: String?) {
+        guard !didConfigureAnalytics else { return }
+        didConfigureAnalytics = true
+        analyticsService = AnalyticsService(coreConfig: coreConfig, orderID: orderID)
+        analyticsService?.sendEvent("payment-button:initialized", buttonType: fundingSource.rawValue)
+    }
 
     private var imageHeight: CGFloat {
         // For pay later or paypal credit return different image height

--- a/Sources/PaymentButtons/PaymentButton.swift
+++ b/Sources/PaymentButtons/PaymentButton.swift
@@ -24,11 +24,8 @@ public class PaymentButton: UIButton {
     static let bundle = Bundle(for: PaymentButton.self)
     #endif
 
-    // Use an empty config and default to live environment for button analytics
-    private let analyticsService = AnalyticsService(
-        coreConfig: .init(clientID: "N/A", environment: .live),
-        orderID: "N/A"
-    )
+    // Defer AnalyticsService creation until a real CoreConfig and orderID are available
+    private var analyticsService: AnalyticsService?
 
     // MARK: - Init
 
@@ -46,7 +43,7 @@ public class PaymentButton: UIButton {
         self.size = size
         self.insets = insets
         self.label = label
-        self.analyticsService.sendEvent("payment-button:initialized", buttonType: fundingSource.rawValue)
+        self.analyticsService?.sendEvent("payment-button:initialized", buttonType: fundingSource.rawValue)
         super.init(frame: .zero)
         UIFont.registerFont()
         customizeAppearance()
@@ -174,7 +171,7 @@ public class PaymentButton: UIButton {
     // MARK: - Private
 
     @objc private func onTap() {
-        analyticsService.sendEvent("payment-button:tapped", buttonType: fundingSource.rawValue)
+        analyticsService?.sendEvent("payment-button:tapped", buttonType: fundingSource.rawValue)
     }
 
     // MARK: - Configuration

--- a/Sources/PaymentButtons/PaymentButton.swift
+++ b/Sources/PaymentButtons/PaymentButton.swift
@@ -125,9 +125,11 @@ public class PaymentButton: UIButton {
     ///   - coreConfig: SDK configuration used for checkout.
     ///   - orderID: PayPal order ID associated with this button session, if available.
     public func configure(coreConfig: CoreConfig, orderID: String?) {
-        guard analyticsService == nil else { return }
+        let shouldSendInitializedEvent = analyticsService == nil
         analyticsService = AnalyticsService(coreConfig: coreConfig, orderID: orderID)
-        analyticsService?.sendEvent("payment-button:initialized", buttonType: fundingSource.rawValue)
+        if shouldSendInitializedEvent {
+            analyticsService?.sendEvent("payment-button:initialized", buttonType: fundingSource.rawValue)
+        }
     }
 
     private var imageHeight: CGFloat {

--- a/Sources/PaymentButtons/PaymentButton.swift
+++ b/Sources/PaymentButtons/PaymentButton.swift
@@ -25,8 +25,7 @@ public class PaymentButton: UIButton {
     #endif
 
     private var analyticsService: AnalyticsService?
-    private var didConfigureAnalytics = false
-
+    
     // MARK: - Init
 
     required init(
@@ -126,8 +125,7 @@ public class PaymentButton: UIButton {
     ///   - coreConfig: SDK configuration used for checkout.
     ///   - orderID: PayPal order ID associated with this button session, if available.
     public func configure(coreConfig: CoreConfig, orderID: String?) {
-        guard !didConfigureAnalytics else { return }
-        didConfigureAnalytics = true
+        guard analyticsService == nil else { return }
         analyticsService = AnalyticsService(coreConfig: coreConfig, orderID: orderID)
         analyticsService?.sendEvent("payment-button:initialized", buttonType: fundingSource.rawValue)
     }

--- a/UnitTests/PaymentsCoreTests/AnalyticsService_Tests.swift
+++ b/UnitTests/PaymentsCoreTests/AnalyticsService_Tests.swift
@@ -47,6 +47,19 @@ class AnalyticsService_Tests: XCTestCase {
         
         XCTAssertEqual(mockTrackingEventsAPI.capturedAnalyticsEventData?.environment, "sandbox")
     }
+
+    func testSendEvent_whenOrderIDIsNil_sendsNilOrderID() async {
+        let sut = AnalyticsService(
+            coreConfig: coreConfig,
+            orderID: nil,
+            trackingEventsAPI: mockTrackingEventsAPI
+        )
+
+        await sut.performEventRequest("some-event")
+
+        XCTAssertEqual(mockTrackingEventsAPI.capturedAnalyticsEventData?.eventName, "some-event")
+        XCTAssertNil(mockTrackingEventsAPI.capturedAnalyticsEventData?.orderID)
+    }
     
     func testSendEvent_whenAPIRequestFails_logsErrorToConsole() {
         // We currently have no way to validate our console logging

--- a/UnitTests/PaymentsCoreTests/AnalyticsService_Tests.swift
+++ b/UnitTests/PaymentsCoreTests/AnalyticsService_Tests.swift
@@ -16,7 +16,7 @@ class AnalyticsService_Tests: XCTestCase {
         super.setUp()
                 
         mockTrackingEventsAPI = MockTrackingEventsAPI(coreConfig: coreConfig)
-        sut = AnalyticsService(coreConfig: coreConfig, orderID: "some-order-id", trackingEventsAPI: mockTrackingEventsAPI)
+        sut = AnalyticsService(coreConfig: coreConfig, trackingEventsAPI: mockTrackingEventsAPI)
     }
 
     // MARK: - sendEvent()
@@ -26,14 +26,12 @@ class AnalyticsService_Tests: XCTestCase {
 
         XCTAssertEqual(mockTrackingEventsAPI.capturedAnalyticsEventData?.eventName, "some-event")
         XCTAssertEqual(mockTrackingEventsAPI.capturedAnalyticsEventData?.clientID, "some-client-id")
-        XCTAssertEqual(mockTrackingEventsAPI.capturedAnalyticsEventData?.orderID, "some-order-id")
         XCTAssertEqual(mockTrackingEventsAPI.capturedAnalyticsEventData?.correlationID, "fake-correlation-id")
     }
     
     func testSendEvent_whenLive_sendsAppropriateEnvName() async {
         let sut = AnalyticsService(
             coreConfig: CoreConfig(clientID: "some-client-id", environment: .live),
-            orderID: "some-order-id",
             trackingEventsAPI: mockTrackingEventsAPI
         )
         
@@ -51,7 +49,6 @@ class AnalyticsService_Tests: XCTestCase {
     func testSendEvent_whenOrderIDIsNil_sendsNilOrderID() async {
         let sut = AnalyticsService(
             coreConfig: coreConfig,
-            orderID: nil,
             trackingEventsAPI: mockTrackingEventsAPI
         )
 


### PR DESCRIPTION
### Reason for changes

`AnalyticsService` is getting initialized with fake credentials in `PaymentButton.swift.` 
A `payment-button:initialized` event fires against the live FPTI endpoint with clientID: `"N/A" `every time any payment button is instantiated — even in sandbox or unit test environments. This pollutes live analytics with meaningless events and could cause FPTI attribution issues.
**Example:** 
<img width="1342" height="489" alt="Screenshot 2026-06-04 at 6 01 17 PM" src="https://github.com/user-attachments/assets/bee348ab-9c23-49e2-a660-a027bd9548d2" />


### Summary of changes

- Pass AnalyticsService parameters to PaymentButton
- Do not fire analytics events inside PaymentButton unless valid AnalyticsService instance is available

### Result

<img width="1347" height="547" alt="Screenshot 2026-06-04 at 5 45 51 PM" src="https://github.com/user-attachments/assets/6e2c9c09-7887-46c8-8f82-b05ef88ab85f" />

Now merchants can track `paymentButton` events along with `paypal-web-payments:..` and others by Order and Client IDs

### Checklist

- [x] Added a changelog entry

### Authors
> List GitHub usernames for everyone who contributed to this pull request.

- NastassiaRodzik (nrodzik)