### PR TITLE
Add analytics tracking to cancel button on Login popup

### DIFF
--- a/Sources/PayPalWebPayments/PayPalWebCheckoutClient.swift
+++ b/Sources/PayPalWebPayments/PayPalWebCheckoutClient.swift
@@ -815,6 +815,11 @@ public class PayPalWebCheckoutClient: NSObject {
             switch error {
             case ASWebAuthenticationSessionError.canceledLogin:
                 sdkError = PayPalError.vaultCanceledError
+                analyticsService?.sendEvent(
+                    "paypal:tokenize:browser-login:canceled",
+                    errorDescription: sdkError.errorDescription,
+                    checkoutAnalyticsData: analyticsData
+                )
             default:
                 sdkError = PayPalError.webSessionError(error)
             }

--- a/Sources/PayPalWebPayments/PayPalWebCheckoutClient.swift
+++ b/Sources/PayPalWebPayments/PayPalWebCheckoutClient.swift
@@ -768,7 +768,7 @@ public class PayPalWebCheckoutClient: NSObject {
             case ASWebAuthenticationSessionError.canceledLogin:
                 sdkError = PayPalError.checkoutCanceledError
                 analyticsService?.sendEvent(
-                    "paypal:tokenize:browser-login:canceled",
+                    "paypal:tokenize:browser-login:alert-canceled",
                     errorDescription: sdkError.errorDescription,
                     checkoutAnalyticsData: analyticsData
                 )
@@ -816,7 +816,7 @@ public class PayPalWebCheckoutClient: NSObject {
             case ASWebAuthenticationSessionError.canceledLogin:
                 sdkError = PayPalError.vaultCanceledError
                 analyticsService?.sendEvent(
-                    "paypal:tokenize:browser-login:canceled",
+                    "paypal:tokenize:browser-login:alert-canceled",
                     errorDescription: sdkError.errorDescription,
                     checkoutAnalyticsData: analyticsData
                 )


### PR DESCRIPTION
### Reason for changes

There is an ask from the Analytics team: to report paypal:tokenize:browser-login:alert-canceled event by analogy with BT Native iOS

### Summary of changes

- Added tracking on cancel button when the alert is shown in Vaulting, only added on vaulting because this is already tracked on web checkout flow.

### Checklist

- [ ] Added a changelog entry

### Authors

- EdgarBarocio