### PR TITLE
Shopper Session ID UI, Checkout flow 

### DIFF
--- a/Demo/Demo.xcodeproj/project.pbxproj
+++ b/Demo/Demo.xcodeproj/project.pbxproj
@@ -40,6 +40,7 @@
 		3BA570032AA053AE0081D14F /* PayPalWebCreateOrderView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3BA570022AA053AE0081D14F /* PayPalWebCreateOrderView.swift */; };
 		3BA570072AA0DF330081D14F /* PayPalWebButtonsView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3BA570062AA0DF330081D14F /* PayPalWebButtonsView.swift */; };
 		3BA5700B2AA13C1C0081D14F /* CoreConfigManager.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3BA5700A2AA13C1C0081D14F /* CoreConfigManager.swift */; };
+		A30ABBEB9DF94308BED38BD9 /* UserIdentityView.swift in Sources */ = {isa = PBXBuildFile; fileRef = C5DDBA0EEDF0422CA93EDE6B /* UserIdentityView.swift */; };
 		3BB60B532B1F9F1100A298CF /* PayPalVaultView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3BB60B522B1F9F1100A298CF /* PayPalVaultView.swift */; };
 		3BB60B552B1FA00C00A298CF /* PayPalVaultViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3BB60B542B1FA00C00A298CF /* PayPalVaultViewModel.swift */; };
 		3BB7A9772A5CA6FD00C05140 /* MerchantIntegration.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3BB7A9762A5CA6FD00C05140 /* MerchantIntegration.swift */; };
@@ -154,6 +155,7 @@
 		3BA570022AA053AE0081D14F /* PayPalWebCreateOrderView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PayPalWebCreateOrderView.swift; sourceTree = "<group>"; };
 		3BA570062AA0DF330081D14F /* PayPalWebButtonsView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PayPalWebButtonsView.swift; sourceTree = "<group>"; };
 		3BA5700A2AA13C1C0081D14F /* CoreConfigManager.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CoreConfigManager.swift; sourceTree = "<group>"; };
+		C5DDBA0EEDF0422CA93EDE6B /* UserIdentityView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = UserIdentityView.swift; sourceTree = "<group>"; };
 		3BB60B522B1F9F1100A298CF /* PayPalVaultView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PayPalVaultView.swift; sourceTree = "<group>"; };
 		3BB60B542B1FA00C00A298CF /* PayPalVaultViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PayPalVaultViewModel.swift; sourceTree = "<group>"; };
 		3BB7A9762A5CA6FD00C05140 /* MerchantIntegration.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MerchantIntegration.swift; sourceTree = "<group>"; };
@@ -406,6 +408,7 @@
 				3BC6220A2A97204E00251B85 /* CircularProgressView.swift */,
 				3BC622082A97198500251B85 /* LeadingText.swift */,
 				3BA5700A2AA13C1C0081D14F /* CoreConfigManager.swift */,
+				C5DDBA0EEDF0422CA93EDE6B /* UserIdentityView.swift */,
 				BE5898942B2B91F800AA196E /* LabelViewText.swift */,
 			);
 			path = CommonComponents;
@@ -697,6 +700,7 @@
 				3BA56FE72A9DC9D70081D14F /* CardPaymentViewModel.swift in Sources */,
 				1001E2C52CFFD2800023A03C /* PayPalApprovalResultView.swift in Sources */,
 				3BA5700B2AA13C1C0081D14F /* CoreConfigManager.swift in Sources */,
+				A30ABBEB9DF94308BED38BD9 /* UserIdentityView.swift in Sources */,
 				80F33CE826F8DE29006811B1 /* DemoMerchantAPI.swift in Sources */,
 				80F33CEF26F8E7CC006811B1 /* CreateOrderParams.swift in Sources */,
 				BECD84A227036DDB007CCAE4 /* Intent.swift in Sources */,

--- a/Demo/Demo/PayPalWebPayments/PayPalWebPaymentsView/PayPalWebCreateOrderView.swift
+++ b/Demo/Demo/PayPalWebPayments/PayPalWebPaymentsView/PayPalWebCreateOrderView.swift
@@ -19,77 +19,79 @@ struct PayPalWebCreateOrderView: View {
     @State var shouldVaultSelected = false
 
     var body: some View {
-        VStack(spacing: 16) {
-            HStack {
-                Text("Checkout")
-                    .font(.system(size: 20))
-                Spacer()
-                Button("Reset") {
-                    payPalWebViewModel.resetState()
-                }
-            }
-            .frame(maxWidth: .infinity)
-            .font(.headline)
-            VStack(alignment: .leading, spacing: 8) {
-                Text("Intent")
-                    .font(.subheadline)
-                    .foregroundColor(.secondary)
-                Picker("Intent", selection: $selectedIntent) {
-                    ForEach(Intent.allCases, id: \.self) {
-                        Text($0.rawValue).tag($0)
+        ScrollView {
+            VStack(spacing: 16) {
+                HStack {
+                    Text("Checkout")
+                        .font(.system(size: 20))
+                    Spacer()
+                    Button("Reset") {
+                        payPalWebViewModel.resetState()
                     }
                 }
-                .pickerStyle(SegmentedPickerStyle())
-            }
-            VStack(alignment: .leading, spacing: 8) {
-                Text("User Action")
-                    .font(.subheadline)
-                    .foregroundColor(.secondary)
-                Picker("User Action", selection: $selectedUserAction) {
-                    ForEach(UserActionSelection.allCases, id: \.self) {
-                        Text($0.rawValue).tag($0)
-                    }
-                }
-                .pickerStyle(SegmentedPickerStyle())
-            }
-            UserIdentityView(
-                selectedUserIdentity: $selectedUserIdentity,
-                email: $email,
-                phone: $phone,
-                ssid: $ssid
-            )
-            HStack {
-                Toggle("Should Vault with Purchase", isOn: $shouldVaultSelected)
-                Spacer()
-            }
-            ZStack {
-                Button("Checkout") {
-                    Task {
-                        do {
-                            payPalWebViewModel.intent = selectedIntent
-                            try await payPalWebViewModel.createOrder(shouldVault: shouldVaultSelected)
-                        } catch {
-                            print("Error in getting setup token. \(error.localizedDescription)")
+                .frame(maxWidth: .infinity)
+                .font(.headline)
+                VStack(alignment: .leading, spacing: 8) {
+                    Text("Intent")
+                        .font(.subheadline)
+                        .foregroundColor(.primary)
+                    Picker("Intent", selection: $selectedIntent) {
+                        ForEach(Intent.allCases, id: \.self) {
+                            Text($0.rawValue).tag($0)
                         }
                     }
+                    .pickerStyle(SegmentedPickerStyle())
                 }
-                .buttonStyle(RoundedBlueButtonStyle())
-                if case .loading = payPalWebViewModel.state.createdOrderResponse {
-                    CircularProgressView()
+                VStack(alignment: .leading, spacing: 8) {
+                    Text("User Action")
+                        .font(.subheadline)
+                        .foregroundColor(.primary)
+                    Picker("User Action", selection: $selectedUserAction) {
+                        ForEach(UserActionSelection.allCases, id: \.self) {
+                            Text($0.rawValue).tag($0)
+                        }
+                    }
+                    .pickerStyle(SegmentedPickerStyle())
+                }
+                UserIdentityView(
+                    selectedUserIdentity: $selectedUserIdentity,
+                    email: $email,
+                    phone: $phone,
+                    ssid: $ssid
+                )
+                HStack {
+                    Toggle("Should Vault with Purchase", isOn: $shouldVaultSelected)
+                    Spacer()
+                }
+                ZStack {
+                    Button("Checkout") {
+                        Task {
+                            do {
+                                payPalWebViewModel.intent = selectedIntent
+                                try await payPalWebViewModel.createOrder(shouldVault: shouldVaultSelected)
+                            } catch {
+                                print("Error in getting setup token. \(error.localizedDescription)")
+                            }
+                        }
+                    }
+                    .buttonStyle(RoundedBlueButtonStyle())
+                    if case .loading = payPalWebViewModel.state.createdOrderResponse {
+                        CircularProgressView()
+                    }
                 }
             }
-        }
-        .onAppear {
-            UISegmentedControl.appearance().selectedSegmentTintColor = .systemBlue
-            UISegmentedControl.appearance().setTitleTextAttributes(
-                [.foregroundColor: UIColor.white], for: .selected
+            .onAppear {
+                UISegmentedControl.appearance().selectedSegmentTintColor = .systemBlue
+                UISegmentedControl.appearance().setTitleTextAttributes(
+                    [.foregroundColor: UIColor.white], for: .selected
+                )
+            }
+            .padding()
+            .background(
+                RoundedRectangle(cornerRadius: 10)
+                    .stroke(.gray, lineWidth: 2)
+                    .padding(5)
             )
         }
-        .padding()
-        .background(
-            RoundedRectangle(cornerRadius: 10)
-                .stroke(.gray, lineWidth: 2)
-                .padding(5)
-        )
     }
 }

--- a/Demo/Demo/PayPalWebPayments/PayPalWebPaymentsView/PayPalWebCreateOrderView.swift
+++ b/Demo/Demo/PayPalWebPayments/PayPalWebPaymentsView/PayPalWebCreateOrderView.swift
@@ -12,6 +12,10 @@ struct PayPalWebCreateOrderView: View {
 
     @State private var selectedIntent: Intent = .authorize
     @State private var selectedUserAction: UserActionSelection = .payNow
+    @State private var selectedUserIdentity: UserIdentitySelection = .none
+    @State private var email: String = ""
+    @State private var phone: String = ""
+    @State private var ssid: String = ""
     @State var shouldVaultSelected = false
 
     var body: some View {
@@ -36,6 +40,12 @@ struct PayPalWebCreateOrderView: View {
                 Text("CONTINUE").tag(UserActionSelection.continue)
             }
             .pickerStyle(SegmentedPickerStyle())
+            UserIdentityView(
+                selectedUserIdentity: $selectedUserIdentity,
+                email: $email,
+                phone: $phone,
+                ssid: $ssid
+            )
             HStack {
                 Toggle("Should Vault with Purchase", isOn: $shouldVaultSelected)
                 Spacer()

--- a/Demo/Demo/PayPalWebPayments/PayPalWebPaymentsView/PayPalWebCreateOrderView.swift
+++ b/Demo/Demo/PayPalWebPayments/PayPalWebPaymentsView/PayPalWebCreateOrderView.swift
@@ -30,16 +30,26 @@ struct PayPalWebCreateOrderView: View {
             }
             .frame(maxWidth: .infinity)
             .font(.headline)
-            Picker("Intent", selection: $selectedIntent) {
-                Text("AUTHORIZE").tag(Intent.authorize)
-                Text("CAPTURE").tag(Intent.capture)
+            VStack(alignment: .leading, spacing: 8) {
+                Text("Intent")
+                    .font(.subheadline)
+                    .foregroundColor(.secondary)
+                Picker("Intent", selection: $selectedIntent) {
+                    Text("AUTHORIZE").tag(Intent.authorize)
+                    Text("CAPTURE").tag(Intent.capture)
+                }
+                .pickerStyle(SegmentedPickerStyle())
             }
-            .pickerStyle(SegmentedPickerStyle())
-            Picker("User Action", selection: $selectedUserAction) {
-                Text("PAY NOW").tag(UserActionSelection.payNow)
-                Text("CONTINUE").tag(UserActionSelection.continue)
+            VStack(alignment: .leading, spacing: 8) {
+                Text("User Action")
+                    .font(.subheadline)
+                    .foregroundColor(.secondary)
+                Picker("User Action", selection: $selectedUserAction) {
+                    Text("PAY NOW").tag(UserActionSelection.payNow)
+                    Text("CONTINUE").tag(UserActionSelection.continue)
+                }
+                .pickerStyle(SegmentedPickerStyle())
             }
-            .pickerStyle(SegmentedPickerStyle())
             UserIdentityView(
                 selectedUserIdentity: $selectedUserIdentity,
                 email: $email,

--- a/Demo/Demo/PayPalWebPayments/PayPalWebPaymentsView/PayPalWebCreateOrderView.swift
+++ b/Demo/Demo/PayPalWebPayments/PayPalWebPaymentsView/PayPalWebCreateOrderView.swift
@@ -1,16 +1,23 @@
 import SwiftUI
 
+// TODO: Replace with PayPalUserAction from SDK when feature/shopper-session-id merges
+enum UserActionSelection: String, CaseIterable {
+    case `continue` = "CONTINUE"
+    case payNow = "PAY NOW"
+}
+
 struct PayPalWebCreateOrderView: View {
 
     @ObservedObject var payPalWebViewModel: PayPalWebViewModel
 
     @State private var selectedIntent: Intent = .authorize
+    @State private var selectedUserAction: UserActionSelection = .payNow
     @State var shouldVaultSelected = false
 
     var body: some View {
         VStack(spacing: 16) {
             HStack {
-                Text("Create an Order")
+                Text("Checkout")
                     .font(.system(size: 20))
                 Spacer()
                 Button("Reset") {
@@ -24,16 +31,17 @@ struct PayPalWebCreateOrderView: View {
                 Text("CAPTURE").tag(Intent.capture)
             }
             .pickerStyle(SegmentedPickerStyle())
+            Picker("User Action", selection: $selectedUserAction) {
+                Text("PAY NOW").tag(UserActionSelection.payNow)
+                Text("CONTINUE").tag(UserActionSelection.continue)
+            }
+            .pickerStyle(SegmentedPickerStyle())
             HStack {
                 Toggle("Should Vault with Purchase", isOn: $shouldVaultSelected)
                 Spacer()
             }
-            HStack {
-                Toggle("Enable App Switch", isOn: $payPalWebViewModel.appSwitch)
-                Spacer()
-            }
             ZStack {
-                Button("Create an Order") {
+                Button("Checkout") {
                     Task {
                         do {
                             payPalWebViewModel.intent = selectedIntent
@@ -48,6 +56,12 @@ struct PayPalWebCreateOrderView: View {
                     CircularProgressView()
                 }
             }
+        }
+        .onAppear {
+            UISegmentedControl.appearance().selectedSegmentTintColor = .systemBlue
+            UISegmentedControl.appearance().setTitleTextAttributes(
+                [.foregroundColor: UIColor.white], for: .selected
+            )
         }
         .padding()
         .background(

--- a/Demo/Demo/PayPalWebPayments/PayPalWebPaymentsView/PayPalWebCreateOrderView.swift
+++ b/Demo/Demo/PayPalWebPayments/PayPalWebPaymentsView/PayPalWebCreateOrderView.swift
@@ -2,8 +2,8 @@ import SwiftUI
 
 // TODO: Replace with PayPalUserAction from SDK when feature/shopper-session-id merges
 enum UserActionSelection: String, CaseIterable {
-    case `continue` = "CONTINUE"
     case payNow = "PAY NOW"
+    case `continue` = "CONTINUE"
 }
 
 struct PayPalWebCreateOrderView: View {
@@ -35,8 +35,9 @@ struct PayPalWebCreateOrderView: View {
                     .font(.subheadline)
                     .foregroundColor(.secondary)
                 Picker("Intent", selection: $selectedIntent) {
-                    Text("AUTHORIZE").tag(Intent.authorize)
-                    Text("CAPTURE").tag(Intent.capture)
+                    ForEach(Intent.allCases, id: \.self) {
+                        Text($0.rawValue).tag($0)
+                    }
                 }
                 .pickerStyle(SegmentedPickerStyle())
             }
@@ -45,8 +46,9 @@ struct PayPalWebCreateOrderView: View {
                     .font(.subheadline)
                     .foregroundColor(.secondary)
                 Picker("User Action", selection: $selectedUserAction) {
-                    Text("PAY NOW").tag(UserActionSelection.payNow)
-                    Text("CONTINUE").tag(UserActionSelection.continue)
+                    ForEach(UserActionSelection.allCases, id: \.self) {
+                        Text($0.rawValue).tag($0)
+                    }
                 }
                 .pickerStyle(SegmentedPickerStyle())
             }

--- a/Demo/Demo/SwiftUIComponents/CommonComponents/FloatingLabelTextField.swift
+++ b/Demo/Demo/SwiftUIComponents/CommonComponents/FloatingLabelTextField.swift
@@ -4,6 +4,7 @@ struct FloatingLabelTextField: View {
 
     let placeholder: String
     @Binding var text: String
+    var keyboardType: UIKeyboardType = .numberPad
 
     var body: some View {
         ZStack(alignment: .leading) {
@@ -13,7 +14,7 @@ struct FloatingLabelTextField: View {
                 .font(.system(text.isEmpty ? .title3 : .title3, design: .rounded))
                 .foregroundColor(.gray)
             TextField("", text: $text)
-                .keyboardType(.numberPad)
+                .keyboardType(keyboardType)
         }
         .padding(.top, text.isEmpty ? 0 : 18)
         .animation(.default, value: 0)

--- a/Demo/Demo/SwiftUIComponents/CommonComponents/UserIdentityView.swift
+++ b/Demo/Demo/SwiftUIComponents/CommonComponents/UserIdentityView.swift
@@ -20,9 +20,9 @@ struct UserIdentityView: View {
                 .font(.subheadline)
                 .foregroundColor(.secondary)
             Picker("User Identity", selection: $selectedUserIdentity) {
-                Text("None").tag(UserIdentitySelection.none)
-                Text("Email/Phone").tag(UserIdentitySelection.buyerHints)
-                Text("SSID").tag(UserIdentitySelection.ssid)
+                ForEach(UserIdentitySelection.allCases, id: \.self) {
+                    Text($0.rawValue).tag($0)
+                }
             }
             .pickerStyle(SegmentedPickerStyle())
             switch selectedUserIdentity {

--- a/Demo/Demo/SwiftUIComponents/CommonComponents/UserIdentityView.swift
+++ b/Demo/Demo/SwiftUIComponents/CommonComponents/UserIdentityView.swift
@@ -18,7 +18,7 @@ struct UserIdentityView: View {
         VStack(alignment: .leading, spacing: 8) {
             Text("User Identity (optional)")
                 .font(.subheadline)
-                .foregroundColor(.secondary)
+                .foregroundColor(.primary)
             Picker("User Identity", selection: $selectedUserIdentity) {
                 ForEach(UserIdentitySelection.allCases, id: \.self) {
                     Text($0.rawValue).tag($0)
@@ -29,17 +29,11 @@ struct UserIdentityView: View {
             case .none:
                 EmptyView()
             case .buyerHints:
-                TextField("Email (optional)", text: $email)
-                    .textFieldStyle(RoundedBorderTextFieldStyle())
-                    .keyboardType(.emailAddress)
+                FloatingLabelTextField(placeholder: "Email (optional)", text: $email, keyboardType: .emailAddress)
                     .autocapitalization(.none)
-                TextField("Phone (optional)", text: $phone)
-                    .textFieldStyle(RoundedBorderTextFieldStyle())
-                    .keyboardType(.phonePad)
+                FloatingLabelTextField(placeholder: "Phone (optional)", text: $phone, keyboardType: .phonePad)
             case .ssid:
-                TextField("Server-side Shopper Session ID", text: $ssid)
-                    .textFieldStyle(RoundedBorderTextFieldStyle())
-                    .autocapitalization(.none)
+                FloatingLabelTextField(placeholder: "Server-side Shopper Session ID", text: $ssid)
             }
         }
     }

--- a/Demo/Demo/SwiftUIComponents/CommonComponents/UserIdentityView.swift
+++ b/Demo/Demo/SwiftUIComponents/CommonComponents/UserIdentityView.swift
@@ -16,7 +16,7 @@ struct UserIdentityView: View {
 
     var body: some View {
         VStack(alignment: .leading, spacing: 8) {
-            Text("User Identity")
+            Text("User Identity (optional)")
                 .font(.subheadline)
                 .foregroundColor(.secondary)
             Picker("User Identity", selection: $selectedUserIdentity) {
@@ -29,11 +29,11 @@ struct UserIdentityView: View {
             case .none:
                 EmptyView()
             case .buyerHints:
-                TextField("Email", text: $email)
+                TextField("Email (optional)", text: $email)
                     .textFieldStyle(RoundedBorderTextFieldStyle())
                     .keyboardType(.emailAddress)
                     .autocapitalization(.none)
-                TextField("Phone", text: $phone)
+                TextField("Phone (optional)", text: $phone)
                     .textFieldStyle(RoundedBorderTextFieldStyle())
                     .keyboardType(.phonePad)
             case .ssid:

--- a/Demo/Demo/SwiftUIComponents/CommonComponents/UserIdentityView.swift
+++ b/Demo/Demo/SwiftUIComponents/CommonComponents/UserIdentityView.swift
@@ -1,0 +1,46 @@
+import SwiftUI
+
+// TODO: Replace with PayPalUserIdentity from SDK when feature/shopper-session-id merges
+enum UserIdentitySelection: String, CaseIterable {
+    case none = "None"
+    case buyerHints = "Email/Phone"
+    case ssid = "SSID"
+}
+
+struct UserIdentityView: View {
+
+    @Binding var selectedUserIdentity: UserIdentitySelection
+    @Binding var email: String
+    @Binding var phone: String
+    @Binding var ssid: String
+
+    var body: some View {
+        VStack(alignment: .leading, spacing: 8) {
+            Text("User Identity")
+                .font(.subheadline)
+                .foregroundColor(.secondary)
+            Picker("User Identity", selection: $selectedUserIdentity) {
+                Text("None").tag(UserIdentitySelection.none)
+                Text("Email/Phone").tag(UserIdentitySelection.buyerHints)
+                Text("SSID").tag(UserIdentitySelection.ssid)
+            }
+            .pickerStyle(SegmentedPickerStyle())
+            switch selectedUserIdentity {
+            case .none:
+                EmptyView()
+            case .buyerHints:
+                TextField("Email", text: $email)
+                    .textFieldStyle(RoundedBorderTextFieldStyle())
+                    .keyboardType(.emailAddress)
+                    .autocapitalization(.none)
+                TextField("Phone", text: $phone)
+                    .textFieldStyle(RoundedBorderTextFieldStyle())
+                    .keyboardType(.phonePad)
+            case .ssid:
+                TextField("Server-side Shopper Session ID", text: $ssid)
+                    .textFieldStyle(RoundedBorderTextFieldStyle())
+                    .autocapitalization(.none)
+            }
+        }
+    }
+}


### PR DESCRIPTION
### Summary of changes

- Implement UI for Shopper Session ID feature, PayPal Checkout flow 
- Added UserIdentity view that can be reused across Checkout and Vault flows 
- Left temporary TODOs which will be replaced with Shopper Session ID - related enums in following PRs (to keep PRs small)
- Updated segmented control tint color for better visibility 

### Checklist

- [ ] Added a changelog entry 

### Authors
> List GitHub usernames for everyone who contributed to this pull request.

- NastassiaRodzik