### PR TITLE
fix(ci): resolve CI failures from deprecated Node.js actions and Xcode/simulator mismatch

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -9,7 +9,7 @@ jobs:
     runs-on: macos-26
     steps:
       - name: Check out repository
-        uses: actions/checkout@v3
+        uses: actions/checkout@v5
         with:
           ref: ${{ github.event.pull_request.head.ref }}
           repository: ${{ github.event.pull_request.head.repo.full_name }}
@@ -22,7 +22,7 @@ jobs:
     runs-on: macos-26
     steps:
       - name: Check out repository
-        uses: actions/checkout@v3
+        uses: actions/checkout@v5
         with:
           ref: ${{ github.event.pull_request.head.ref }}
           repository: ${{ github.event.pull_request.head.repo.full_name }}

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -14,7 +14,7 @@ jobs:
           ref: ${{ github.event.pull_request.head.ref }}
           repository: ${{ github.event.pull_request.head.repo.full_name }}
       - name: Select Xcode Version
-        run: sudo xcode-select -switch /Applications/Xcode_26.0.1.app/Contents/Developer
+        run: sudo xcode-select -switch /Applications/Xcode_26.2.app/Contents/Developer
       - name: Run pod lib lint
         run: pod lib lint
   spm:
@@ -27,7 +27,7 @@ jobs:
           ref: ${{ github.event.pull_request.head.ref }}
           repository: ${{ github.event.pull_request.head.repo.full_name }}
       - name: Select Xcode Version
-        run: sudo xcode-select -switch /Applications/Xcode_26.0.1.app/Contents/Developer
+        run: sudo xcode-select -switch /Applications/Xcode_26.2.app/Contents/Developer
       - name: Use current branch
         run: sed -i '' 's/branch = .*/branch = \"'"${GITHUB_HEAD_REF//\//\/}"'\";/' SampleApps/SPMTest/SPMTest.xcodeproj/project.pbxproj
       - name: Run swift package resolve

--- a/.github/workflows/publish-docs.yml
+++ b/.github/workflows/publish-docs.yml
@@ -14,7 +14,7 @@ jobs:
     runs-on: macos-26
     steps:
       - name: Check out repository
-        uses: actions/checkout@v3
+        uses: actions/checkout@v5
         with:
           fetch-depth: 0
       - name: Select Xcode Version

--- a/.github/workflows/publish-docs.yml
+++ b/.github/workflows/publish-docs.yml
@@ -18,7 +18,7 @@ jobs:
         with:
           fetch-depth: 0
       - name: Select Xcode Version
-        run: sudo xcode-select -switch /Applications/Xcode_26.0.1.app/Contents/Developer
+        run: sudo xcode-select -switch /Applications/Xcode_26.2.app/Contents/Developer
       - name: Set git username and email
         run: |
           git config user.name paypalsdks

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -29,7 +29,7 @@ jobs:
     runs-on: macos-26
     steps:
       - name: Check out repository
-        uses: actions/checkout@v3
+        uses: actions/checkout@v5
         with:
           fetch-depth: 0
       - name: Select Xcode Version
@@ -81,16 +81,9 @@ jobs:
       - name: Save changelog entries to a file
         run: sed -e '1,/##/d' -e '/##/,$d' CHANGELOG.md > changelog_entries.md
       - name: Create GitHub release
-        id: create_release
-        uses: actions/create-release@v1
         env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-        with:
-          tag_name: ${{ env.VALIDATED_VERSION }}
-          release_name: ${{ env.VALIDATED_VERSION }}
-          body_path: changelog_entries.md
-          draft: false
-          prerelease: false
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: gh release create "${VALIDATED_VERSION}" --title "${VALIDATED_VERSION}" --notes-file changelog_entries.md
       - name: Publish to CocoaPods
         env:
           COCOAPODS_TRUNK_TOKEN: ${{ secrets.COCOAPODS_TRUNK_TOKEN }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -33,7 +33,7 @@ jobs:
         with:
           fetch-depth: 0
       - name: Select Xcode Version
-        run: sudo xcode-select -switch /Applications/Xcode_26.0.1.app/Contents/Developer
+        run: sudo xcode-select -switch /Applications/Xcode_26.2.app/Contents/Developer
       - name: Check for unreleased section in changelog
         run: grep "## unreleased" CHANGELOG.md || (echo "::error::No unreleased section found in CHANGELOG" && exit 1)
       - name: Set git username and email

--- a/.github/workflows/swiftlint.yml
+++ b/.github/workflows/swiftlint.yml
@@ -9,7 +9,7 @@ jobs:
     runs-on: macos-26
     steps:
       - name: Check out repository
-        uses: actions/checkout@v2
+        uses: actions/checkout@v5
       - name: Select Xcode Version
         run: sudo xcode-select -switch /Applications/Xcode_26.0.1.app/Contents/Developer
       - name: Install SwiftLint

--- a/.github/workflows/swiftlint.yml
+++ b/.github/workflows/swiftlint.yml
@@ -11,7 +11,7 @@ jobs:
       - name: Check out repository
         uses: actions/checkout@v5
       - name: Select Xcode Version
-        run: sudo xcode-select -switch /Applications/Xcode_26.0.1.app/Contents/Developer
+        run: sudo xcode-select -switch /Applications/Xcode_26.2.app/Contents/Developer
       - name: Install SwiftLint
         run: brew install swiftlint
       - name: Run SwiftLint

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -14,6 +14,6 @@ jobs:
           ref: ${{ github.event.pull_request.head.ref }}
           repository: ${{ github.event.pull_request.head.repo.full_name }}
       - name: Select Xcode Version
-        run: sudo xcode-select -switch /Applications/Xcode_26.0.1.app/Contents/Developer
+        run: sudo xcode-select -switch /Applications/Xcode_26.2.app/Contents/Developer
       - name: Run Unit Tests
         run: set -o pipefail && xcodebuild -workspace 'PayPal.xcworkspace' -sdk 'iphonesimulator' -configuration 'Debug' -scheme 'UnitTests' -destination 'platform=iOS Simulator,name=iPhone 17,OS=26.2' test | xcpretty

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -9,7 +9,7 @@ jobs:
     runs-on: macos-26
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v3
+        uses: actions/checkout@v5
         with:
           ref: ${{ github.event.pull_request.head.ref }}
           repository: ${{ github.event.pull_request.head.repo.full_name }}

--- a/Sources/CorePayments/Networking/Enums/Environment.swift
+++ b/Sources/CorePayments/Networking/Enums/Environment.swift
@@ -1,6 +1,5 @@
 import Foundation
 
-// swiftlint:disable force_unwrapping
 public enum Environment {
     case sandbox
     case live
@@ -42,4 +41,3 @@ public enum Environment {
         }
     }
 }
-// swiftlint:enable force_unwrapping

--- a/Sources/PayPalWebPayments/Environment+PayPalWebCheckout.swift
+++ b/Sources/PayPalWebPayments/Environment+PayPalWebCheckout.swift
@@ -6,7 +6,6 @@ import CorePayments
 
 extension Environment {
 
-    // swiftlint:disable force_unwrapping
     var payPalBaseURL: URL {
         switch self {
         case .sandbox:
@@ -15,5 +14,4 @@ extension Environment {
             return URL(string: "https://www.paypal.com")!
         }
     }
-    // swiftlint:enable force_unwrapping
 }


### PR DESCRIPTION
## Summary
- Upgrade `actions/checkout` from v2/v3 (Node 12/16) to v5 (Node 24) across all 5 workflow files
- Replace archived `actions/create-release@v1` (Node 12) with `gh release create` CLI in `release.yml`

GitHub enforces hard failures for actions running on deprecated Node.js runtimes (Node 12, 16, and 20 are all deprecated). All 7 action references in this repo were affected.

Ref: https://github.blog/changelog/2025-09-19-deprecation-of-node-20-on-github-actions-runners/

## Changes

| Action | Old | New | Node Runtime |
|--------|-----|-----|--------------|
| `actions/checkout` | v2 | v5 | Node 12 → 24 |
| `actions/checkout` | v3 (×5) | v5 | Node 16 → 24 |
| `actions/create-release` | v1 | `gh` CLI | Node 12 → N/A |

## Test plan
- [ ] Confirm Build, Tests, and SwiftLint workflows pass on this PR
- [ ] Confirm no Node.js deprecation warnings/errors in Actions logs
- [ ] Review `release.yml` and `publish-docs.yml` changes (workflow_dispatch only, not triggered by PR)