### PR TITLE
Shopper session fallback update

### DIFF
--- a/Demo/Demo/PayPalVault/PayPalVaultViewModel/PayPalVaultViewModel.swift
+++ b/Demo/Demo/PayPalVault/PayPalVaultViewModel/PayPalVaultViewModel.swift
@@ -25,10 +25,18 @@ class PayPalVaultViewModel: VaultViewModel {
             phone: userPhone,
             ssid: userSSID
         )
+        let urlConfig: PayPalURLConfig
+        do {
+            urlConfig = try ShopperSessionURLConfigFactory.makeURLConfig()
+        } catch {
+            state.setupTokenResponse = .error(message: error.localizedDescription)
+            throw error
+        }
+
         client.createPayPalSession(
             sessionType: .vaultWithoutPurchase,
             userIdentity: resolvedUserIdentity,
-            urlConfig: ShopperSessionURLConfigFactory.urlConfig,
+            urlConfig: urlConfig,
             userAction: selectedUserAction
         )
 

--- a/Demo/Demo/PayPalWebPayments/PayPalWebPaymentsView/PayPalWebPaymentsView.swift
+++ b/Demo/Demo/PayPalWebPayments/PayPalWebPaymentsView/PayPalWebPaymentsView.swift
@@ -13,6 +13,8 @@ struct PayPalWebPaymentsView: View {
                     
                     if case .loaded = payPalWebViewModel.state.createdOrderResponse {
                         PayPalOrderCreateResultView(payPalWebViewModel: payPalWebViewModel)
+                    } else if case .error = payPalWebViewModel.state.createdOrderResponse {
+                        PayPalOrderCreateResultView(payPalWebViewModel: payPalWebViewModel)
                     }
                     
                     if case .loaded = payPalWebViewModel.state.approveResultResponse {

--- a/Demo/Demo/PayPalWebPayments/PayPalWebViewModel/PayPalWebViewModel.swift
+++ b/Demo/Demo/PayPalWebPayments/PayPalWebViewModel/PayPalWebViewModel.swift
@@ -42,10 +42,18 @@ class PayPalWebViewModel: ObservableObject {
         }
         payPalWebCheckoutClient = client
 
+        let urlConfig: PayPalURLConfig
+        do {
+            urlConfig = try ShopperSessionURLConfigFactory.makeURLConfig()
+        } catch {
+            state.createdOrderResponse = .error(message: error.localizedDescription)
+            throw error
+        }
+
         client.createPayPalSession(
             sessionType: .checkout,
             userIdentity: userIdentity,
-            urlConfig: ShopperSessionURLConfigFactory.urlConfig,
+            urlConfig: urlConfig,
             userAction: userAction
         )
 

--- a/Demo/Demo/SwiftUIComponents/CommonComponents/ShopperSessionURLConfigFactory.swift
+++ b/Demo/Demo/SwiftUIComponents/CommonComponents/ShopperSessionURLConfigFactory.swift
@@ -6,12 +6,22 @@ import PayPalWebPayments
 /// Used by both the PayPalWeb and Vault flows so the callback URLs stay in sync.
 enum ShopperSessionURLConfigFactory {
 
-    static let urlConfig: PayPalURLConfig = {
-        let baseReturnUrl = "https://ppcp-mobile-demo-sandbox-87bbd7f0a27f.herokuapp.com"
+    enum ConfigurationError: LocalizedError {
+        case invalidCallbackURL(String)
 
+        var errorDescription: String? {
+            switch self {
+            case .invalidCallbackURL(let baseReturnUrl):
+                return "Failed to construct Shopper Session callback URLs for base return URL: \(baseReturnUrl)"
+            }
+        }
+    }
+
+    static func makeURLConfig() throws -> PayPalURLConfig {
+        let baseReturnUrl = "https://ppcp-mobile-demo-sandbox-87bbd7f0a27f.herokuapp.com"
         guard var returnAppURLComponents = URLComponents(string: "\(baseReturnUrl)/success"),
               let cancelAppURL = URL(string: "\(baseReturnUrl)/cancel") else {
-            fatalError("Failed to construct Shopper Session callback URLs for base return URL: \(baseReturnUrl)")
+            throw ConfigurationError.invalidCallbackURL(baseReturnUrl)
         }
 
         returnAppURLComponents.queryItems = (returnAppURLComponents.queryItems ?? []) + [
@@ -19,7 +29,7 @@ enum ShopperSessionURLConfigFactory {
         ]
 
         guard let returnAppURL = returnAppURLComponents.url else {
-            fatalError("Failed to construct Shopper Session callback URLs for base return URL: \(baseReturnUrl)")
+            throw ConfigurationError.invalidCallbackURL(baseReturnUrl)
         }
 
         let checkoutPath = "x-callback-url/paypal-sdk/paypal-checkout"
@@ -30,5 +40,5 @@ enum ShopperSessionURLConfigFactory {
             cancelAppURL: cancelAppURL,
             fallbackSchemeURL: URL(string: "\(scheme)://\(checkoutPath)")
         )
-    }()
+    }
 }

--- a/Demo/Demo/SwiftUIComponents/CommonComponents/ShopperSessionURLConfigFactory.swift
+++ b/Demo/Demo/SwiftUIComponents/CommonComponents/ShopperSessionURLConfigFactory.swift
@@ -9,8 +9,16 @@ enum ShopperSessionURLConfigFactory {
     static let urlConfig: PayPalURLConfig = {
         let baseReturnUrl = "https://ppcp-mobile-demo-sandbox-87bbd7f0a27f.herokuapp.com"
 
-        guard let returnAppURL = URL(string: "\(baseReturnUrl)/success"),
+        guard var returnAppURLComponents = URLComponents(string: "\(baseReturnUrl)/success"),
               let cancelAppURL = URL(string: "\(baseReturnUrl)/cancel") else {
+            fatalError("Failed to construct Shopper Session callback URLs for base return URL: \(baseReturnUrl)")
+        }
+
+        returnAppURLComponents.queryItems = (returnAppURLComponents.queryItems ?? []) + [
+            URLQueryItem(name: "platform", value: "iOS")
+        ]
+
+        guard let returnAppURL = returnAppURLComponents.url else {
             fatalError("Failed to construct Shopper Session callback URLs for base return URL: \(baseReturnUrl)")
         }
 

--- a/Sources/PayPalWebPayments/Models/PayPalCheckoutAnalyticsData+Analytics.swift
+++ b/Sources/PayPalWebPayments/Models/PayPalCheckoutAnalyticsData+Analytics.swift
@@ -1,5 +1,8 @@
 import UIKit
+
+#if canImport(CorePayments)
 import CorePayments
+#endif
 
 extension PayPalCheckoutAnalyticsData {
 

--- a/Sources/PayPalWebPayments/PayPalError.swift
+++ b/Sources/PayPalWebPayments/PayPalError.swift
@@ -32,6 +32,8 @@ public enum PayPalError {
 
         /// 7. `createPayPalSession()` was not called before `start()` or `vault()`
         case sessionNotStarted
+        
+        case sessionCreationFailed
     }
 
     public static let webSessionError: (Error) -> CoreSDKError = { error in
@@ -76,6 +78,12 @@ public enum PayPalError {
         code: Code.sessionNotStarted.rawValue,
         domain: domain,
         errorDescription: "createPayPalSession() must be called before start() or vault()."
+    )
+    
+    public static let sessionNotCreatedError = CoreSDKError(
+        code: Code.sessionCreationFailed.rawValue,
+        domain: domain,
+        errorDescription: "Failed to create PayPal Session"
     )
 
     // Helper function that allows handling of PayPal checkout cancel errors separately without having to cast the error to CoreSDKError and checking code and domain properties.

--- a/Sources/PayPalWebPayments/PayPalWebCheckoutClient.swift
+++ b/Sources/PayPalWebPayments/PayPalWebCheckoutClient.swift
@@ -172,44 +172,9 @@ public class PayPalWebCheckoutClient: NSObject {
                     errorDescription: error.localizedDescription,
                     checkoutAnalyticsData: analyticsData
                 )
-                await fallBackToPatchCCOOrWeb(session: nil, orderID: orderID, completion: completion)
+                let error = PayPalError.sessionNotCreatedError
+                DispatchQueue.main.async { completion(.failure(error)) }
             }
-        }
-    }
-
-    /// Falls back to the legacy PatchCCO app-switch-eligibility check (and, if that's not eligible or
-    /// fails to launch, to the web auth flow) when the Shopper Session fetch itself fails, so a session
-    /// fetch error doesn't fail checkout outright if app-switch or web checkout can still recover it.
-    private func fallBackToPatchCCOOrWeb(
-        session: ShopperSessionResult?,
-        orderID: String,
-        completion: @escaping (Result<PayPalWebCheckoutResult, CoreSDKError>) -> Void
-    ) async {
-        let completionOnce = makeCompletionOnce(completion)
-        let appInstalled = urlOpener.isPayPalAppInstalled()
-
-        guard appInstalled else {
-            startWebCheckoutFlow(session: session, orderID: orderID, fundingSource: .paypal, completion: completionOnce)
-            return
-        }
-
-        let result = await attemptAppSwitchIfEligible(
-            token: orderID,
-            tokenType: ExternalTokenKind.orderId,
-            handlers: SessionAppSwitchHandlers(
-                completionOnce: completionOnce,
-                setCompletion: { [weak self] in self?.appSwitchCompletion = $0 },
-                eventPrefix: "paypal-web-payments:checkout"
-            ),
-            paypalNativeAppInstalled: appInstalled
-        )
-        switch result {
-        case .launched:
-            // Do nothing here. We will complete when handleReturnURL is invoked.
-            return
-        case .fallback(let reason):
-            analyticsService?.sendEvent("paypal-web-payments:checkout:fallback-to-web:\(reason)")
-            startWebCheckoutFlow(session: session, orderID: orderID, fundingSource: .paypal, completion: completionOnce)
         }
     }
 
@@ -267,46 +232,9 @@ public class PayPalWebCheckoutClient: NSObject {
                     errorDescription: error.localizedDescription,
                     checkoutAnalyticsData: analyticsData
                 )
-                await fallBackToPatchCCOOrWebForVault(session: nil, setupTokenID: setupTokenID, completion: completion)
+                let error = PayPalError.sessionNotCreatedError
+                DispatchQueue.main.async { completion(.failure(error)) }
             }
-        }
-    }
-
-    /// Falls back to the legacy PatchCCO app-switch-eligibility check (and, if that's not eligible or
-    /// fails to launch, to the vault web auth flow) when the Shopper Session fetch itself fails, so a
-    /// session fetch error doesn't fail vault outright if app-switch or web vault can still recover it.
-    /// Mirrors `fallBackToPatchCCOOrWeb`, but checks eligibility for `setupTokenID` under
-    /// `ExternalTokenKind.vaultId` (per Android's equivalent implementation) instead of an order ID.
-    private func fallBackToPatchCCOOrWebForVault(
-        session: ShopperSessionResult?,
-        setupTokenID: String,
-        completion: @escaping (Result<PayPalVaultResult, CoreSDKError>) -> Void
-    ) async {
-        let completionOnce = makeCompletionOnce(completion)
-        let appInstalled = urlOpener.isPayPalAppInstalled()
-
-        guard appInstalled else {
-            startVaultWebAuthFlow(session: session, setupTokenID: setupTokenID, completion: completionOnce)
-            return
-        }
-
-        let result = await attemptAppSwitchIfEligible(
-            token: setupTokenID,
-            tokenType: ExternalTokenKind.vaultId,
-            handlers: SessionAppSwitchHandlers(
-                completionOnce: completionOnce,
-                setCompletion: { [weak self] in self?.vaultAppSwitchCompletion = $0 },
-                eventPrefix: "paypal-web-payments:vault-wo-purchase"
-            ),
-            paypalNativeAppInstalled: appInstalled
-        )
-        switch result {
-        case .launched:
-            // Do nothing here. We will complete when handleReturnURL is invoked.
-            return
-        case .fallback(let reason):
-            analyticsService?.sendEvent("paypal-web-payments:vault-wo-purchase:fallback-to-web:\(reason)")
-            startVaultWebAuthFlow(session: session, setupTokenID: setupTokenID, completion: completionOnce)
         }
     }
 

--- a/UnitTests/PayPalWebPaymentsTests/PayPalWebCheckoutClient_CreateSession_Tests.swift
+++ b/UnitTests/PayPalWebPaymentsTests/PayPalWebCheckoutClient_CreateSession_Tests.swift
@@ -191,69 +191,44 @@ class PayPalWebCheckoutClient_CreateSession_Tests: XCTestCase {
 
     // MARK: - Session fetch failure
     //
-    // A failed Shopper Session fetch no longer fails start()/vault() outright — it falls back to the
-    // legacy PatchCCO app-switch-eligibility check, then to the web auth flow, so the outcome now
-    // depends on that fallback rather than on the original session-fetch error (which is no longer
-    // surfaced to the caller).
+    // A failed Shopper Session fetch now fails start()/vault() immediately with
+    // `PayPalError.sessionNotCreatedError` — there is no fallback to the legacy PatchCCO
+    // app-switch-eligibility check or to the web auth flow, regardless of whether the PayPal
+    // app is installed.
 
-    func testCreatePayPalSession_whenSessionFetchFails_appNotInstalled_startFallsBackToWebCheckoutAndSucceeds() {
+    func testCreatePayPalSession_whenSessionFetchFails_startFailsWithSessionNotCreatedError() {
         mockCreateShopperSessionAPI.stubError = CoreSDKError(
             code: PayPalError.Code.unknown.rawValue,
             domain: PayPalError.domain,
             errorDescription: "Session fetch failed."
         )
         mockURLOpener.mockIsPayPalAppInstalled = false
-        mockClientConfigAPI.stubUpdateClientConfigResponse = ClientConfigResponse(updateClientConfig: true)
-        mockWebAuthenticationSession.cannedResponseURL = URL(
-            string: "https://fakeURL?token=order-123&PayerID=payer-456"
-        )
 
         payPalClient.createPayPalSession(sessionType: .checkout, urlConfig: fakeURLConfig)
 
-        let expectation = expectation(description: "start falls back to web checkout and succeeds")
-        payPalClient.start(orderID: "order-123") { result in
-            switch result {
-            case .success(let checkoutResult):
-                XCTAssertEqual(checkoutResult.orderID, "order-123")
-                XCTAssertEqual(checkoutResult.payerID, "payer-456")
-            case .failure(let error):
-                XCTFail("Expected fallback to web checkout to succeed, got: \(error.localizedDescription)")
-            }
-            expectation.fulfill()
-        }
-
-        waitForExpectations(timeout: 2)
-    }
-
-    func testCreatePayPalSession_whenSessionFetchFails_appNotInstalled_startFallsBackToWebCheckoutAndFails() {
-        mockCreateShopperSessionAPI.stubError = CoreSDKError(
-            code: PayPalError.Code.unknown.rawValue,
-            domain: PayPalError.domain,
-            errorDescription: "Session fetch failed."
-        )
-        mockURLOpener.mockIsPayPalAppInstalled = false
-        mockWebAuthenticationSession.cannedResponseURL = URL(string: "https://fakeURL?opType=cancel")
-
-        payPalClient.createPayPalSession(sessionType: .checkout, urlConfig: fakeURLConfig)
-
-        let expectation = expectation(description: "start falls back to web checkout and fails")
+        let expectation = expectation(description: "start fails with sessionNotCreatedError")
         payPalClient.start(orderID: "order-123") { result in
             switch result {
             case .success:
                 XCTFail("Expected failure")
             case .failure(let error):
-                // The fallback's own web checkout outcome (canceled here) is what's surfaced now —
-                // not the original "Session fetch failed." error.
                 XCTAssertEqual(error.domain, PayPalError.domain)
-                XCTAssertEqual(error.code, PayPalError.Code.checkoutCanceledError.rawValue)
+                XCTAssertEqual(error.code, PayPalError.Code.sessionCreationFailed.rawValue)
+                XCTAssertEqual(error.localizedDescription, "Failed to create PayPal Session")
             }
             expectation.fulfill()
         }
 
         waitForExpectations(timeout: 2)
+
+        // No fallback attempted — neither a web auth session nor an app switch URL was opened.
+        XCTAssertNil(mockWebAuthenticationSession.lastLaunchedURL)
+        XCTAssertNil(mockURLOpener.lastOpenedURL)
     }
 
-    func testCreatePayPalSession_whenSessionFetchFails_appInstalledAndEligible_startAttemptsAppSwitch() {
+    func testCreatePayPalSession_whenSessionFetchFails_appInstalledAndEligible_startStillFailsWithoutAppSwitch() {
+        // Even when the PayPal app is installed and PatchCCO would report eligibility, a failed
+        // session fetch short-circuits to an error instead of falling back to that legacy check.
         mockCreateShopperSessionAPI.stubError = CoreSDKError(
             code: PayPalError.Code.unknown.rawValue,
             domain: PayPalError.domain,
@@ -269,84 +244,54 @@ class PayPalWebCheckoutClient_CreateSession_Tests: XCTestCase {
 
         payPalClient.createPayPalSession(sessionType: .checkout, urlConfig: fakeURLConfig)
 
-        let urlOpenedExpectation = expectation(description: "app switch URL opened")
-        mockURLOpener.didOpenURLHandler = { urlOpenedExpectation.fulfill() }
-
-        let completionExpectation = expectation(description: "start completes after handleReturnURL")
+        let expectation = expectation(description: "start fails with sessionNotCreatedError")
         payPalClient.start(orderID: "order-123") { result in
-            if case .success(let checkoutResult) = result {
-                XCTAssertEqual(checkoutResult.orderID, "order-123")
-                XCTAssertEqual(checkoutResult.payerID, "payer-456")
-            } else {
-                XCTFail("Expected success via app switch")
-            }
-            completionExpectation.fulfill()
-        }
-
-        wait(for: [urlOpenedExpectation], timeout: 2)
-        XCTAssertNil(mockWebAuthenticationSession.lastLaunchedURL)
-
-        payPalClient.handleReturnURL(URL(string: "https://appswitch.com/success?token=order-123&PayerID=payer-456")!)
-        wait(for: [completionExpectation], timeout: 2)
-    }
-
-    func testCreatePayPalSession_whenSessionFetchFails_appNotInstalled_vaultFallsBackToWebAuthAndSucceeds() {
-        mockCreateShopperSessionAPI.stubError = CoreSDKError(
-            code: PayPalError.Code.unknown.rawValue,
-            domain: PayPalError.domain,
-            errorDescription: "Session fetch failed."
-        )
-        mockURLOpener.mockIsPayPalAppInstalled = false
-        mockWebAuthenticationSession.cannedResponseURL = URL(
-            string: "sdk.ios.paypal://vault/success?approval_token_id=token-abc&approval_session_id=session-xyz"
-        )
-
-        payPalClient.createPayPalSession(sessionType: .vaultWithoutPurchase, urlConfig: fakeURLConfig)
-
-        let expectation = expectation(description: "vault falls back to web auth and succeeds")
-        payPalClient.vault(setupTokenID: "fake-setup-token") { result in
             switch result {
-            case .success(let vaultResult):
-                XCTAssertEqual(vaultResult.tokenID, "token-abc")
-                XCTAssertEqual(vaultResult.approvalSessionID, "session-xyz")
+            case .success:
+                XCTFail("Expected failure")
             case .failure(let error):
-                XCTFail("Expected fallback to web auth to succeed, got: \(error.localizedDescription)")
+                XCTAssertEqual(error.domain, PayPalError.domain)
+                XCTAssertEqual(error.code, PayPalError.Code.sessionCreationFailed.rawValue)
             }
             expectation.fulfill()
         }
 
         waitForExpectations(timeout: 2)
+
+        XCTAssertNil(mockURLOpener.lastOpenedURL)
+        XCTAssertNil(mockWebAuthenticationSession.lastLaunchedURL)
     }
 
-    func testCreatePayPalSession_whenSessionFetchFails_appNotInstalled_vaultFallsBackToWebAuthAndFails() {
+    func testCreatePayPalSession_whenSessionFetchFails_vaultFailsWithSessionNotCreatedError() {
         mockCreateShopperSessionAPI.stubError = CoreSDKError(
             code: PayPalError.Code.unknown.rawValue,
             domain: PayPalError.domain,
             errorDescription: "Session fetch failed."
         )
         mockURLOpener.mockIsPayPalAppInstalled = false
-        mockWebAuthenticationSession.cannedResponseURL = URL(string: "https://fakeURL/cancel")
 
         payPalClient.createPayPalSession(sessionType: .vaultWithoutPurchase, urlConfig: fakeURLConfig)
 
-        let expectation = expectation(description: "vault falls back to web auth and fails")
+        let expectation = expectation(description: "vault fails with sessionNotCreatedError")
         payPalClient.vault(setupTokenID: "fake-setup-token") { result in
             switch result {
             case .success:
                 XCTFail("Expected failure")
             case .failure(let error):
-                // The fallback's own web auth outcome (canceled here) is what's surfaced now —
-                // not the original "Session fetch failed." error.
                 XCTAssertEqual(error.domain, PayPalError.domain)
-                XCTAssertEqual(error.code, PayPalError.Code.vaultCanceledError.rawValue)
+                XCTAssertEqual(error.code, PayPalError.Code.sessionCreationFailed.rawValue)
+                XCTAssertEqual(error.localizedDescription, "Failed to create PayPal Session")
             }
             expectation.fulfill()
         }
 
         waitForExpectations(timeout: 2)
+
+        XCTAssertNil(mockWebAuthenticationSession.lastLaunchedURL)
+        XCTAssertNil(mockURLOpener.lastOpenedURL)
     }
 
-    func testCreatePayPalSession_whenSessionFetchFails_appInstalledAndEligible_vaultAttemptsAppSwitch() {
+    func testCreatePayPalSession_whenSessionFetchFails_appInstalledAndEligible_vaultStillFailsWithoutAppSwitch() {
         mockCreateShopperSessionAPI.stubError = CoreSDKError(
             code: PayPalError.Code.unknown.rawValue,
             domain: PayPalError.domain,
@@ -362,27 +307,22 @@ class PayPalWebCheckoutClient_CreateSession_Tests: XCTestCase {
 
         payPalClient.createPayPalSession(sessionType: .vaultWithoutPurchase, urlConfig: fakeURLConfig)
 
-        let urlOpenedExpectation = expectation(description: "app switch URL opened")
-        mockURLOpener.didOpenURLHandler = { urlOpenedExpectation.fulfill() }
-
-        let completionExpectation = expectation(description: "vault completes after handleReturnURL")
+        let expectation = expectation(description: "vault fails with sessionNotCreatedError")
         payPalClient.vault(setupTokenID: "fake-setup-token") { result in
-            if case .success(let vaultResult) = result {
-                XCTAssertEqual(vaultResult.tokenID, "token-abc")
-                XCTAssertEqual(vaultResult.approvalSessionID, "session-xyz")
-            } else {
-                XCTFail("Expected success via app switch")
+            switch result {
+            case .success:
+                XCTFail("Expected failure")
+            case .failure(let error):
+                XCTAssertEqual(error.domain, PayPalError.domain)
+                XCTAssertEqual(error.code, PayPalError.Code.sessionCreationFailed.rawValue)
             }
-            completionExpectation.fulfill()
+            expectation.fulfill()
         }
 
-        wait(for: [urlOpenedExpectation], timeout: 2)
-        XCTAssertNil(mockWebAuthenticationSession.lastLaunchedURL)
+        waitForExpectations(timeout: 2)
 
-        payPalClient.handleReturnURL(
-            URL(string: "https://appswitch.com/success?approval_token_id=token-abc&approval_session_id=session-xyz")!
-        )
-        wait(for: [completionExpectation], timeout: 2)
+        XCTAssertNil(mockURLOpener.lastOpenedURL)
+        XCTAssertNil(mockWebAuthenticationSession.lastLaunchedURL)
     }
 
     // MARK: - Response fields
@@ -502,15 +442,18 @@ class PayPalWebCheckoutClient_CreateSession_Tests: XCTestCase {
         mockCreateShopperSessionAPI.stubError = CoreSDKError(
             code: 0, domain: "test", errorDescription: "fetch failed"
         )
-        // Session fetch failure now falls back to the web checkout flow (app not installed, per
-        // mockURLOpener's default) rather than failing immediately, so the fallback needs its own
-        // deterministic outcome for `firstStart`'s completion to fire at all.
-        mockWebAuthenticationSession.cannedResponseURL = URL(string: "https://fakeURL?opType=cancel")
 
         payPalClient.createPayPalSession(sessionType: .checkout, urlConfig: fakeURLConfig)
 
         let firstStart = expectation(description: "first start completes with error")
-        payPalClient.start(orderID: "order-123") { _ in firstStart.fulfill() }
+        payPalClient.start(orderID: "order-123") { result in
+            if case .failure(let error) = result {
+                XCTAssertEqual(error.code, PayPalError.Code.sessionCreationFailed.rawValue)
+            } else {
+                XCTFail("Expected sessionCreationFailed error")
+            }
+            firstStart.fulfill()
+        }
         wait(for: [firstStart], timeout: 2)
 
         // sessionTask should be cleared


### PR DESCRIPTION
### Reason for changes

- On Shopper Session creation error, we show error instead of falling back to PatchCCOWithAppSwitchEligibility

### Summary of changes

- Update PayPalWebCheckout Client 
- Introduce new error
- Update tests
- Add platform = iOS query param to return url (Demo app)

### Checklist

- [ ] Added a changelog entry

### Authors
> List GitHub usernames for everyone who contributed to this pull request.

- NastassiaRodzik