### PR TITLE
Analytics reporting when cancelling flow.

### DIFF
--- a/Sources/CardPayments/CardClient.swift
+++ b/Sources/CardPayments/CardClient.swift
@@ -184,16 +184,13 @@ public class CardClient: NSObject {
                     self?.analyticsService?.sendEvent("card-payments:approve-order:auth-challenge-presentation:failed")
                 }
             },
+            sessionDidCancel: { [weak self] in
+                self?.notify3dsCheckoutCancelWithError(with: CardError.threeDSecureCanceledError, completion: completion)
+            },
             sessionDidComplete: { _, error in
-                if let error = error {
-                    switch error {
-                    case ASWebAuthenticationSessionError.canceledLogin:
-                        self.notify3dsCheckoutCancelWithError(with: CardError.threeDSecureCanceledError, completion: completion)
-                        return
-                    default:
-                        self.notify3dsCheckoutFailure(with: CardError.threeDSecureError(error), completion: completion)
-                        return
-                    }
+                if let error {
+                    self.notify3dsCheckoutFailure(with: CardError.threeDSecureError(error), completion: completion)
+                    return
                 }
 
                 let cardResult = CardResult(orderID: orderId, status: nil, didAttemptThreeDSecureAuthentication: true)
@@ -224,16 +221,13 @@ public class CardClient: NSObject {
                     self?.analyticsService?.sendEvent("card-payments:vault-wo-purchase:auth-challenge-presentation:failed")
                 }
             },
+            sessionDidCancel: { [weak self] in
+                self?.notify3dsVaultCancelWithError(with: CardError.threeDSecureCanceledError, completion: completion)
+            },
             sessionDidComplete: { _, error in
-                if let error = error {
-                    switch error {
-                    case ASWebAuthenticationSessionError.canceledLogin:
-                        self.notify3dsVaultCancelWithError(with: CardError.threeDSecureCanceledError, completion: completion)
-                        return
-                    default:
-                        self.notify3dsVaultFailure(with: CardError.threeDSecureError(error), completion: completion)
-                        return
-                    }
+                if let error {
+                    self.notify3dsVaultFailure(with: CardError.threeDSecureError(error), completion: completion)
+                    return
                 }
 
                 let cardVaultResult = CardVaultResult(setupTokenID: setupTokenID, status: nil, didAttemptThreeDSecureAuthentication: true)

--- a/Sources/CorePayments/WebAuthenticationSession.swift
+++ b/Sources/CorePayments/WebAuthenticationSession.swift
@@ -8,13 +8,21 @@ public class WebAuthenticationSession: NSObject {
         url: URL,
         context: ASWebAuthenticationPresentationContextProviding,
         sessionDidDisplay: @escaping (Bool) -> Void,
+        sessionDidCancel: (() -> Void)? = nil,
         sessionDidComplete: @escaping (URL?, Error?) -> Void
     ) {
         let authenticationSession = ASWebAuthenticationSession(
             url: url,
-            callbackURLScheme: PayPalCoreConstants.callbackURLScheme,
-            completionHandler: sessionDidComplete
-        )
+            callbackURLScheme: PayPalCoreConstants.callbackURLScheme
+        ) { url, error in
+            if let error = error as NSError?,
+               error.domain == ASWebAuthenticationSessionError.errorDomain,
+               error.code == ASWebAuthenticationSessionError.canceledLogin.rawValue {
+                sessionDidCancel?()
+            } else {
+                sessionDidComplete(url, error)
+            }
+        }
 
         authenticationSession.presentationContextProvider = context
 

--- a/Sources/PayPalWebPayments/PayPalWebCheckoutClient.swift
+++ b/Sources/PayPalWebPayments/PayPalWebCheckoutClient.swift
@@ -972,8 +972,8 @@ public class PayPalWebCheckoutClient: NSObject {
 
     private func sendBrowserLoginCancelEvent(errorDescription: String?) {
         let eventName = webSessionReturned
-            ? "paypal-web-payments:checkout:browser-login:canceled"
-            : "paypal-web-payments:checkout:browser-login:alert-canceled"
+            ? "paypal:tokenize:browser-login:canceled"
+            : "paypal:tokenize:browser-login:alert-canceled"
         analyticsService?.sendEvent(
             eventName,
             errorDescription: errorDescription,

--- a/Sources/PayPalWebPayments/PayPalWebCheckoutClient.swift
+++ b/Sources/PayPalWebPayments/PayPalWebCheckoutClient.swift
@@ -1,4 +1,5 @@
 import AuthenticationServices
+import UIKit
 
 #if canImport(CorePayments)
 import CorePayments
@@ -42,6 +43,10 @@ public class PayPalWebCheckoutClient: NSObject {
 
     // MARK: - Analytics State
     private var analyticsData: PayPalCheckoutAnalyticsData?
+
+    /// Whether the web auth modal (close button) appeared after the consent alert.
+    private var webAuthSheetPresented = false
+    private var webAuthModalPollTimer: Timer?
 
     // MARK: - Initializer
 
@@ -694,11 +699,13 @@ public class PayPalWebCheckoutClient: NSObject {
                 return
             }
 
+            webAuthSheetPresented = false
             webAuthenticationSession.start(
                 url: payPalCheckoutURLComponents,
                 context: self,
                 sessionDidDisplay: { [weak self] didDisplay in
                     if didDisplay {
+                        self?.beginMonitoringWebAuthModal()
                         self?.analyticsService?.sendEvent(
                             "paypal-web-payments:checkout:auth-challenge-presentation:succeeded",
                             checkoutAnalyticsData: self?.analyticsData
@@ -739,10 +746,14 @@ public class PayPalWebCheckoutClient: NSObject {
                 notifyVaultFailure(with: PayPalError.payPalURLError, completion: completion)
                 return
             }
+            webAuthSheetPresented = false
             webAuthenticationSession.start(
                 url: vaultCheckoutURL,
                 context: self,
                 sessionDidDisplay: { [weak self] didDisplay in
+                    if didDisplay {
+                        self?.beginMonitoringWebAuthModal()
+                    }
                     let event = didDisplay
                         ? "paypal-web-payments:vault-wo-purchase:auth-challenge-presentation:succeeded"
                         : "paypal-web-payments:vault-wo-purchase:auth-challenge-presentation:failed"
@@ -761,6 +772,7 @@ public class PayPalWebCheckoutClient: NSObject {
         error: Error?,
         completion: @escaping (Result<PayPalWebCheckoutResult, CoreSDKError>) -> Void
     ) {
+        stopMonitoringWebAuthModal()
         defer { analyticsData = nil }
         if let error {
             let sdkError: CoreSDKError
@@ -768,7 +780,7 @@ public class PayPalWebCheckoutClient: NSObject {
             case ASWebAuthenticationSessionError.canceledLogin:
                 sdkError = PayPalError.checkoutCanceledError
                 analyticsService?.sendEvent(
-                    "paypal:tokenize:browser-login:canceled",
+                    browserLoginEventNameForCanceledLogin(),
                     errorDescription: sdkError.errorDescription,
                     checkoutAnalyticsData: analyticsData
                 )
@@ -809,12 +821,18 @@ public class PayPalWebCheckoutClient: NSObject {
         error: Error?,
         completion: @escaping (Result<PayPalVaultResult, CoreSDKError>) -> Void
     ) {
+        stopMonitoringWebAuthModal()
         defer { analyticsData = nil }
         if let error {
             let sdkError: CoreSDKError
             switch error {
             case ASWebAuthenticationSessionError.canceledLogin:
                 sdkError = PayPalError.vaultCanceledError
+                analyticsService?.sendEvent(
+                    browserLoginEventNameForCanceledLogin(),
+                    errorDescription: sdkError.errorDescription,
+                    checkoutAnalyticsData: analyticsData
+                )
             default:
                 sdkError = PayPalError.webSessionError(error)
             }
@@ -969,6 +987,52 @@ public class PayPalWebCheckoutClient: NSObject {
     private func getQueryStringParameter(url: String, param: String) -> String? {
         guard let url = URLComponents(string: url) else { return nil }
         return url.queryItems?.first { $0.name == param }?.value
+    }
+
+    /// Maps `canceledLogin` to the correct tokenize event based on whether the web auth modal was shown.
+    private func browserLoginEventNameForCanceledLogin() -> String {
+        webAuthSheetPresented
+            ? "paypal:tokenize:browser-login:canceled"
+            : "paypal:tokenize:browser-login:alert-canceled"
+    }
+
+    private func beginMonitoringWebAuthModal() {
+        webAuthModalPollTimer?.invalidate()
+        webAuthModalPollTimer = Timer.scheduledTimer(withTimeInterval: 0.1, repeats: true) { [weak self] timer in
+            guard let self, Self.isWebAuthModalVisible else { return }
+            self.webAuthSheetPresented = true
+            timer.invalidate()
+            self.webAuthModalPollTimer = nil
+        }
+    }
+
+    private func stopMonitoringWebAuthModal() {
+        webAuthModalPollTimer?.invalidate()
+        webAuthModalPollTimer = nil
+    }
+
+    private static var isWebAuthModalVisible: Bool {
+        let windows: [UIWindow]
+        if #available(iOS 15, *) {
+            windows = UIApplication.shared.connectedScenes
+                .compactMap { $0 as? UIWindowScene }
+                .flatMap(\.windows)
+        } else {
+            windows = UIApplication.shared.windows
+        }
+        return windows.contains { window in
+            var viewController = window.rootViewController
+            while let current = viewController {
+                let className = String(describing: type(of: current))
+                if className.contains("SFAuthentication")
+                    || className.contains("SFSafari")
+                    || className.contains("AuthenticationSession") {
+                    return true
+                }
+                viewController = current.presentedViewController
+            }
+            return false
+        }
     }
 
     // MARK: - Private: Notify Helpers

--- a/Sources/PayPalWebPayments/PayPalWebCheckoutClient.swift
+++ b/Sources/PayPalWebPayments/PayPalWebCheckoutClient.swift
@@ -972,8 +972,8 @@ public class PayPalWebCheckoutClient: NSObject {
 
     private func sendBrowserLoginCancelEvent(errorDescription: String?) {
         let eventName = webSessionReturned
-            ? "paypal:tokenize:browser-login:canceled"
-            : "paypal:tokenize:browser-login:alert-canceled"
+            ? "paypal-web-payments:checkout:browser-login:canceled"
+            : "paypal-web-payments:checkout:browser-login:alert-canceled"
         analyticsService?.sendEvent(
             eventName,
             errorDescription: errorDescription,

--- a/Sources/PayPalWebPayments/PayPalWebCheckoutClient.swift
+++ b/Sources/PayPalWebPayments/PayPalWebCheckoutClient.swift
@@ -45,7 +45,7 @@ public class PayPalWebCheckoutClient: NSObject {
     private var analyticsData: PayPalCheckoutAnalyticsData?
 
     /// Indicates whether the buyer progressed past the consent alert into the web auth modal.
-    private var webSessionReturned = false
+    private var didApplicationBecomeActive = false
 
     private let systemLatency = SystemLatencyTracker()
 
@@ -100,7 +100,7 @@ public class PayPalWebCheckoutClient: NSObject {
     }
 
     @objc private func applicationDidBecomeActive() {
-        webSessionReturned = true
+        didApplicationBecomeActive = true
     }
 
     // MARK: - Session Creation
@@ -677,7 +677,7 @@ public class PayPalWebCheckoutClient: NSObject {
                 return
             }
 
-            webSessionReturned = false
+            didApplicationBecomeActive = false
             endSystemLatencyTracking(presentationType: .browser)
             webAuthenticationSession.start(
                 url: payPalCheckoutURLComponents,
@@ -730,7 +730,7 @@ public class PayPalWebCheckoutClient: NSObject {
                 notifyVaultFailure(with: PayPalError.payPalURLError, completion: completion)
                 return
             }
-            webSessionReturned = false
+            didApplicationBecomeActive = false
             endSystemLatencyTracking(presentationType: .browser)
             webAuthenticationSession.start(
                 url: vaultCheckoutURL,
@@ -971,7 +971,7 @@ public class PayPalWebCheckoutClient: NSObject {
     }
 
     private func sendBrowserLoginCancelEvent(errorDescription: String?) {
-        let eventName = webSessionReturned
+        let eventName = didApplicationBecomeActive
             ? "paypal-web-payments:checkout:browser-login:canceled"
             : "paypal-web-payments:checkout:browser-login:alert-canceled"
         analyticsService?.sendEvent(

--- a/Sources/PayPalWebPayments/PayPalWebCheckoutClient.swift
+++ b/Sources/PayPalWebPayments/PayPalWebCheckoutClient.swift
@@ -44,9 +44,8 @@ public class PayPalWebCheckoutClient: NSObject {
     // MARK: - Analytics State
     private var analyticsData: PayPalCheckoutAnalyticsData?
 
-    /// Whether the web auth modal (close button) appeared after the consent alert.
-    private var webAuthSheetPresented = false
-    private var webAuthModalPollTimer: Timer?
+    /// Indicates whether the buyer progressed past the consent alert into the web auth modal.
+    private var webSessionReturned = false
 
     // MARK: - Initializer
 
@@ -59,6 +58,13 @@ public class PayPalWebCheckoutClient: NSObject {
         self.clientConfigAPI = UpdateClientConfigAPI(coreConfig: config)
         self.patchCCOAPI = PatchCCOWithAppSwitchEligibility(coreConfig: config)
         self.createShopperSessionAPI = CreateShopperSessionAPI(coreConfig: config)
+        super.init()
+        NotificationCenter.default.addObserver(
+            self,
+            selector: #selector(applicationDidBecomeActive),
+            name: UIApplication.didBecomeActiveNotification,
+            object: nil
+        )
     }
 
     /// For internal use for testing/mocking purposes.
@@ -78,6 +84,21 @@ public class PayPalWebCheckoutClient: NSObject {
         self.createShopperSessionAPI = createShopperSessionAPI
         
         analyticsService = AnalyticsService(coreConfig: config)
+        super.init()
+        NotificationCenter.default.addObserver(
+            self,
+            selector: #selector(applicationDidBecomeActive),
+            name: UIApplication.didBecomeActiveNotification,
+            object: nil
+        )
+    }
+
+    deinit {
+        NotificationCenter.default.removeObserver(self)
+    }
+
+    @objc private func applicationDidBecomeActive() {
+        webSessionReturned = true
     }
 
     // MARK: - Session Creation
@@ -699,18 +720,21 @@ public class PayPalWebCheckoutClient: NSObject {
                 return
             }
 
-            webAuthSheetPresented = false
+            webSessionReturned = false
             webAuthenticationSession.start(
                 url: payPalCheckoutURLComponents,
                 context: self,
                 sessionDidDisplay: { [weak self] didDisplay in
                     if didDisplay {
-                        self?.beginMonitoringWebAuthModal()
                         self?.analyticsService?.sendEvent(
                             "paypal-web-payments:checkout:auth-challenge-presentation:succeeded",
                             checkoutAnalyticsData: self?.analyticsData
                         )
                     }
+                },
+                sessionDidCancel: { [weak self] in
+                    guard let self else { return }
+                    self.handleCheckoutWebAuthCancel(completion: completion)
                 },
                 sessionDidComplete: { [weak self] url, error in
                     guard let self else { return }
@@ -746,18 +770,19 @@ public class PayPalWebCheckoutClient: NSObject {
                 notifyVaultFailure(with: PayPalError.payPalURLError, completion: completion)
                 return
             }
-            webAuthSheetPresented = false
+            webSessionReturned = false
             webAuthenticationSession.start(
                 url: vaultCheckoutURL,
                 context: self,
                 sessionDidDisplay: { [weak self] didDisplay in
-                    if didDisplay {
-                        self?.beginMonitoringWebAuthModal()
-                    }
                     let event = didDisplay
                         ? "paypal-web-payments:vault-wo-purchase:auth-challenge-presentation:succeeded"
                         : "paypal-web-payments:vault-wo-purchase:auth-challenge-presentation:failed"
                     self?.analyticsService?.sendEvent(event, checkoutAnalyticsData: self?.analyticsData)
+                },
+                sessionDidCancel: { [weak self] in
+                    guard let self else { return }
+                    self.handleVaultWebAuthCancel(completion: completion)
                 },
                 sessionDidComplete: { [weak self] url, error in
                     guard let self else { return }
@@ -767,32 +792,29 @@ public class PayPalWebCheckoutClient: NSObject {
         }
     }
 
+    private func handleCheckoutWebAuthCancel(
+        completion: @escaping (Result<PayPalWebCheckoutResult, CoreSDKError>) -> Void
+    ) {
+        defer { analyticsData = nil }
+        let sdkError = PayPalError.checkoutCanceledError
+        sendBrowserLoginCancelEvent(errorDescription: sdkError.errorDescription)
+        sessionTask = nil
+        notifyCheckoutFailure(with: sdkError, completion: completion)
+    }
+
     private func handleCheckoutWebAuthCompletion(
         url: URL?,
         error: Error?,
         completion: @escaping (Result<PayPalWebCheckoutResult, CoreSDKError>) -> Void
     ) {
-        stopMonitoringWebAuthModal()
         defer { analyticsData = nil }
         if let error {
-            let sdkError: CoreSDKError
-            switch error {
-            case ASWebAuthenticationSessionError.canceledLogin:
-                sdkError = PayPalError.checkoutCanceledError
-                analyticsService?.sendEvent(
-                    browserLoginEventNameForCanceledLogin(),
-                    errorDescription: sdkError.errorDescription,
-                    checkoutAnalyticsData: analyticsData
-                )
-            default:
-                sdkError = PayPalError.webSessionError(error)
-                analyticsService?.sendEvent(
-                    "paypal-web-payments:checkout:auth-challenge-presentation:failed",
-                    errorDescription: sdkError.errorDescription,
-                    checkoutAnalyticsData: analyticsData
-                )
-            }
-
+            let sdkError = PayPalError.webSessionError(error)
+            analyticsService?.sendEvent(
+                "paypal-web-payments:checkout:auth-challenge-presentation:failed",
+                errorDescription: sdkError.errorDescription,
+                checkoutAnalyticsData: analyticsData
+            )
             sessionTask = nil
             notifyCheckoutFailure(with: sdkError, completion: completion)
         }
@@ -816,28 +838,26 @@ public class PayPalWebCheckoutClient: NSObject {
         }
     }
 
+    private func handleVaultWebAuthCancel(
+        completion: @escaping (Result<PayPalVaultResult, CoreSDKError>) -> Void
+    ) {
+        defer { analyticsData = nil }
+        let sdkError = PayPalError.vaultCanceledError
+        sendBrowserLoginCancelEvent(errorDescription: sdkError.errorDescription)
+        sessionTask = nil
+        notifyVaultCancelWithError(with: sdkError, completion: completion)
+    }
+
     private func handleVaultWebAuthCompletion(
         url: URL?,
         error: Error?,
         completion: @escaping (Result<PayPalVaultResult, CoreSDKError>) -> Void
     ) {
-        stopMonitoringWebAuthModal()
         defer { analyticsData = nil }
         if let error {
-            let sdkError: CoreSDKError
-            switch error {
-            case ASWebAuthenticationSessionError.canceledLogin:
-                sdkError = PayPalError.vaultCanceledError
-                analyticsService?.sendEvent(
-                    browserLoginEventNameForCanceledLogin(),
-                    errorDescription: sdkError.errorDescription,
-                    checkoutAnalyticsData: analyticsData
-                )
-            default:
-                sdkError = PayPalError.webSessionError(error)
-            }
+            let sdkError = PayPalError.webSessionError(error)
             sessionTask = nil
-            notifyVaultCancelWithError(with: sdkError, completion: completion)
+            notifyVaultFailure(with: sdkError, completion: completion)
         }
 
         if let url {
@@ -989,50 +1009,15 @@ public class PayPalWebCheckoutClient: NSObject {
         return url.queryItems?.first { $0.name == param }?.value
     }
 
-    /// Maps `canceledLogin` to the correct tokenize event based on whether the web auth modal was shown.
-    private func browserLoginEventNameForCanceledLogin() -> String {
-        webAuthSheetPresented
+    private func sendBrowserLoginCancelEvent(errorDescription: String?) {
+        let eventName = webSessionReturned
             ? "paypal:tokenize:browser-login:canceled"
             : "paypal:tokenize:browser-login:alert-canceled"
-    }
-
-    private func beginMonitoringWebAuthModal() {
-        webAuthModalPollTimer?.invalidate()
-        webAuthModalPollTimer = Timer.scheduledTimer(withTimeInterval: 0.1, repeats: true) { [weak self] timer in
-            guard let self, Self.isWebAuthModalVisible else { return }
-            self.webAuthSheetPresented = true
-            timer.invalidate()
-            self.webAuthModalPollTimer = nil
-        }
-    }
-
-    private func stopMonitoringWebAuthModal() {
-        webAuthModalPollTimer?.invalidate()
-        webAuthModalPollTimer = nil
-    }
-
-    private static var isWebAuthModalVisible: Bool {
-        let windows: [UIWindow]
-        if #available(iOS 15, *) {
-            windows = UIApplication.shared.connectedScenes
-                .compactMap { $0 as? UIWindowScene }
-                .flatMap(\.windows)
-        } else {
-            windows = UIApplication.shared.windows
-        }
-        return windows.contains { window in
-            var viewController = window.rootViewController
-            while let current = viewController {
-                let className = String(describing: type(of: current))
-                if className.contains("SFAuthentication")
-                    || className.contains("SFSafari")
-                    || className.contains("AuthenticationSession") {
-                    return true
-                }
-                viewController = current.presentedViewController
-            }
-            return false
-        }
+        analyticsService?.sendEvent(
+            eventName,
+            errorDescription: errorDescription,
+            checkoutAnalyticsData: analyticsData
+        )
     }
 
     // MARK: - Private: Notify Helpers

--- a/Sources/PayPalWebPayments/PayPalWebCheckoutClient.swift
+++ b/Sources/PayPalWebPayments/PayPalWebCheckoutClient.swift
@@ -1011,8 +1011,8 @@ public class PayPalWebCheckoutClient: NSObject {
 
     private func sendBrowserLoginCancelEvent(errorDescription: String?) {
         let eventName = webSessionReturned
-            ? "paypal:tokenize:browser-login:canceled"
-            : "paypal:tokenize:browser-login:alert-canceled"
+            ? "paypal-web-payments:checkout:browser-login:canceled"
+            : "paypal-web-payments:checkout:browser-login:alert-canceled"
         analyticsService?.sendEvent(
             eventName,
             errorDescription: errorDescription,

--- a/UnitTests/TestShared/MockWebAuthenticationSession.swift
+++ b/UnitTests/TestShared/MockWebAuthenticationSession.swift
@@ -15,12 +15,20 @@ class MockWebAuthenticationSession: WebAuthenticationSession {
         url: URL,
         context: ASWebAuthenticationPresentationContextProviding,
         sessionDidDisplay: @escaping (Bool) -> Void,
+        sessionDidCancel: (() -> Void)? = nil,
         sessionDidComplete: @escaping (URL?, Error?) -> Void
     ) {
         lastLaunchedURL = url
         onStart?()
-        
+
         sessionDidDisplay(cannedDidDisplayResult)
-        sessionDidComplete(cannedResponseURL, cannedErrorResponse)
+
+        if let error = cannedErrorResponse as? NSError,
+           error.domain == ASWebAuthenticationSessionError.errorDomain,
+           error.code == ASWebAuthenticationSessionError.canceledLogin.rawValue {
+            sessionDidCancel?()
+        } else {
+            sessionDidComplete(cannedResponseURL, cannedErrorResponse)
+        }
     }
 }


### PR DESCRIPTION
### Reason for changes

There is an ask from the Analytics team: to report paypal:tokenize:browser-login:alert-canceled event by analogy with BT Native iOS

### Summary of changes

Added tracking on cancel button when the alert is shown in Vaulting, only added on vaulting because this is already tracked on web checkout flow.

### Checklist


- [ ] Added a changelog entry

### Authors

EdgarBarocio