### PR TITLE
Add returnAppUrl/fallbackSchemeUrl validation error

### DIFF
--- a/Sources/PayPalWebPayments/Models/PayPalURLConfig.swift
+++ b/Sources/PayPalWebPayments/Models/PayPalURLConfig.swift
@@ -13,3 +13,16 @@ public struct PayPalURLConfig {
         self.fallbackSchemeURL = fallbackSchemeURL
     }
 }
+
+extension PayPalURLConfig {
+
+    /// True when neither `returnAppURL` nor `fallbackSchemeURL` is usable (both nil/blank).
+    /// Mirrors Android's ReturnToAppUrlConfig validation.
+    var isReturnToAppConfigMissing: Bool {
+        func isBlank(_ url: URL?) -> Bool {
+            guard let url else { return true }
+            return url.absoluteString.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty
+        }
+        return isBlank(returnAppURL) && isBlank(fallbackSchemeURL)
+    }
+}

--- a/Sources/PayPalWebPayments/Models/PayPalURLConfig.swift
+++ b/Sources/PayPalWebPayments/Models/PayPalURLConfig.swift
@@ -16,13 +16,23 @@ public struct PayPalURLConfig {
 
 extension PayPalURLConfig {
 
-    /// True when neither `returnAppURL` nor `fallbackSchemeURL` is usable (both nil/blank).
-    /// Mirrors Android's ReturnToAppUrlConfig validation.
+    /// True when neither `returnAppURL` nor `fallbackSchemeURL` is usable.
+    /// A URL is unusable when it's nil, blank, or "scheme-only" (no host and no path,
+    /// e.g. `myapp://` or `https://`) — i.e. it can't route the buyer back into the app.
+    /// Defensive early-fail so `start()`/`vault()` can fail immediately without a network call;
+    /// this is a guard, not full parity with Android's nullable `ReturnToAppUrlConfig`.
     var isReturnToAppConfigMissing: Bool {
-        func isBlank(_ url: URL?) -> Bool {
-            guard let url else { return true }
-            return url.absoluteString.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty
-        }
-        return isBlank(returnAppURL) && isBlank(fallbackSchemeURL)
+        isUnusable(returnAppURL) && isUnusable(fallbackSchemeURL)
+    }
+
+    /// A URL is "unusable" for return-to-app routing if it's nil, blank after trimming, or
+    /// scheme-only (no host and no meaningful path, e.g. `myapp://`, `https://`).
+    private func isUnusable(_ url: URL?) -> Bool {
+        guard let url else { return true }
+        let trimmed = url.absoluteString.trimmingCharacters(in: .whitespacesAndNewlines)
+        if trimmed.isEmpty { return true }
+        let hasHost = !(url.host?.isEmpty ?? true)
+        let hasPath = !url.path.isEmpty && url.path != "/"
+        return !hasHost && !hasPath
     }
 }

--- a/Sources/PayPalWebPayments/PayPalError.swift
+++ b/Sources/PayPalWebPayments/PayPalError.swift
@@ -32,6 +32,9 @@ public enum PayPalError {
 
         /// 7. `createPayPalSession()` was not called before `start()` or `vault()`
         case sessionNotStarted
+
+        /// 8. Neither returnAppURL nor fallbackSchemeURL was provided in the return-to-app URL config.
+        case returnToAppURLConfigMissingError
     }
 
     public static let webSessionError: (Error) -> CoreSDKError = { error in
@@ -76,6 +79,12 @@ public enum PayPalError {
         code: Code.sessionNotStarted.rawValue,
         domain: domain,
         errorDescription: "createPayPalSession() must be called before start() or vault()."
+    )
+
+    public static let returnToAppURLConfigMissingError = CoreSDKError(
+        code: Code.returnToAppURLConfigMissingError.rawValue,
+        domain: domain,
+        errorDescription: "PayPalURLConfig must provide at least one of returnAppURL or fallbackSchemeURL"
     )
 
     // Helper function that allows handling of PayPal checkout cancel errors separately without having to cast the error to CoreSDKError and checking code and domain properties.

--- a/Sources/PayPalWebPayments/PayPalWebCheckoutClient.swift
+++ b/Sources/PayPalWebPayments/PayPalWebCheckoutClient.swift
@@ -108,7 +108,7 @@ public class PayPalWebCheckoutClient: NSObject {
         sessionTask = nil
         configValidationError = nil
 
-        guard !urlConfig.isReturnToAppConfigMissing else {
+        if urlConfig.isReturnToAppConfigMissing {
             configValidationError = PayPalError.returnToAppURLConfigMissingError
             analyticsService?.sendEvent(
                 "paypal-web-payments:create-paypal-session:return-to-app-url-config-missing",

--- a/Sources/PayPalWebPayments/PayPalWebCheckoutClient.swift
+++ b/Sources/PayPalWebPayments/PayPalWebCheckoutClient.swift
@@ -40,6 +40,9 @@ public class PayPalWebCheckoutClient: NSObject {
     /// rather than crashing.
     private var tokenType: TokenType?
 
+    /// Set by `createPayPalSession()` when the return-to-app URL config is missing both URLs.
+    /// Checked by `start()`/`vault()` so they can fail fast without awaiting a session fetch.
+    private var configValidationError: CoreSDKError?
     // MARK: - Analytics State
     private var analyticsData: PayPalCheckoutAnalyticsData?
 
@@ -102,6 +105,17 @@ public class PayPalWebCheckoutClient: NSObject {
         userAction: PayPalUserAction = .continue
     ) {
         sessionTask?.cancel()
+        sessionTask = nil
+        configValidationError = nil
+
+        guard !urlConfig.isReturnToAppConfigMissing else {
+            configValidationError = PayPalError.returnToAppURLConfigMissingError
+            analyticsService?.sendEvent(
+                "paypal-web-payments:create-paypal-session:return-to-app-url-config-missing",
+                errorDescription: PayPalError.returnToAppURLConfigMissingError.errorDescription
+            )
+            return
+        }
 
         let tokenType = sessionType.tokenType
         self.tokenType = tokenType
@@ -137,6 +151,18 @@ public class PayPalWebCheckoutClient: NSObject {
         orderID: String,
         completion: @escaping (Result<PayPalWebCheckoutResult, CoreSDKError>) -> Void
     ) {
+        if let configValidationError {
+            analyticsService?.sendEvent(
+                "paypal-web-payments:checkout:return-to-app-url-config-missing",
+                errorDescription: configValidationError.errorDescription,
+                checkoutAnalyticsData: analyticsData
+            )
+            DispatchQueue.main.async {
+                completion(.failure(configValidationError))
+            }
+            return
+        }
+
         guard let task = sessionTask else {
             analyticsService?.sendEvent(
                 "paypal-web-payments:checkout:session-not-started",
@@ -232,6 +258,18 @@ public class PayPalWebCheckoutClient: NSObject {
         setupTokenID: String,
         completion: @escaping (Result<PayPalVaultResult, CoreSDKError>) -> Void
     ) {
+        if let configValidationError {
+            analyticsService?.sendEvent(
+                "paypal-web-payments:vault-wo-purchase:return-to-app-url-config-missing",
+                errorDescription: configValidationError.errorDescription,
+                checkoutAnalyticsData: analyticsData
+            )
+            DispatchQueue.main.async {
+                completion(.failure(configValidationError))
+            }
+            return
+        }
+
         guard let task = sessionTask else {
             analyticsService?.sendEvent(
                 "paypal-web-payments:vault-wo-purchase:session-not-started",

--- a/UnitTests/PayPalWebPaymentsTests/PayPalURLConfig_Tests.swift
+++ b/UnitTests/PayPalWebPaymentsTests/PayPalURLConfig_Tests.swift
@@ -14,4 +14,56 @@ class PayPalURLConfig_Tests: XCTestCase {
         XCTAssertEqual(config.cancelAppURL, URL(string: "myapp://cancel"))
         XCTAssertEqual(config.fallbackSchemeURL, URL(string: "myapp://fallback"))
     }
+
+    // MARK: - isReturnToAppConfigMissing
+
+    func testIsReturnToAppConfigMissing_whenBothUsable_returnsFalse() {
+        let config = PayPalURLConfig(
+            returnAppURL: URL(string: "https://example.com/return")!,
+            cancelAppURL: URL(string: "https://example.com/cancel")!,
+            fallbackSchemeURL: URL(string: "myapp://paypal/return")!
+        )
+
+        XCTAssertFalse(config.isReturnToAppConfigMissing)
+    }
+
+    func testIsReturnToAppConfigMissing_whenOnlyReturnAppURLUsable_fallbackNil_returnsFalse() {
+        let config = PayPalURLConfig(
+            returnAppURL: URL(string: "https://example.com/return")!,
+            cancelAppURL: URL(string: "https://example.com/cancel")!,
+            fallbackSchemeURL: nil
+        )
+
+        XCTAssertFalse(config.isReturnToAppConfigMissing)
+    }
+
+    func testIsReturnToAppConfigMissing_whenOnlyFallbackUsable_returnAppURLSchemeOnly_returnsFalse() {
+        let config = PayPalURLConfig(
+            returnAppURL: URL(string: "myapp://")!,
+            cancelAppURL: URL(string: "https://example.com/cancel")!,
+            fallbackSchemeURL: URL(string: "myapp://paypal/return")!
+        )
+
+        XCTAssertFalse(config.isReturnToAppConfigMissing)
+    }
+
+    func testIsReturnToAppConfigMissing_whenReturnSchemeOnly_fallbackNil_returnsTrue() {
+        let config = PayPalURLConfig(
+            returnAppURL: URL(string: "myapp://")!,
+            cancelAppURL: URL(string: "https://example.com/cancel")!,
+            fallbackSchemeURL: nil
+        )
+
+        XCTAssertTrue(config.isReturnToAppConfigMissing)
+    }
+
+    func testIsReturnToAppConfigMissing_whenBothSchemeOnly_returnsTrue() {
+        let config = PayPalURLConfig(
+            returnAppURL: URL(string: "https://")!,
+            cancelAppURL: URL(string: "https://example.com/cancel")!,
+            fallbackSchemeURL: URL(string: "myapp://")!
+        )
+
+        XCTAssertTrue(config.isReturnToAppConfigMissing)
+    }
 }

--- a/UnitTests/PayPalWebPaymentsTests/PayPalWebCheckoutClient_CreateSession_Tests.swift
+++ b/UnitTests/PayPalWebPaymentsTests/PayPalWebCheckoutClient_CreateSession_Tests.swift
@@ -140,6 +140,118 @@ class PayPalWebCheckoutClient_CreateSession_Tests: XCTestCase {
         waitForExpectations(timeout: 1)
     }
 
+    // MARK: - Guard: returnToAppURLConfigMissing
+
+    /// A config where neither `returnAppURL` nor `fallbackSchemeURL` is usable
+    /// (`returnAppURL` is scheme-only, `fallbackSchemeURL` is nil).
+    let missingReturnToAppURLConfig = PayPalURLConfig(
+        returnAppURL: URL(string: "myapp://")!,
+        cancelAppURL: URL(string: "myapp://cancel")!,
+        fallbackSchemeURL: nil
+    )
+
+    func testStart_whenReturnToAppConfigMissing_returnsConfigMissingError_andMakesNoNetworkCall() {
+        payPalClient.createPayPalSession(sessionType: .checkout, urlConfig: missingReturnToAppURLConfig)
+
+        let expectation = expectation(description: "start returns returnToAppURLConfigMissingError")
+        payPalClient.start(orderID: "fake-order-id") { result in
+            switch result {
+            case .success:
+                XCTFail("Expected failure")
+            case .failure(let error):
+                XCTAssertEqual(error.domain, PayPalError.domain)
+                XCTAssertEqual(error.code, PayPalError.Code.returnToAppURLConfigMissingError.rawValue)
+            }
+            expectation.fulfill()
+        }
+
+        waitForExpectations(timeout: 1)
+        XCTAssertEqual(mockCreateShopperSessionAPI.callCount, 0, "No session fetch expected for invalid config")
+    }
+
+    func testVault_whenReturnToAppConfigMissing_returnsConfigMissingError_andMakesNoNetworkCall() {
+        payPalClient.createPayPalSession(
+            sessionType: .vaultWithoutPurchase,
+            urlConfig: missingReturnToAppURLConfig
+        )
+
+        let expectation = expectation(description: "vault returns returnToAppURLConfigMissingError")
+        payPalClient.vault(setupTokenID: "fake-setup-token") { result in
+            switch result {
+            case .success:
+                XCTFail("Expected failure")
+            case .failure(let error):
+                XCTAssertEqual(error.domain, PayPalError.domain)
+                XCTAssertEqual(error.code, PayPalError.Code.returnToAppURLConfigMissingError.rawValue)
+            }
+            expectation.fulfill()
+        }
+
+        waitForExpectations(timeout: 1)
+        XCTAssertEqual(mockCreateShopperSessionAPI.callCount, 0, "No session fetch expected for invalid config")
+    }
+
+    func testStart_whenOnlyFallbackProvided_proceedsNormally() {
+        mockCreateShopperSessionAPI.stubResponse = makeIneligibleSession()
+        mockClientConfigAPI.stubUpdateClientConfigResponse = ClientConfigResponse(updateClientConfig: true)
+        mockWebAuthenticationSession.cannedResponseURL = URL(
+            string: "https://fakeURL?token=order-123&PayerID=payer-456"
+        )
+        // returnAppURL is scheme-only (unusable) but a usable fallback is provided — config is valid.
+        let onlyFallbackConfig = PayPalURLConfig(
+            returnAppURL: URL(string: "myapp://")!,
+            cancelAppURL: URL(string: "myapp://cancel")!,
+            fallbackSchemeURL: URL(string: "myapp://paypal/fallback")!
+        )
+
+        payPalClient.createPayPalSession(sessionType: .checkout, urlConfig: onlyFallbackConfig)
+
+        let expectation = expectation(description: "start proceeds to checkout with only a fallback")
+        payPalClient.start(orderID: "order-123") { result in
+            switch result {
+            case .success(let checkoutResult):
+                XCTAssertEqual(checkoutResult.orderID, "order-123")
+                XCTAssertEqual(checkoutResult.payerID, "payer-456")
+            case .failure(let error):
+                XCTFail("Expected success, got error: \(error.localizedDescription)")
+            }
+            expectation.fulfill()
+        }
+
+        waitForExpectations(timeout: 2)
+        XCTAssertGreaterThanOrEqual(mockCreateShopperSessionAPI.callCount, 1)
+    }
+
+    func testStart_whenOnlyReturnAppURLProvided_fallbackNil_proceedsNormally() {
+        mockCreateShopperSessionAPI.stubResponse = makeIneligibleSession()
+        mockClientConfigAPI.stubUpdateClientConfigResponse = ClientConfigResponse(updateClientConfig: true)
+        mockWebAuthenticationSession.cannedResponseURL = URL(
+            string: "https://fakeURL?token=order-123&PayerID=payer-456"
+        )
+        let onlyReturnConfig = PayPalURLConfig(
+            returnAppURL: URL(string: "https://example.com/return")!,
+            cancelAppURL: URL(string: "https://example.com/cancel")!,
+            fallbackSchemeURL: nil
+        )
+
+        payPalClient.createPayPalSession(sessionType: .checkout, urlConfig: onlyReturnConfig)
+
+        let expectation = expectation(description: "start proceeds to checkout with only a return URL")
+        payPalClient.start(orderID: "order-123") { result in
+            switch result {
+            case .success(let checkoutResult):
+                XCTAssertEqual(checkoutResult.orderID, "order-123")
+                XCTAssertEqual(checkoutResult.payerID, "payer-456")
+            case .failure(let error):
+                XCTFail("Expected success, got error: \(error.localizedDescription)")
+            }
+            expectation.fulfill()
+        }
+
+        waitForExpectations(timeout: 2)
+        XCTAssertGreaterThanOrEqual(mockCreateShopperSessionAPI.callCount, 1)
+    }
+
     // MARK: - Success flow
 
     func testCreatePayPalSession_whenSessionSucceeds_startProceedsToCheckout() {


### PR DESCRIPTION
### Reason for changes
To have parity with Android SDK, we check the returned returnAppUrl and fallbackSchemeUrl, and fail early in case they are both empty.

In the case of returnAppUrl, because it's not an optional value, we check for usability of the url.

Ticket: https://paypal.atlassian.net/browse/DTPPMOBILE-580

### Summary of changes

- Added new error
- Added validations before session creations to avoid calls
- Added tests

### Checklist

- [ ] Added a changelog entry

### Authors
> EdgarBarocio