### PR TITLE
[Patch] Pass app install state to patchCCOWithAppSwitchEligibility

### DIFF
--- a/Sources/CorePayments/PatchCCOWithAppSwitchEligibility.swift
+++ b/Sources/CorePayments/PatchCCOWithAppSwitchEligibility.swift
@@ -71,7 +71,7 @@ public class PatchCCOWithAppSwitchEligibility {
     public func patchCCOWithAppSwitchEligibility(
         token: String,
         tokenType: String,
-        paypalNativeAppInstalled: Bool
+        paypalNativeAppInstalled: Bool = true
     ) async throws -> AppSwitchEligibility {
 
         let lsat = try await authenticationSecureTokenServiceAPI.createLowScopedAccessToken().accessToken

--- a/Sources/CorePayments/PatchCCOWithAppSwitchEligibility.swift
+++ b/Sources/CorePayments/PatchCCOWithAppSwitchEligibility.swift
@@ -70,7 +70,8 @@ public class PatchCCOWithAppSwitchEligibility {
 
     public func patchCCOWithAppSwitchEligibility(
         token: String,
-        tokenType: String
+        tokenType: String,
+        paypalNativeAppInstalled: Bool
     ) async throws -> AppSwitchEligibility {
 
         let lsat = try await authenticationSecureTokenServiceAPI.createLowScopedAccessToken().accessToken
@@ -83,7 +84,7 @@ public class PatchCCOWithAppSwitchEligibility {
             token: token,
             tokenType: tokenType,
             integrationArtifact: "MOBILE_SDK",
-            paypalNativeAppInstalled: true
+            paypalNativeAppInstalled: paypalNativeAppInstalled
         )
 
         let graphQLRequest = GraphQLRequest(

--- a/Sources/CorePayments/PatchCCOWithAppSwitchEligibility.swift
+++ b/Sources/CorePayments/PatchCCOWithAppSwitchEligibility.swift
@@ -71,7 +71,7 @@ public class PatchCCOWithAppSwitchEligibility {
     public func patchCCOWithAppSwitchEligibility(
         token: String,
         tokenType: String,
-        paypalNativeAppInstalled: Bool = true
+        canSwitchToApp paypalNativeAppInstalled: Bool = true
     ) async throws -> AppSwitchEligibility {
 
         let lsat = try await authenticationSecureTokenServiceAPI.createLowScopedAccessToken().accessToken

--- a/Sources/PayPalWebPayments/PayPalWebCheckoutClient.swift
+++ b/Sources/PayPalWebPayments/PayPalWebCheckoutClient.swift
@@ -171,7 +171,7 @@ public class PayPalWebCheckoutClient: NSObject {
 
     private func attemptAppSwitchIfEligible(
         request: PayPalWebCheckoutRequest,
-        paypalNativeAppInstalled: Bool,
+        paypalNativeAppInstalled: Bool = true,
         completionOnce: @escaping (Result<PayPalWebCheckoutResult, CoreSDKError>) -> Void
     ) async -> AppSwitchAttempt {
         do {

--- a/Sources/PayPalWebPayments/PayPalWebCheckoutClient.swift
+++ b/Sources/PayPalWebPayments/PayPalWebCheckoutClient.swift
@@ -178,7 +178,7 @@ public class PayPalWebCheckoutClient: NSObject {
             let eligibility = try await patchCCOAPI.patchCCOWithAppSwitchEligibility(
                 token: request.orderID,
                 tokenType: "ORDER_ID",
-                paypalNativeAppInstalled: paypalNativeAppInstalled
+                canSwitchToApp: paypalNativeAppInstalled
             )
 
             guard eligibility.appSwitchEligible == true,

--- a/Sources/PayPalWebPayments/PayPalWebCheckoutClient.swift
+++ b/Sources/PayPalWebPayments/PayPalWebCheckoutClient.swift
@@ -69,7 +69,7 @@ public class PayPalWebCheckoutClient: NSObject {
 
         Task {
             if request.appSwitchIfEligible && appInstalled {
-                switch await attemptAppSwitchIfEligible(request: request, completionOnce: completionOnce) {
+                switch await attemptAppSwitchIfEligible(request: request, paypalNativeAppInstalled: appInstalled, completionOnce: completionOnce) {
                 case .launched:
                     // Do nothing here. We will complete when handleReturnURL is invoked.
                     return
@@ -171,12 +171,14 @@ public class PayPalWebCheckoutClient: NSObject {
 
     private func attemptAppSwitchIfEligible(
         request: PayPalWebCheckoutRequest,
+        paypalNativeAppInstalled: Bool,
         completionOnce: @escaping (Result<PayPalWebCheckoutResult, CoreSDKError>) -> Void
     ) async -> AppSwitchAttempt {
         do {
             let eligibility = try await patchCCOAPI.patchCCOWithAppSwitchEligibility(
                 token: request.orderID,
-                tokenType: "ORDER_ID"
+                tokenType: "ORDER_ID",
+                paypalNativeAppInstalled: paypalNativeAppInstalled
             )
 
             guard eligibility.appSwitchEligible == true,

--- a/UnitTests/CorePaymentTests/PatchCCOWithAppSwitchEligibility.swift
+++ b/UnitTests/CorePaymentTests/PatchCCOWithAppSwitchEligibility.swift
@@ -93,7 +93,7 @@ final class PatchCCOWithAppSwitchEligibility_Tests: XCTestCase {
         """
 
         mockNetworkingClient.stubHTTPResponse = HTTPResponse(status: 200, body: successJSON.data(using: .utf8))
-        let result = try await sut.patchCCOWithAppSwitchEligibility(token: token, tokenType: tokenType, paypalNativeAppInstalled: true)
+        let result = try await sut.patchCCOWithAppSwitchEligibility(token: token, tokenType: tokenType, canSwitchToApp: true)
         XCTAssertEqual(result.appSwitchEligible, true)
         XCTAssertEqual(result.redirectURL, "paypal://app-switch")
         XCTAssertNil(result.ineligibleReason)
@@ -128,7 +128,7 @@ final class PatchCCOWithAppSwitchEligibility_Tests: XCTestCase {
         mockNetworkingClient.stubHTTPError = CoreSDKError(code: 999, domain: "networking", errorDescription: "boom")
 
         do {
-            _ = try await sut.patchCCOWithAppSwitchEligibility(token: "t", tokenType: "CLIENT_TOKEN", paypalNativeAppInstalled: true)
+            _ = try await sut.patchCCOWithAppSwitchEligibility(token: "t", tokenType: "CLIENT_TOKEN", canSwitchToApp: true)
             XCTFail("Expected error")
         } catch let error as CoreSDKError {
             XCTAssertEqual(error.domain, "networking")
@@ -143,7 +143,7 @@ final class PatchCCOWithAppSwitchEligibility_Tests: XCTestCase {
         mockAuthSTS.stubbedError = CoreSDKError(code: 401, domain: "auth", errorDescription: "unauthorized")
 
         do {
-            _ = try await sut.patchCCOWithAppSwitchEligibility(token: "t", tokenType: "CLIENT_TOKEN", paypalNativeAppInstalled: true)
+            _ = try await sut.patchCCOWithAppSwitchEligibility(token: "t", tokenType: "CLIENT_TOKEN", canSwitchToApp: true)
             XCTFail("Expected auth error")
         } catch let error as CoreSDKError {
             XCTAssertEqual(error.domain, "auth")
@@ -170,7 +170,7 @@ final class PatchCCOWithAppSwitchEligibility_Tests: XCTestCase {
         mockNetworkingClient.stubHTTPResponse = HTTPResponse(status: 200, body: missingEligibilityJSON.data(using: .utf8))
 
         do {
-            _ = try await sut.patchCCOWithAppSwitchEligibility(token: "t", tokenType: "CLIENT_TOKEN", paypalNativeAppInstalled: true)
+            _ = try await sut.patchCCOWithAppSwitchEligibility(token: "t", tokenType: "CLIENT_TOKEN", canSwitchToApp: true)
             XCTFail("Expected NetworkingError.noGraphQLDataKey")
         } catch let error as CoreSDKError {
             guard NetworkingError.noGraphQLDataKey == error else {
@@ -201,7 +201,7 @@ final class PatchCCOWithAppSwitchEligibility_Tests: XCTestCase {
         """
         mockNetworkingClient.stubHTTPResponse = HTTPResponse(status: 200, body: body.data(using: .utf8))
 
-        let response = try await sut.patchCCOWithAppSwitchEligibility(token: "tok", tokenType: "CLIENT_TOKEN", paypalNativeAppInstalled: false)
+        let response = try await sut.patchCCOWithAppSwitchEligibility(token: "tok", tokenType: "CLIENT_TOKEN", canSwitchToApp: false)
 
         XCTAssertEqual(response.appSwitchEligible, false)
         XCTAssertNil(response.redirectURL)

--- a/UnitTests/CorePaymentTests/PatchCCOWithAppSwitchEligibility.swift
+++ b/UnitTests/CorePaymentTests/PatchCCOWithAppSwitchEligibility.swift
@@ -93,7 +93,7 @@ final class PatchCCOWithAppSwitchEligibility_Tests: XCTestCase {
         """
 
         mockNetworkingClient.stubHTTPResponse = HTTPResponse(status: 200, body: successJSON.data(using: .utf8))
-        let result = try await sut.patchCCOWithAppSwitchEligibility(token: token, tokenType: tokenType)
+        let result = try await sut.patchCCOWithAppSwitchEligibility(token: token, tokenType: tokenType, paypalNativeAppInstalled: true)
         XCTAssertEqual(result.appSwitchEligible, true)
         XCTAssertEqual(result.redirectURL, "paypal://app-switch")
         XCTAssertNil(result.ineligibleReason)
@@ -128,7 +128,7 @@ final class PatchCCOWithAppSwitchEligibility_Tests: XCTestCase {
         mockNetworkingClient.stubHTTPError = CoreSDKError(code: 999, domain: "networking", errorDescription: "boom")
 
         do {
-            _ = try await sut.patchCCOWithAppSwitchEligibility(token: "t", tokenType: "CLIENT_TOKEN")
+            _ = try await sut.patchCCOWithAppSwitchEligibility(token: "t", tokenType: "CLIENT_TOKEN", paypalNativeAppInstalled: true)
             XCTFail("Expected error")
         } catch let error as CoreSDKError {
             XCTAssertEqual(error.domain, "networking")
@@ -143,7 +143,7 @@ final class PatchCCOWithAppSwitchEligibility_Tests: XCTestCase {
         mockAuthSTS.stubbedError = CoreSDKError(code: 401, domain: "auth", errorDescription: "unauthorized")
 
         do {
-            _ = try await sut.patchCCOWithAppSwitchEligibility(token: "t", tokenType: "CLIENT_TOKEN")
+            _ = try await sut.patchCCOWithAppSwitchEligibility(token: "t", tokenType: "CLIENT_TOKEN", paypalNativeAppInstalled: true)
             XCTFail("Expected auth error")
         } catch let error as CoreSDKError {
             XCTAssertEqual(error.domain, "auth")
@@ -170,7 +170,7 @@ final class PatchCCOWithAppSwitchEligibility_Tests: XCTestCase {
         mockNetworkingClient.stubHTTPResponse = HTTPResponse(status: 200, body: missingEligibilityJSON.data(using: .utf8))
 
         do {
-            _ = try await sut.patchCCOWithAppSwitchEligibility(token: "t", tokenType: "CLIENT_TOKEN")
+            _ = try await sut.patchCCOWithAppSwitchEligibility(token: "t", tokenType: "CLIENT_TOKEN", paypalNativeAppInstalled: true)
             XCTFail("Expected NetworkingError.noGraphQLDataKey")
         } catch let error as CoreSDKError {
             guard NetworkingError.noGraphQLDataKey == error else {
@@ -201,7 +201,7 @@ final class PatchCCOWithAppSwitchEligibility_Tests: XCTestCase {
         """
         mockNetworkingClient.stubHTTPResponse = HTTPResponse(status: 200, body: body.data(using: .utf8))
 
-        let response = try await sut.patchCCOWithAppSwitchEligibility(token: "tok", tokenType: "CLIENT_TOKEN")
+        let response = try await sut.patchCCOWithAppSwitchEligibility(token: "tok", tokenType: "CLIENT_TOKEN", paypalNativeAppInstalled: false)
 
         XCTAssertEqual(response.appSwitchEligible, false)
         XCTAssertNil(response.redirectURL)

--- a/UnitTests/TestShared/MockPatchCCOAPI.swift
+++ b/UnitTests/TestShared/MockPatchCCOAPI.swift
@@ -9,7 +9,7 @@ class MockPatchCCOAPI: PatchCCOWithAppSwitchEligibility {
     override func patchCCOWithAppSwitchEligibility(
         token: String,
         tokenType: String,
-        paypalNativeAppInstalled: Bool
+        canSwitchToApp paypalNativeAppInstalled: Bool = true
     ) async throws -> AppSwitchEligibility {
 
         if let stubError {

--- a/UnitTests/TestShared/MockPatchCCOAPI.swift
+++ b/UnitTests/TestShared/MockPatchCCOAPI.swift
@@ -8,7 +8,8 @@ class MockPatchCCOAPI: PatchCCOWithAppSwitchEligibility {
 
     override func patchCCOWithAppSwitchEligibility(
         token: String,
-        tokenType: String
+        tokenType: String,
+        paypalNativeAppInstalled: Bool
     ) async throws -> AppSwitchEligibility {
 
         if let stubError {


### PR DESCRIPTION
### Reason for changes

- Avoid `paypalNativeAppInstalled` to be always hardcoded as true
- Add ability to pass actual install state to `patchCCOWithAppSwitchEligibility`

### Summary of changes

- Pass app install state to patchCCOWithAppSwitchEligibility
- Apply previously submitted suggestion to pass default value of `paypalNativeAppInstalled` to not break existing integrations 

### Checklist

- [x] Added a changelog entry

### Authors
> List GitHub usernames for everyone who contributed to this pull request.

- NastassiaRodzik 