### PR TITLE
Custom Environment

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,13 @@
 
 # PayPal iOS SDK Release Notes
 
+## unreleased
+
+* CorePayments
+  * Add DEBUG-only `Environment.custom(baseURL:graphQLURL:)` case for pointing the SDK at a custom REST/GraphQL host during development. The case is compiled out of release builds, so merchants can only use `.sandbox` or `.live`.
+* Demo
+  * Add a "Custom" environment that lets you enter and persist a Client ID, SDK REST Base URL, and SDK GraphQL Base URL (DEBUG only).
+
 ## 2.0.1 (2025-11-03)
 
 * PayPalWebPayments

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,13 +1,6 @@
 
 # PayPal iOS SDK Release Notes
 
-## unreleased
-
-* CorePayments
-  * Add DEBUG-only `Environment.custom(baseURL:graphQLURL:)` case for pointing the SDK at a custom REST/GraphQL host during development. The case is compiled out of release builds, so merchants can only use `.sandbox` or `.live`.
-* Demo
-  * Add a "Custom" environment that lets you enter and persist a Client ID, SDK REST Base URL, and SDK GraphQL Base URL (DEBUG only).
-
 ## 2.0.1 (2025-11-03)
 
 * PayPalWebPayments

--- a/Demo/Demo.xcodeproj/project.pbxproj
+++ b/Demo/Demo.xcodeproj/project.pbxproj
@@ -63,6 +63,7 @@
 		80F33CED26F8E7A9006811B1 /* Order.swift in Sources */ = {isa = PBXBuildFile; fileRef = 80F33CEC26F8E7A9006811B1 /* Order.swift */; };
 		80F33CEF26F8E7CC006811B1 /* CreateOrderParams.swift in Sources */ = {isa = PBXBuildFile; fileRef = 80F33CEE26F8E7CC006811B1 /* CreateOrderParams.swift */; };
 		80F33CF326F8EA50006811B1 /* DemoSettings.swift in Sources */ = {isa = PBXBuildFile; fileRef = 80F33CF226F8EA50006811B1 /* DemoSettings.swift */; };
+		9A8C7ADC2FF6FD1B00471F38 /* CustomEnvironmentView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9A8C7ADB2FF6FD0F00471F38 /* CustomEnvironmentView.swift */; };
 		BC6460CD2A12A2A0002B974B /* EmptyBodyParams.swift in Sources */ = {isa = PBXBuildFile; fileRef = BC6460CC2A12A2A0002B974B /* EmptyBodyParams.swift */; };
 		BC9D4D2227C554090089E5B1 /* LaunchApp.swift in Sources */ = {isa = PBXBuildFile; fileRef = BC9D4D2127C554090089E5B1 /* LaunchApp.swift */; };
 		BC9D4D2427C58B8D0089E5B1 /* XCUIApplication+Helpers.swift in Sources */ = {isa = PBXBuildFile; fileRef = BC9D4D2327C58B8D0089E5B1 /* XCUIApplication+Helpers.swift */; };
@@ -182,6 +183,7 @@
 		80F33CEC26F8E7A9006811B1 /* Order.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Order.swift; sourceTree = "<group>"; };
 		80F33CEE26F8E7CC006811B1 /* CreateOrderParams.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CreateOrderParams.swift; sourceTree = "<group>"; };
 		80F33CF226F8EA50006811B1 /* DemoSettings.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DemoSettings.swift; sourceTree = "<group>"; };
+		9A8C7ADB2FF6FD0F00471F38 /* CustomEnvironmentView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CustomEnvironmentView.swift; sourceTree = "<group>"; };
 		BC6460CC2A12A2A0002B974B /* EmptyBodyParams.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = EmptyBodyParams.swift; sourceTree = "<group>"; };
 		BC9D4D1527C54F3F0089E5B1 /* DemoUITests.xctest */ = {isa = PBXFileReference; explicitFileType = wrapper.cfbundle; includeInIndex = 0; path = DemoUITests.xctest; sourceTree = BUILT_PRODUCTS_DIR; };
 		BC9D4D2127C554090089E5B1 /* LaunchApp.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LaunchApp.swift; sourceTree = "<group>"; };
@@ -521,6 +523,7 @@
 		BECD849E27036D95007CCAE4 /* DemoSettings */ = {
 			isa = PBXGroup;
 			children = (
+				9A8C7ADB2FF6FD0F00471F38 /* CustomEnvironmentView.swift */,
 				80F33CF226F8EA50006811B1 /* DemoSettings.swift */,
 				BECD849F27036DC2007CCAE4 /* Environment.swift */,
 				BECD84A127036DDB007CCAE4 /* Intent.swift */,
@@ -699,6 +702,7 @@
 				3BA5700B2AA13C1C0081D14F /* CoreConfigManager.swift in Sources */,
 				80F33CE826F8DE29006811B1 /* DemoMerchantAPI.swift in Sources */,
 				80F33CEF26F8E7CC006811B1 /* CreateOrderParams.swift in Sources */,
+				9A8C7ADC2FF6FD1B00471F38 /* CustomEnvironmentView.swift in Sources */,
 				BECD84A227036DDB007CCAE4 /* Intent.swift in Sources */,
 				3BB7A9772A5CA6FD00C05140 /* MerchantIntegration.swift in Sources */,
 				3BA56FEE2A9DCC340081D14F /* OrderCreateCardResultView.swift in Sources */,

--- a/Demo/Demo/DemoSettings/CustomEnvironmentView.swift
+++ b/Demo/Demo/DemoSettings/CustomEnvironmentView.swift
@@ -3,7 +3,8 @@ import SwiftUI
 
 struct CustomEnvironmentView: View {
 
-    @SwiftUI.Environment(\.presentationMode) private var presentationMode
+    @SwiftUI.Environment(\.presentationMode)
+    private var presentationMode
 
     var onSave: () -> Void
     var onCancel: () -> Void
@@ -111,7 +112,10 @@ struct CustomEnvironmentView: View {
 
                 Section(
                     header: Text("Merchant Base URL"),
-                    footer: Text("Optional. Serves /orders, /setup-tokens and /payment-tokens. Leave empty to use the sandbox merchant server.")
+                    footer: Text(
+                        "Optional. Serves /orders, /setup-tokens and /payment-tokens. " +
+                        "Leave empty to use the sandbox merchant server."
+                    )
                 ) {
                     TextField("https://...", text: $merchantBaseURL)
                         .autocapitalization(.none)

--- a/Demo/Demo/DemoSettings/CustomEnvironmentView.swift
+++ b/Demo/Demo/DemoSettings/CustomEnvironmentView.swift
@@ -64,6 +64,10 @@ struct CustomEnvironmentView: View {
             && merchantBaseURLError == nil
     }
 
+    private var isEmpty: Bool {
+        clientID.isEmpty && restBaseURL.isEmpty && graphQLBaseURL.isEmpty && merchantBaseURL.isEmpty
+    }
+
     private static func urlError(_ value: String) -> String? {
         if value.isEmpty {
             return "URL is required"
@@ -115,6 +119,16 @@ struct CustomEnvironmentView: View {
                         .keyboardType(.URL)
                     errorText(merchantBaseURLError)
                 }
+
+                Section {
+                    Button(role: .destructive) {
+                        clearFields()
+                    } label: {
+                        Text("Clear")
+                            .frame(maxWidth: .infinity, alignment: .center)
+                    }
+                    .disabled(isEmpty)
+                }
             }
             .navigationTitle("Custom Environment")
             .navigationBarTitleDisplayMode(.inline)
@@ -142,6 +156,16 @@ struct CustomEnvironmentView: View {
                 .font(.caption)
                 .foregroundColor(.red)
         }
+    }
+
+    private func clearFields() {
+        clientID = ""
+        restBaseURL = ""
+        graphQLBaseURL = ""
+        merchantBaseURL = ""
+        // Also remove the persisted config; with no custom environment stored the app
+        // falls back to sandbox (see `DemoSettings.environment`).
+        DemoSettings.customEnvironment = nil
     }
 
     private func save() {

--- a/Demo/Demo/DemoSettings/CustomEnvironmentView.swift
+++ b/Demo/Demo/DemoSettings/CustomEnvironmentView.swift
@@ -1,0 +1,137 @@
+#if DEBUG
+import SwiftUI
+
+struct CustomEnvironmentView: View {
+
+    @SwiftUI.Environment(\.presentationMode) private var presentationMode
+
+    var onSave: () -> Void
+    var onCancel: () -> Void
+
+    @State private var clientID: String
+    @State private var restBaseURL: String
+    @State private var graphQLBaseURL: String
+
+    init(onSave: @escaping () -> Void, onCancel: @escaping () -> Void) {
+        self.onSave = onSave
+        self.onCancel = onCancel
+        let config = DemoSettings.customEnvironment
+        _clientID = State(initialValue: config?.clientID ?? "")
+        _restBaseURL = State(initialValue: config?.restBaseURL ?? "")
+        _graphQLBaseURL = State(initialValue: config?.graphQLBaseURL ?? "")
+    }
+
+    // MARK: - Validation
+
+    private var trimmedClientID: String {
+        clientID.trimmingCharacters(in: .whitespacesAndNewlines)
+    }
+
+    private var trimmedRestBaseURL: String {
+        restBaseURL.trimmingCharacters(in: .whitespacesAndNewlines)
+    }
+
+    private var trimmedGraphQLBaseURL: String {
+        graphQLBaseURL.trimmingCharacters(in: .whitespacesAndNewlines)
+    }
+
+    private var clientIDError: String? {
+        trimmedClientID.isEmpty ? "Client ID is required" : nil
+    }
+
+    private var restBaseURLError: String? {
+        Self.urlError(trimmedRestBaseURL)
+    }
+
+    private var graphQLBaseURLError: String? {
+        Self.urlError(trimmedGraphQLBaseURL)
+    }
+
+    private var isValid: Bool {
+        clientIDError == nil && restBaseURLError == nil && graphQLBaseURLError == nil
+    }
+
+    private static func urlError(_ value: String) -> String? {
+        if value.isEmpty {
+            return "URL is required"
+        }
+        guard let components = URLComponents(string: value),
+            let scheme = components.scheme?.lowercased(),
+            scheme == "http" || scheme == "https",
+            let host = components.host, !host.isEmpty else {
+            return "Enter a valid http/https URL"
+        }
+        return nil
+    }
+
+    // MARK: - Body
+
+    var body: some View {
+        NavigationView {
+            Form {
+                Section(header: Text("Client ID")) {
+                    TextField("Client ID", text: $clientID)
+                        .autocapitalization(.none)
+                        .disableAutocorrection(true)
+                    errorText(clientIDError)
+                }
+
+                Section(header: Text("SDK REST Base URL")) {
+                    TextField("https://...", text: $restBaseURL)
+                        .autocapitalization(.none)
+                        .disableAutocorrection(true)
+                        .keyboardType(.URL)
+                    errorText(restBaseURLError)
+                }
+
+                Section(header: Text("SDK GraphQL Base URL")) {
+                    TextField("https://.../graphql", text: $graphQLBaseURL)
+                        .autocapitalization(.none)
+                        .disableAutocorrection(true)
+                        .keyboardType(.URL)
+                    errorText(graphQLBaseURLError)
+                }
+            }
+            .navigationTitle("Custom Environment")
+            .navigationBarTitleDisplayMode(.inline)
+            .toolbar {
+                ToolbarItem(placement: .cancellationAction) {
+                    Button("Cancel") {
+                        onCancel()
+                        presentationMode.wrappedValue.dismiss()
+                    }
+                }
+                ToolbarItem(placement: .confirmationAction) {
+                    Button("Save") {
+                        save()
+                    }
+                    .disabled(!isValid)
+                }
+            }
+        }
+    }
+
+    @ViewBuilder
+    private func errorText(_ message: String?) -> some View {
+        if let message {
+            Text(message)
+                .font(.caption)
+                .foregroundColor(.red)
+        }
+    }
+
+    private func save() {
+        guard isValid else {
+            return
+        }
+        DemoSettings.customEnvironment = CustomEnvironmentConfig(
+            clientID: trimmedClientID,
+            restBaseURL: trimmedRestBaseURL,
+            graphQLBaseURL: trimmedGraphQLBaseURL
+        )
+        DemoSettings.environment = .custom
+        onSave()
+        presentationMode.wrappedValue.dismiss()
+    }
+}
+#endif

--- a/Demo/Demo/DemoSettings/CustomEnvironmentView.swift
+++ b/Demo/Demo/DemoSettings/CustomEnvironmentView.swift
@@ -11,6 +11,7 @@ struct CustomEnvironmentView: View {
     @State private var clientID: String
     @State private var restBaseURL: String
     @State private var graphQLBaseURL: String
+    @State private var merchantBaseURL: String
 
     init(onSave: @escaping () -> Void, onCancel: @escaping () -> Void) {
         self.onSave = onSave
@@ -19,6 +20,7 @@ struct CustomEnvironmentView: View {
         _clientID = State(initialValue: config?.clientID ?? "")
         _restBaseURL = State(initialValue: config?.restBaseURL ?? "")
         _graphQLBaseURL = State(initialValue: config?.graphQLBaseURL ?? "")
+        _merchantBaseURL = State(initialValue: config?.merchantBaseURL ?? "")
     }
 
     // MARK: - Validation
@@ -35,6 +37,10 @@ struct CustomEnvironmentView: View {
         graphQLBaseURL.trimmingCharacters(in: .whitespacesAndNewlines)
     }
 
+    private var trimmedMerchantBaseURL: String {
+        merchantBaseURL.trimmingCharacters(in: .whitespacesAndNewlines)
+    }
+
     private var clientIDError: String? {
         trimmedClientID.isEmpty ? "Client ID is required" : nil
     }
@@ -47,8 +53,15 @@ struct CustomEnvironmentView: View {
         Self.urlError(trimmedGraphQLBaseURL)
     }
 
+    private var merchantBaseURLError: String? {
+        trimmedMerchantBaseURL.isEmpty ? nil : Self.urlError(trimmedMerchantBaseURL)
+    }
+
     private var isValid: Bool {
-        clientIDError == nil && restBaseURLError == nil && graphQLBaseURLError == nil
+        clientIDError == nil
+            && restBaseURLError == nil
+            && graphQLBaseURLError == nil
+            && merchantBaseURLError == nil
     }
 
     private static func urlError(_ value: String) -> String? {
@@ -91,6 +104,17 @@ struct CustomEnvironmentView: View {
                         .keyboardType(.URL)
                     errorText(graphQLBaseURLError)
                 }
+
+                Section(
+                    header: Text("Merchant Base URL"),
+                    footer: Text("Optional. Serves /orders, /setup-tokens and /payment-tokens. Leave empty to use the sandbox merchant server.")
+                ) {
+                    TextField("https://...", text: $merchantBaseURL)
+                        .autocapitalization(.none)
+                        .disableAutocorrection(true)
+                        .keyboardType(.URL)
+                    errorText(merchantBaseURLError)
+                }
             }
             .navigationTitle("Custom Environment")
             .navigationBarTitleDisplayMode(.inline)
@@ -127,7 +151,8 @@ struct CustomEnvironmentView: View {
         DemoSettings.customEnvironment = CustomEnvironmentConfig(
             clientID: trimmedClientID,
             restBaseURL: trimmedRestBaseURL,
-            graphQLBaseURL: trimmedGraphQLBaseURL
+            graphQLBaseURL: trimmedGraphQLBaseURL,
+            merchantBaseURL: trimmedMerchantBaseURL.isEmpty ? nil : trimmedMerchantBaseURL
         )
         DemoSettings.environment = .custom
         onSave()

--- a/Demo/Demo/DemoSettings/DemoSettings.swift
+++ b/Demo/Demo/DemoSettings/DemoSettings.swift
@@ -2,6 +2,7 @@ import Foundation
 
 #if DEBUG
 struct CustomEnvironmentConfig: Codable, Equatable {
+
     var clientID: String
     var restBaseURL: String
     var graphQLBaseURL: String

--- a/Demo/Demo/DemoSettings/DemoSettings.swift
+++ b/Demo/Demo/DemoSettings/DemoSettings.swift
@@ -5,6 +5,7 @@ struct CustomEnvironmentConfig: Codable, Equatable {
     var clientID: String
     var restBaseURL: String
     var graphQLBaseURL: String
+    var merchantBaseURL: String?
 }
 #endif
 

--- a/Demo/Demo/DemoSettings/DemoSettings.swift
+++ b/Demo/Demo/DemoSettings/DemoSettings.swift
@@ -1,20 +1,55 @@
 import Foundation
 
+#if DEBUG
+struct CustomEnvironmentConfig: Codable, Equatable {
+    var clientID: String
+    var restBaseURL: String
+    var graphQLBaseURL: String
+}
+#endif
+
 enum DemoSettings {
 
     private static let EnvironmentDefaultsKey = "environment"
     private static let ClientIDKey = "clientID"
     private static let MerchantIntegrationDefaultKey = "merchantIntegration"
+    #if DEBUG
+    private static let CustomEnvironmentKey = "customEnvironment"
+    #endif
 
     static var environment: Environment {
         get {
-            UserDefaults.standard.string(forKey: EnvironmentDefaultsKey)
+            let stored = UserDefaults.standard.string(forKey: EnvironmentDefaultsKey)
                 .flatMap { Environment(rawValue: $0) } ?? .sandbox
+            #if DEBUG
+            if stored == .custom, customEnvironment == nil {
+                return .sandbox
+            }
+            #endif
+            return stored
         }
         set {
             UserDefaults.standard.set(newValue.rawValue, forKey: EnvironmentDefaultsKey)
         }
     }
+
+    #if DEBUG
+    static var customEnvironment: CustomEnvironmentConfig? {
+        get {
+            guard let data = UserDefaults.standard.data(forKey: CustomEnvironmentKey) else {
+                return nil
+            }
+            return try? JSONDecoder().decode(CustomEnvironmentConfig.self, from: data)
+        }
+        set {
+            if let newValue, let data = try? JSONEncoder().encode(newValue) {
+                UserDefaults.standard.set(data, forKey: CustomEnvironmentKey)
+            } else {
+                UserDefaults.standard.removeObject(forKey: CustomEnvironmentKey)
+            }
+        }
+    }
+    #endif
 
     static var merchantIntegration: MerchantIntegration {
         get {

--- a/Demo/Demo/DemoSettings/Environment.swift
+++ b/Demo/Demo/DemoSettings/Environment.swift
@@ -16,11 +16,14 @@ enum Environment: String, CaseIterable {
             return "https://sdk-sample-merchant-server.herokuapp.com"
         #if DEBUG
         case .custom:
-            // The custom fields (REST/GraphQL/clientID) configure the CorePayments SDK only
+            // The custom REST/GraphQL/clientID fields configure the CorePayments SDK only
             // (see `paypalSDKEnvironment`). The merchant endpoints /orders, /setup-tokens and
-            // /payment-tokens are served by the sample merchant backend, not the PayPal API,
-            // so they keep using the existing sandbox merchant server.
-            return Environment.sandbox.baseURL
+            // /payment-tokens are served by the sample merchant backend, not the PayPal API.
+            // A custom merchant URL can be provided; when empty it falls back to the sandbox
+            // merchant server.
+            let merchantBaseURL = DemoSettings.customEnvironment?.merchantBaseURL?
+                .trimmingCharacters(in: .whitespacesAndNewlines) ?? ""
+            return merchantBaseURL.isEmpty ? Environment.sandbox.baseURL : merchantBaseURL
         #endif
         }
     }

--- a/Demo/Demo/DemoSettings/Environment.swift
+++ b/Demo/Demo/DemoSettings/Environment.swift
@@ -3,6 +3,9 @@ import CorePayments
 enum Environment: String, CaseIterable {
     case sandbox
     case live
+    #if DEBUG
+    case custom
+    #endif
 
     var baseURL: String {
         switch self {
@@ -11,6 +14,14 @@ enum Environment: String, CaseIterable {
         case .live:
             // we can replace during testing
             return "https://sdk-sample-merchant-server.herokuapp.com"
+        #if DEBUG
+        case .custom:
+            // The custom fields (REST/GraphQL/clientID) configure the CorePayments SDK only
+            // (see `paypalSDKEnvironment`). The merchant endpoints /orders, /setup-tokens and
+            // /payment-tokens are served by the sample merchant backend, not the PayPal API,
+            // so they keep using the existing sandbox merchant server.
+            return Environment.sandbox.baseURL
+        #endif
         }
     }
 
@@ -20,6 +31,14 @@ enum Environment: String, CaseIterable {
             return .sandbox
         case .live:
             return .live
+        #if DEBUG
+        case .custom:
+            let config = DemoSettings.customEnvironment
+            return .custom(
+                baseURL: config?.restBaseURL ?? "",
+                graphQLURL: config?.graphQLBaseURL ?? ""
+            )
+        #endif
         }
     }
 }

--- a/Demo/Demo/Networking/DemoMerchantAPI.swift
+++ b/Demo/Demo/Networking/DemoMerchantAPI.swift
@@ -126,6 +126,12 @@ final class DemoMerchantAPI {
             return injectedClientID
         }
 
+        #if DEBUG
+        if environment == .custom {
+            return DemoSettings.customEnvironment?.clientID
+        }
+        #endif
+
         return selectedMerchantIntegration.clientID
     }
 

--- a/Demo/Demo/SwiftUIComponents/FeatureSelectionView.swift
+++ b/Demo/Demo/SwiftUIComponents/FeatureSelectionView.swift
@@ -4,6 +4,10 @@ struct FeatureSelectionView: View {
 
     @State private var selectedEnvironment: Environment = DemoSettings.environment
     @State private var selectedIntegration: MerchantIntegration = DemoSettings.merchantIntegration
+    #if DEBUG
+    @State private var lastCommittedEnvironment: Environment = DemoSettings.environment
+    @State private var showCustomEnvironmentSheet = false
+    #endif
 
     var body: some View {
         NavigationView {
@@ -15,6 +19,14 @@ struct FeatureSelectionView: View {
                         }
                     }
                     .pickerStyle(MenuPickerStyle())
+
+                    #if DEBUG
+                    if selectedEnvironment == .custom {
+                        Button("Setup Environment") {
+                            showCustomEnvironmentSheet = true
+                        }
+                    }
+                    #endif
 
                     Picker("Merchant Integration", selection: $selectedIntegration.onChange(updateIntegration)) {
                         ForEach(MerchantIntegration.allCases, id: \.self) { integration in
@@ -58,11 +70,39 @@ struct FeatureSelectionView: View {
                 .listStyle(InsetGroupedListStyle())
                 .navigationTitle("Feature Selection")
             }
+            #if DEBUG
+            .sheet(isPresented: $showCustomEnvironmentSheet) {
+                CustomEnvironmentView(
+                    onSave: {
+                        selectedEnvironment = .custom
+                        lastCommittedEnvironment = .custom
+                    },
+                    onCancel: {
+                        if DemoSettings.customEnvironment != nil {
+                            DemoSettings.environment = .custom
+                            selectedEnvironment = .custom
+                            lastCommittedEnvironment = .custom
+                        } else {
+                            selectedEnvironment = lastCommittedEnvironment
+                        }
+                    }
+                )
+            }
+            #endif
         }
     }
 
     func updateEnvironment(newEnvironment: Environment) {
+        #if DEBUG
+        if newEnvironment == .custom {
+            showCustomEnvironmentSheet = true
+            return
+        }
+        #endif
         DemoSettings.environment = newEnvironment
+        #if DEBUG
+        lastCommittedEnvironment = newEnvironment
+        #endif
     }
 
     func updateIntegration(newIntegration: MerchantIntegration) {

--- a/Sources/CorePayments/Networking/Enums/Environment.swift
+++ b/Sources/CorePayments/Networking/Enums/Environment.swift
@@ -1,6 +1,6 @@
 import Foundation
 
-public enum Environment {
+public enum Environment: Equatable {
     case sandbox
     case live
 

--- a/Sources/CorePayments/Networking/Enums/Environment.swift
+++ b/Sources/CorePayments/Networking/Enums/Environment.swift
@@ -16,7 +16,7 @@ public enum Environment {
             return URL(string: "https://api-m.paypal.com")!
         #if DEBUG
         case .custom(let baseURL, _):
-            return URL(string: baseURL)!
+            return URL(string: baseURL) ?? URL(fileURLWithPath: "")
         #endif
         }
     }
@@ -29,7 +29,7 @@ public enum Environment {
             return URL(string: "https://www.paypal.com/graphql")!
         #if DEBUG
         case .custom(_, let graphQLURL):
-            return URL(string: graphQLURL)!
+            return URL(string: graphQLURL) ?? URL(fileURLWithPath: "")
         #endif
         }
     }

--- a/Sources/CorePayments/Networking/Enums/Environment.swift
+++ b/Sources/CorePayments/Networking/Enums/Environment.swift
@@ -5,12 +5,20 @@ public enum Environment {
     case sandbox
     case live
 
+    #if DEBUG
+    case custom(baseURL: String, graphQLURL: String)
+    #endif
+
     var baseURL: URL {
         switch self {
         case .sandbox:
             return URL(string: "https://api-m.sandbox.paypal.com")!
         case .live:
             return URL(string: "https://api-m.paypal.com")!
+        #if DEBUG
+        case .custom(let baseURL, _):
+            return URL(string: baseURL)!
+        #endif
         }
     }
 
@@ -20,9 +28,13 @@ public enum Environment {
             return URL(string: "https://www.sandbox.paypal.com/graphql")!
         case .live:
             return URL(string: "https://www.paypal.com/graphql")!
+        #if DEBUG
+        case .custom(_, let graphQLURL):
+            return URL(string: graphQLURL)!
+        #endif
         }
     }
-    
+
     /// URL used to display the PayPal Vault w/o Purchase experience in web browser
     public var paypalVaultCheckoutURL: URL {
         switch self {
@@ -30,15 +42,27 @@ public enum Environment {
             return URL(string: "https://sandbox.paypal.com/agreements/approve")!
         case .live:
             return URL(string: "https://paypal.com/agreements/approve")!
+        #if DEBUG
+        case .custom(let baseURL, _):
+            if let host = URL(string: baseURL)?.host,
+                let url = URL(string: "https://\(host)/agreements/approve") {
+                return url
+            }
+            return URL(string: "https://paypal.com/agreements/approve")!
+        #endif
         }
     }
-    
+
     public var toString: String {
         switch self {
         case .sandbox:
             return "sandbox"
         case .live:
             return "live"
+        #if DEBUG
+        case .custom:
+            return "custom"
+        #endif
         }
     }
 }

--- a/Sources/FraudProtection/CoreConfig+MagnesSDK.swift
+++ b/Sources/FraudProtection/CoreConfig+MagnesSDK.swift
@@ -11,6 +11,11 @@ extension CoreConfig {
             return .SANDBOX
         case .live:
             return .LIVE
+        #if DEBUG
+        case .custom:
+            // Magnes has no custom environment; use sandbox for local/QA testing.
+            return .SANDBOX
+        #endif
         }
     }
 }

--- a/Sources/PayPalWebPayments/Environment+PayPalWebCheckout.swift
+++ b/Sources/PayPalWebPayments/Environment+PayPalWebCheckout.swift
@@ -13,6 +13,13 @@ extension Environment {
             return URL(string: "https://www.sandbox.paypal.com")!
         case .live:
             return URL(string: "https://www.paypal.com")!
+        #if DEBUG
+        case .custom:
+            if let host = graphQLURL.host, let url = URL(string: "https://\(host)") {
+                return url
+            }
+            return URL(string: "https://www.paypal.com")!
+        #endif
         }
     }
     // swiftlint:enable force_unwrapping


### PR DESCRIPTION
### Reason for changes

Add a developer-only "Custom" environment to the Demo app for testing the SDK against a custom PayPal REST/GraphQL host.

### Summary of changes

- CorePayments SDK: Added a `#if DEBUG-only` `Environment.custom(baseURL:graphQLURL:)` case (compiled out of release builds, so merchants only see .sandbox/.live).
- Handled the new case in all Environment switches: `CorePayments/Environment`, `PayPalWebPayments/Environment+PayPalWebCheckout`, and `FraudProtection/CoreConfig+MagnesSDK`.
- Demo app: New "Custom" option in the environment picker that opens a setup screen for Client ID, SDK REST Base URL, and SDK GraphQL Base URL, with inline validation (non-empty + valid http/https URLs) and persistence to UserDefaults.
- Added a "Setup Environment" button to re-open the form. The three custom fields configure only the CorePayments SDK; the merchant endpoints (/orders, /setup-tokens, /payment-tokens) keep using the sample merchant server, which fixed the create-order failure.
All Demo-side custom code is gated with #if DEBUG so a release build of the Demo still compiles.

### Checklist

- [x] Added a changelog entry

### Authors
> List GitHub usernames for everyone who contributed to this pull request.

- joaaraujo-paypal