### PR TITLE
Rename Demo and CorePayments Environment Types

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,7 @@
 * CorePayments
   * **Breaking:** `CoreConfig` requires a `merchantID` parameter; optional `bnCode` parameter added. See the [v3 Migration Guide](v3_MIGRATION_GUIDE.md) for details.
   * **Breaking:** Remove `PatchCCOWithAppSwitchEligibility` (and its `AppSwitchEligibility` response type) and the `ExternalTokenKind` constants — the legacy PatchCCO app-switch-eligibility path is no longer used
+  * **Breaking:** Rename `Environment` to `CoreEnvironment`
   * Improve error messages for non-JSON/unstructured error responses to include the HTTP status, request URL, and raw response body
 
 ## 2.0.1 (2025-11-03)

--- a/Demo/Demo.xcodeproj/project.pbxproj
+++ b/Demo/Demo.xcodeproj/project.pbxproj
@@ -40,9 +40,6 @@
 		3BA570032AA053AE0081D14F /* PayPalWebCreateOrderView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3BA570022AA053AE0081D14F /* PayPalWebCreateOrderView.swift */; };
 		3BA570072AA0DF330081D14F /* PayPalWebButtonsView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3BA570062AA0DF330081D14F /* PayPalWebButtonsView.swift */; };
 		3BA5700B2AA13C1C0081D14F /* CoreConfigManager.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3BA5700A2AA13C1C0081D14F /* CoreConfigManager.swift */; };
-		A30ABBEB9DF94308BED38BD9 /* UserIdentityView.swift in Sources */ = {isa = PBXBuildFile; fileRef = C5DDBA0EEDF0422CA93EDE6B /* UserIdentityView.swift */; };
-		6A4CB47A11720F32B630C6D5 /* UserIdentityFactory.swift in Sources */ = {isa = PBXBuildFile; fileRef = E100A9BBE64964EE134DB022 /* UserIdentityFactory.swift */; };
-		554657F5B5FD929C70949517 /* ShopperSessionURLConfigFactory.swift in Sources */ = {isa = PBXBuildFile; fileRef = C2DFDC66B206AB9B11A80589 /* ShopperSessionURLConfigFactory.swift */; };
 		3BB60B532B1F9F1100A298CF /* PayPalVaultView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3BB60B522B1F9F1100A298CF /* PayPalVaultView.swift */; };
 		3BB60B552B1FA00C00A298CF /* PayPalVaultViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3BB60B542B1FA00C00A298CF /* PayPalVaultViewModel.swift */; };
 		3BB7A9772A5CA6FD00C05140 /* MerchantIntegration.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3BB7A9762A5CA6FD00C05140 /* MerchantIntegration.swift */; };
@@ -58,6 +55,8 @@
 		3BF999782A8AD072009CBDF2 /* CreatePaymentTokenView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3BF999772A8AD072009CBDF2 /* CreatePaymentTokenView.swift */; };
 		3BF9997A2A8AE12C009CBDF2 /* PaymentTokenResultView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3BF999792A8AE12C009CBDF2 /* PaymentTokenResultView.swift */; };
 		5301468C28918B4D00184F22 /* ApprovalResult.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5301468B28918B4D00184F22 /* ApprovalResult.swift */; };
+		554657F5B5FD929C70949517 /* ShopperSessionURLConfigFactory.swift in Sources */ = {isa = PBXBuildFile; fileRef = C2DFDC66B206AB9B11A80589 /* ShopperSessionURLConfigFactory.swift */; };
+		6A4CB47A11720F32B630C6D5 /* UserIdentityFactory.swift in Sources */ = {isa = PBXBuildFile; fileRef = E100A9BBE64964EE134DB022 /* UserIdentityFactory.swift */; };
 		8052E2A529B684BA00B33FBC /* PPRiskMagnes.xcframework in Frameworks */ = {isa = PBXBuildFile; fileRef = 8052E2A229B684A600B33FBC /* PPRiskMagnes.xcframework */; };
 		8052E2A629B684BA00B33FBC /* PPRiskMagnes.xcframework in Embed Frameworks */ = {isa = PBXBuildFile; fileRef = 8052E2A229B684A600B33FBC /* PPRiskMagnes.xcframework */; settings = {ATTRIBUTES = (CodeSignOnCopy, RemoveHeadersOnCopy, ); }; };
 		806F1E4226B85369007A60E6 /* Assets.xcassets in Resources */ = {isa = PBXBuildFile; fileRef = 806F1E4126B85369007A60E6 /* Assets.xcassets */; };
@@ -67,17 +66,18 @@
 		80F33CEF26F8E7CC006811B1 /* CreateOrderParams.swift in Sources */ = {isa = PBXBuildFile; fileRef = 80F33CEE26F8E7CC006811B1 /* CreateOrderParams.swift */; };
 		80F33CF326F8EA50006811B1 /* DemoSettings.swift in Sources */ = {isa = PBXBuildFile; fileRef = 80F33CF226F8EA50006811B1 /* DemoSettings.swift */; };
 		9A8C7ADC2FF6FD1B00471F38 /* CustomEnvironmentView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9A8C7ADB2FF6FD0F00471F38 /* CustomEnvironmentView.swift */; };
+		A30ABBEB9DF94308BED38BD9 /* UserIdentityView.swift in Sources */ = {isa = PBXBuildFile; fileRef = C5DDBA0EEDF0422CA93EDE6B /* UserIdentityView.swift */; };
 		BC6460CD2A12A2A0002B974B /* EmptyBodyParams.swift in Sources */ = {isa = PBXBuildFile; fileRef = BC6460CC2A12A2A0002B974B /* EmptyBodyParams.swift */; };
 		BC9D4D2227C554090089E5B1 /* LaunchApp.swift in Sources */ = {isa = PBXBuildFile; fileRef = BC9D4D2127C554090089E5B1 /* LaunchApp.swift */; };
 		BC9D4D2427C58B8D0089E5B1 /* XCUIApplication+Helpers.swift in Sources */ = {isa = PBXBuildFile; fileRef = BC9D4D2327C58B8D0089E5B1 /* XCUIApplication+Helpers.swift */; };
 		BC9D4D2627C6D1720089E5B1 /* XCUIElement+Helpers.swift in Sources */ = {isa = PBXBuildFile; fileRef = BC9D4D2527C6D1720089E5B1 /* XCUIElement+Helpers.swift */; };
+		BCC4807E301CEA2700844DFF /* DemoEnvironment.swift in Sources */ = {isa = PBXBuildFile; fileRef = BCC4807D301CEA2700844DFF /* DemoEnvironment.swift */; };
 		BE1766B326F911A2007EF438 /* URLResponseError.swift in Sources */ = {isa = PBXBuildFile; fileRef = BE1766B226F911A2007EF438 /* URLResponseError.swift */; };
 		BE1766D926FA7BC8007EF438 /* Settings.bundle in Resources */ = {isa = PBXBuildFile; fileRef = BE1766D826FA7BC8007EF438 /* Settings.bundle */; };
 		BE5898952B2B91F800AA196E /* LabelViewText.swift in Sources */ = {isa = PBXBuildFile; fileRef = BE5898942B2B91F800AA196E /* LabelViewText.swift */; };
 		BE8117642B07E778009867B9 /* PayPalOrderCreateResultView.swift in Sources */ = {isa = PBXBuildFile; fileRef = BE8117632B07E778009867B9 /* PayPalOrderCreateResultView.swift */; };
 		BE8117682B080472009867B9 /* CurrentState.swift in Sources */ = {isa = PBXBuildFile; fileRef = BE8117672B080472009867B9 /* CurrentState.swift */; };
 		BE9F36D82745490400AFC7DA /* FloatingLabelTextField.swift in Sources */ = {isa = PBXBuildFile; fileRef = BE9F36D72745490400AFC7DA /* FloatingLabelTextField.swift */; };
-		BECD84A027036DC2007CCAE4 /* Environment.swift in Sources */ = {isa = PBXBuildFile; fileRef = BECD849F27036DC2007CCAE4 /* Environment.swift */; };
 		BECD84A227036DDB007CCAE4 /* Intent.swift in Sources */ = {isa = PBXBuildFile; fileRef = BECD84A127036DDB007CCAE4 /* Intent.swift */; };
 		BED042312710833F00C80954 /* CardType.swift in Sources */ = {isa = PBXBuildFile; fileRef = BED042302710833F00C80954 /* CardType.swift */; };
 		BED04233271084DF00C80954 /* CardFormatter.swift in Sources */ = {isa = PBXBuildFile; fileRef = BED04232271084DF00C80954 /* CardFormatter.swift */; };
@@ -158,9 +158,6 @@
 		3BA570022AA053AE0081D14F /* PayPalWebCreateOrderView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PayPalWebCreateOrderView.swift; sourceTree = "<group>"; };
 		3BA570062AA0DF330081D14F /* PayPalWebButtonsView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PayPalWebButtonsView.swift; sourceTree = "<group>"; };
 		3BA5700A2AA13C1C0081D14F /* CoreConfigManager.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CoreConfigManager.swift; sourceTree = "<group>"; };
-		C5DDBA0EEDF0422CA93EDE6B /* UserIdentityView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = UserIdentityView.swift; sourceTree = "<group>"; };
-		E100A9BBE64964EE134DB022 /* UserIdentityFactory.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = UserIdentityFactory.swift; sourceTree = "<group>"; };
-		C2DFDC66B206AB9B11A80589 /* ShopperSessionURLConfigFactory.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ShopperSessionURLConfigFactory.swift; sourceTree = "<group>"; };
 		3BB60B522B1F9F1100A298CF /* PayPalVaultView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PayPalVaultView.swift; sourceTree = "<group>"; };
 		3BB60B542B1FA00C00A298CF /* PayPalVaultViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PayPalVaultViewModel.swift; sourceTree = "<group>"; };
 		3BB7A9762A5CA6FD00C05140 /* MerchantIntegration.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MerchantIntegration.swift; sourceTree = "<group>"; };
@@ -195,6 +192,7 @@
 		BC9D4D2127C554090089E5B1 /* LaunchApp.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LaunchApp.swift; sourceTree = "<group>"; };
 		BC9D4D2327C58B8D0089E5B1 /* XCUIApplication+Helpers.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "XCUIApplication+Helpers.swift"; sourceTree = "<group>"; };
 		BC9D4D2527C6D1720089E5B1 /* XCUIElement+Helpers.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "XCUIElement+Helpers.swift"; sourceTree = "<group>"; };
+		BCC4807D301CEA2700844DFF /* DemoEnvironment.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DemoEnvironment.swift; sourceTree = "<group>"; };
 		BCE8A7ED27EA2B1E00AC301B /* PayPalWebCheckout.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; path = PayPalWebCheckout.framework; sourceTree = BUILT_PRODUCTS_DIR; };
 		BE1766B226F911A2007EF438 /* URLResponseError.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = URLResponseError.swift; sourceTree = "<group>"; };
 		BE1766D826FA7BC8007EF438 /* Settings.bundle */ = {isa = PBXFileReference; lastKnownFileType = "wrapper.plug-in"; path = Settings.bundle; sourceTree = "<group>"; };
@@ -203,10 +201,11 @@
 		BE8117632B07E778009867B9 /* PayPalOrderCreateResultView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PayPalOrderCreateResultView.swift; sourceTree = "<group>"; };
 		BE8117672B080472009867B9 /* CurrentState.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CurrentState.swift; sourceTree = "<group>"; };
 		BE9F36D72745490400AFC7DA /* FloatingLabelTextField.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FloatingLabelTextField.swift; sourceTree = "<group>"; };
-		BECD849F27036DC2007CCAE4 /* Environment.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Environment.swift; sourceTree = "<group>"; };
 		BECD84A127036DDB007CCAE4 /* Intent.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Intent.swift; sourceTree = "<group>"; };
 		BED042302710833F00C80954 /* CardType.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CardType.swift; sourceTree = "<group>"; };
 		BED04232271084DF00C80954 /* CardFormatter.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CardFormatter.swift; sourceTree = "<group>"; };
+		C2DFDC66B206AB9B11A80589 /* ShopperSessionURLConfigFactory.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ShopperSessionURLConfigFactory.swift; sourceTree = "<group>"; };
+		C5DDBA0EEDF0422CA93EDE6B /* UserIdentityView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = UserIdentityView.swift; sourceTree = "<group>"; };
 		CB1AC3B72982AAD70081AED6 /* CardPayments.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; path = CardPayments.framework; sourceTree = BUILT_PRODUCTS_DIR; };
 		CB1AC3BA2982BB130081AED6 /* PaymentButtons.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; path = PaymentButtons.framework; sourceTree = BUILT_PRODUCTS_DIR; };
 		CB1AC3BF2982C4030081AED6 /* PayPalWebPayments.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; path = PayPalWebPayments.framework; sourceTree = BUILT_PRODUCTS_DIR; };
@@ -215,6 +214,7 @@
 		CB9ED44B283FDA900081F4DE /* PaymentButtonEnums+Extension.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "PaymentButtonEnums+Extension.swift"; sourceTree = "<group>"; };
 		CB9ED44D28411B110081F4DE /* SwiftUIPaymentButtonDemo.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SwiftUIPaymentButtonDemo.swift; sourceTree = "<group>"; };
 		CBDEEA212989990200A460A6 /* CorePayments.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; path = CorePayments.framework; sourceTree = BUILT_PRODUCTS_DIR; };
+		E100A9BBE64964EE134DB022 /* UserIdentityFactory.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = UserIdentityFactory.swift; sourceTree = "<group>"; };
 /* End PBXFileReference section */
 
 /* Begin PBXFrameworksBuildPhase section */
@@ -534,7 +534,7 @@
 			children = (
 				9A8C7ADB2FF6FD0F00471F38 /* CustomEnvironmentView.swift */,
 				80F33CF226F8EA50006811B1 /* DemoSettings.swift */,
-				BECD849F27036DC2007CCAE4 /* Environment.swift */,
+				BCC4807D301CEA2700844DFF /* DemoEnvironment.swift */,
 				BECD84A127036DDB007CCAE4 /* Intent.swift */,
 			);
 			path = DemoSettings;
@@ -693,7 +693,6 @@
 				3B22E8BC2A84397600962E34 /* PaymentTokenResponse.swift in Sources */,
 				3B2027432A8A95EF0007907E /* SetupTokenResultView.swift in Sources */,
 				3BF999762A8AC093009CBDF2 /* UpdateSetupTokenResultView.swift in Sources */,
-				BECD84A027036DC2007CCAE4 /* Environment.swift in Sources */,
 				1001E2C12CFFC72E0023A03C /* PayPalPaymentState.swift in Sources */,
 				3BCCFE4B2A9D985F00C5102F /* FeatureSelectionView.swift in Sources */,
 				CB9ED44C283FDA900081F4DE /* PaymentButtonEnums+Extension.swift in Sources */,
@@ -709,6 +708,7 @@
 				3BA56FE72A9DC9D70081D14F /* CardPaymentViewModel.swift in Sources */,
 				1001E2C52CFFD2800023A03C /* PayPalApprovalResultView.swift in Sources */,
 				3BA5700B2AA13C1C0081D14F /* CoreConfigManager.swift in Sources */,
+				BCC4807E301CEA2700844DFF /* DemoEnvironment.swift in Sources */,
 				A30ABBEB9DF94308BED38BD9 /* UserIdentityView.swift in Sources */,
 				6A4CB47A11720F32B630C6D5 /* UserIdentityFactory.swift in Sources */,
 				554657F5B5FD929C70949517 /* ShopperSessionURLConfigFactory.swift in Sources */,

--- a/Demo/Demo/DemoSettings/CustomEnvironmentView.swift
+++ b/Demo/Demo/DemoSettings/CustomEnvironmentView.swift
@@ -3,7 +3,7 @@ import SwiftUI
 
 struct CustomEnvironmentView: View {
 
-    @SwiftUI.Environment(\.presentationMode)
+    @Environment(\.presentationMode)
     private var presentationMode
 
     var onSave: () -> Void

--- a/Demo/Demo/DemoSettings/DemoEnvironment.swift
+++ b/Demo/Demo/DemoSettings/DemoEnvironment.swift
@@ -1,6 +1,6 @@
 import CorePayments
 
-enum Environment: String, CaseIterable {
+enum DemoEnvironment: String, CaseIterable {
     case sandbox
     case live
     #if DEBUG
@@ -23,12 +23,12 @@ enum Environment: String, CaseIterable {
             // merchant server.
             let merchantBaseURL = DemoSettings.customEnvironment?.merchantBaseURL?
                 .trimmingCharacters(in: .whitespacesAndNewlines) ?? ""
-            return merchantBaseURL.isEmpty ? Environment.sandbox.baseURL : merchantBaseURL
+            return merchantBaseURL.isEmpty ? DemoEnvironment.sandbox.baseURL : merchantBaseURL
         #endif
         }
     }
 
-    var paypalSDKEnvironment: CorePayments.Environment {
+    var paypalSDKEnvironment: CorePayments.CoreEnvironment {
         switch self {
         case .sandbox:
             return .sandbox

--- a/Demo/Demo/DemoSettings/DemoSettings.swift
+++ b/Demo/Demo/DemoSettings/DemoSettings.swift
@@ -12,17 +12,17 @@ struct CustomEnvironmentConfig: Codable, Equatable {
 
 enum DemoSettings {
 
-    private static let EnvironmentDefaultsKey = "environment"
+    private static let DemoEnvironmentDefaultsKey = "environment"
     private static let ClientIDKey = "clientID"
     private static let MerchantIntegrationDefaultKey = "merchantIntegration"
     #if DEBUG
     private static let CustomEnvironmentKey = "customEnvironment"
     #endif
 
-    static var environment: Environment {
+    static var environment: DemoEnvironment {
         get {
-            let stored = UserDefaults.standard.string(forKey: EnvironmentDefaultsKey)
-                .flatMap { Environment(rawValue: $0) } ?? .sandbox
+            let stored = UserDefaults.standard.string(forKey: DemoEnvironmentDefaultsKey)
+                .flatMap { DemoEnvironment(rawValue: $0) } ?? .sandbox
             #if DEBUG
             if stored == .custom, customEnvironment == nil {
                 return .sandbox
@@ -31,7 +31,7 @@ enum DemoSettings {
             return stored
         }
         set {
-            UserDefaults.standard.set(newValue.rawValue, forKey: EnvironmentDefaultsKey)
+            UserDefaults.standard.set(newValue.rawValue, forKey: DemoEnvironmentDefaultsKey)
         }
     }
 

--- a/Demo/Demo/Networking/DemoMerchantAPI.swift
+++ b/Demo/Demo/Networking/DemoMerchantAPI.swift
@@ -121,7 +121,7 @@ final class DemoMerchantAPI {
     ///   - environment: the current environment
     /// - Returns: a String representing an clientID
     /// - Throws: an error explaining why fetch clientID failed
-    public func getClientID(environment: Demo.Environment, selectedMerchantIntegration: MerchantIntegration) async -> String? {
+    public func getClientID(environment: DemoEnvironment, selectedMerchantIntegration: MerchantIntegration) async -> String? {
         if let injectedClientID = InjectedValues.clientID {
             return injectedClientID
         }
@@ -178,7 +178,7 @@ final class DemoMerchantAPI {
         URL(string: "https://api.sandbox.paypal.com" + endpoint)
     }
 
-    private func fetchClientID(environment: Demo.Environment, selectedMerchantIntegration: MerchantIntegration) async -> String? {
+    private func fetchClientID(environment: DemoEnvironment, selectedMerchantIntegration: MerchantIntegration) async -> String? {
         do {
             let clientIDRequest = ClientIDRequest()
             let request = try createUrlRequest(
@@ -202,7 +202,7 @@ final class DemoMerchantAPI {
     
     private func createUrlRequest(
         clientIDRequest: ClientIDRequest,
-        environment: Demo.Environment,
+        environment: DemoEnvironment,
         selectedMerchantIntegration: MerchantIntegration
     ) throws -> URLRequest {
         var completeUrl = environment.baseURL

--- a/Demo/Demo/PayPalVault/PayPalVaultViewModel/PayPalVaultViewModel.swift
+++ b/Demo/Demo/PayPalVault/PayPalVaultViewModel/PayPalVaultViewModel.swift
@@ -44,7 +44,7 @@ class PayPalVaultViewModel: VaultViewModel {
             customerID: customerID.isEmpty ? nil : customerID,
             selectedMerchantIntegration: DemoSettings.merchantIntegration,
             paymentType: .paypal,
-            appSwitchURL: Environment.sandbox.baseURL
+            appSwitchURL: DemoEnvironment.sandbox.baseURL
         )
 
         state.paypalVaultTokenResponse = .loading

--- a/Demo/Demo/PayPalWebPayments/PayPalWebViewModel/PayPalWebViewModel.swift
+++ b/Demo/Demo/PayPalWebPayments/PayPalWebViewModel/PayPalWebViewModel.swift
@@ -17,7 +17,7 @@ class PayPalWebViewModel: ObservableObject {
     @Published var checkoutResult: PayPalWebCheckoutResult?
     @Published var appSwitch = false
 
-    let appSwitchURL = Environment.sandbox.baseURL
+    let appSwitchURL = DemoEnvironment.sandbox.baseURL
 
     var payPalWebCheckoutClient: PayPalWebCheckoutClient?
 

--- a/Demo/Demo/SwiftUIComponents/FeatureSelectionView.swift
+++ b/Demo/Demo/SwiftUIComponents/FeatureSelectionView.swift
@@ -2,10 +2,10 @@ import SwiftUI
 
 struct FeatureSelectionView: View {
 
-    @State private var selectedEnvironment: Environment = DemoSettings.environment
+    @State private var selectedEnvironment: DemoEnvironment = DemoSettings.environment
     @State private var selectedIntegration: MerchantIntegration = DemoSettings.merchantIntegration
     #if DEBUG
-    @State private var lastCommittedEnvironment: Environment = DemoSettings.environment
+    @State private var lastCommittedEnvironment: DemoEnvironment = DemoSettings.environment
     @State private var showCustomEnvironmentSheet = false
     #endif
 
@@ -14,7 +14,7 @@ struct FeatureSelectionView: View {
             List {
                 Section(header: Text("Settings")) {
                     Picker("Environment", selection: $selectedEnvironment.onChange(updateEnvironment)) {
-                        ForEach(Environment.allCases, id: \.self) { environment in
+                        ForEach(DemoEnvironment.allCases, id: \.self) { environment in
                             Text(environment.rawValue.capitalized).tag(environment)
                         }
                     }
@@ -92,7 +92,7 @@ struct FeatureSelectionView: View {
         }
     }
 
-    func updateEnvironment(newEnvironment: Environment) {
+    func updateEnvironment(newEnvironment: DemoEnvironment) {
         #if DEBUG
         if newEnvironment == .custom {
             showCustomEnvironmentSheet = true

--- a/PayPal.xcodeproj/project.pbxproj
+++ b/PayPal.xcodeproj/project.pbxproj
@@ -137,7 +137,7 @@
 		BEA100EC26EFA7790036A6A5 /* HTTPMethod.swift in Sources */ = {isa = PBXBuildFile; fileRef = BEA100EB26EFA7790036A6A5 /* HTTPMethod.swift */; };
 		BEA100EE26EFA7990036A6A5 /* HTTPHeader.swift in Sources */ = {isa = PBXBuildFile; fileRef = BEA100ED26EFA7990036A6A5 /* HTTPHeader.swift */; };
 		BEA100F026EFA7C20036A6A5 /* NetworkingError.swift in Sources */ = {isa = PBXBuildFile; fileRef = BEA100EF26EFA7C20036A6A5 /* NetworkingError.swift */; };
-		BEA100F226EFA7DE0036A6A5 /* Environment.swift in Sources */ = {isa = PBXBuildFile; fileRef = BEA100F126EFA7DE0036A6A5 /* Environment.swift */; };
+		BEA100F226EFA7DE0036A6A5 /* CoreEnvironment.swift in Sources */ = {isa = PBXBuildFile; fileRef = BEA100F126EFA7DE0036A6A5 /* CoreEnvironment.swift */; };
 		CB16E6D8285B7A2B00FD6F52 /* FakeConfirmPaymentResponse.swift in Sources */ = {isa = PBXBuildFile; fileRef = CB16E6D7285B7A2B00FD6F52 /* FakeConfirmPaymentResponse.swift */; };
 		CB1A47F22820AFED00BD8184 /* PayPalPayLaterButton.swift in Sources */ = {isa = PBXBuildFile; fileRef = CB1A47F12820AFED00BD8184 /* PayPalPayLaterButton.swift */; };
 		CB1A47F42820BA5D00BD8184 /* PaymentButtonEdges.swift in Sources */ = {isa = PBXBuildFile; fileRef = CB1A47F32820BA5D00BD8184 /* PaymentButtonEdges.swift */; };
@@ -343,7 +343,7 @@
 		BEA100EB26EFA7790036A6A5 /* HTTPMethod.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = HTTPMethod.swift; sourceTree = "<group>"; };
 		BEA100ED26EFA7990036A6A5 /* HTTPHeader.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = HTTPHeader.swift; sourceTree = "<group>"; };
 		BEA100EF26EFA7C20036A6A5 /* NetworkingError.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NetworkingError.swift; sourceTree = "<group>"; };
-		BEA100F126EFA7DE0036A6A5 /* Environment.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Environment.swift; sourceTree = "<group>"; };
+		BEA100F126EFA7DE0036A6A5 /* CoreEnvironment.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CoreEnvironment.swift; sourceTree = "<group>"; };
 		BEDB7FE32788AB8E00CEA554 /* Coordinator.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Coordinator.swift; sourceTree = "<group>"; };
 		BEF3FF1627AC5DF3006B4B69 /* Coordinator_Tests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Coordinator_Tests.swift; sourceTree = "<group>"; };
 		CB16E6D7285B7A2B00FD6F52 /* FakeConfirmPaymentResponse.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FakeConfirmPaymentResponse.swift; sourceTree = "<group>"; };
@@ -793,7 +793,7 @@
 			children = (
 				BEA100EB26EFA7790036A6A5 /* HTTPMethod.swift */,
 				BEA100ED26EFA7990036A6A5 /* HTTPHeader.swift */,
-				BEA100F126EFA7DE0036A6A5 /* Environment.swift */,
+				BEA100F126EFA7DE0036A6A5 /* CoreEnvironment.swift */,
 			);
 			path = Enums;
 			sourceTree = "<group>";
@@ -1290,7 +1290,7 @@
 				BEA100EE26EFA7990036A6A5 /* HTTPHeader.swift in Sources */,
 				CB4BE27E2847EA7D00EA2DD1 /* WebAuthenticationSession.swift in Sources */,
 				80E2FDC12A83535A0045593D /* TrackingEventsAPI.swift in Sources */,
-				BEA100F226EFA7DE0036A6A5 /* Environment.swift in Sources */,
+				BEA100F226EFA7DE0036A6A5 /* CoreEnvironment.swift in Sources */,
 				3BF06F3B2E15CA7E002CA7B4 /* UpdateClientConfigVariables.swift in Sources */,
 				3BBD50EA2E85D8900049C4D5 /* UIApplication+URLOpener.swift in Sources */,
 				BEA100F026EFA7C20036A6A5 /* NetworkingError.swift in Sources */,

--- a/Sources/CorePayments/CoreConfig.swift
+++ b/Sources/CorePayments/CoreConfig.swift
@@ -4,7 +4,7 @@ import Foundation
 /// It is used to initialize all Client objects.
 public struct CoreConfig {
 
-    public let environment: Environment
+    public let environment: CoreEnvironment
     public let clientID: String
 
     /// The PayPal merchant account identifier associated with this integration.
@@ -14,7 +14,7 @@ public struct CoreConfig {
     /// Set this when processing payments on behalf of merchants through a PayPal partner program.
     public let bnCode: String?
 
-    public init(clientID: String, environment: Environment, merchantID: String, bnCode: String? = nil) {
+    public init(clientID: String, environment: CoreEnvironment, merchantID: String, bnCode: String? = nil) {
         self.environment = environment
         self.clientID = clientID
         self.merchantID = merchantID

--- a/Sources/CorePayments/Networking/Enums/CoreEnvironment.swift
+++ b/Sources/CorePayments/Networking/Enums/CoreEnvironment.swift
@@ -1,6 +1,6 @@
 import Foundation
 
-public enum Environment: Equatable {
+public enum CoreEnvironment: Equatable {
     case sandbox
     case live
 

--- a/Sources/PayPalWebPayments/Environment+PayPalWebCheckout.swift
+++ b/Sources/PayPalWebPayments/Environment+PayPalWebCheckout.swift
@@ -4,7 +4,7 @@ import Foundation
 import CorePayments
 #endif
 
-extension Environment {
+extension CoreEnvironment {
 
     var payPalBaseURL: URL {
         switch self {

--- a/UnitTests/PayPalWebPaymentsTests/Environment+PayPalWebCheckout_Tests.swift
+++ b/UnitTests/PayPalWebPaymentsTests/Environment+PayPalWebCheckout_Tests.swift
@@ -5,8 +5,8 @@ import XCTest
 class Environment_PayPalWebCheckout_Tests: XCTestCase {
 
     func testPayPalEnvironment_returnsCorrectBaseURL() {
-        let sandbox = Environment.sandbox
-        let live = Environment.live
+        let sandbox = CoreEnvironment.sandbox
+        let live = CoreEnvironment.live
 
         XCTAssertEqual(sandbox.payPalBaseURL.absoluteString, "https://www.sandbox.paypal.com")
         XCTAssertEqual(live.payPalBaseURL.absoluteString, "https://www.paypal.com")

--- a/UnitTests/PaymentsCoreTests/Environment_Tests.swift
+++ b/UnitTests/PaymentsCoreTests/Environment_Tests.swift
@@ -5,11 +5,11 @@ class Environment_Tests: XCTestCase {
 
     func testEnvironment_sandboxURL_matchesExpectation() throws {
         let expectedUrlString = "https://api-m.sandbox.paypal.com"
-        XCTAssertEqual(Environment.sandbox.baseURL.absoluteString, expectedUrlString)
+        XCTAssertEqual(CoreEnvironment.sandbox.baseURL.absoluteString, expectedUrlString)
     }
 
     func testEnvironment_liveURL_matchesExpectation() throws {
         let expectedUrlString = "https://api-m.paypal.com"
-        XCTAssertEqual(Environment.live.baseURL.absoluteString, expectedUrlString)
+        XCTAssertEqual(CoreEnvironment.live.baseURL.absoluteString, expectedUrlString)
     }
 }


### PR DESCRIPTION
### Reason for changes

- Our `Environment` type collides with SwiftUI's [Environment](https://developer.apple.com/documentation/swiftui/environment) type. The goal of this change is to prevent merchants from having to manually resolve the naming collision:.

**Before**

<img width="652" height="121" alt="Screenshot 2026-07-31 at 9 24 31 AM" src="https://github.com/user-attachments/assets/515502b0-4c30-48a3-8cf0-f3049a25ef8c" />

**After**

<img width="652" height="121" alt="Screenshot 2026-07-31 at 9 47 00 AM" src="https://github.com/user-attachments/assets/d8e5adf3-68c1-4ae4-b084-e8144d746fd3" />

### Summary of changes

- Rename `Environment` to `CoreEnvironment` in the `CorePayments` module
- Rename `Environment` to `DemoEnvironment` in the `Demo` module

### Checklist

- [x] Added a changelog entry

### Authors
> List GitHub usernames for everyone who contributed to this pull request.

- @sshropshire