### PR TITLE
Cleanup DemoMerchantAPI

### DIFF
--- a/Demo/Demo/CardPayments/CardPaymentViewModel/CardPaymentViewModel.swift
+++ b/Demo/Demo/CardPayments/CardPaymentViewModel/CardPaymentViewModel.swift
@@ -42,7 +42,7 @@ class CardPaymentViewModel: ObservableObject {
 
         do {
             DispatchQueue.main.async { self.state.createdOrderResponse = .loading }
-            let order = try await DemoMerchantAPI.sharedService.createOrder(
+            let order = try await DemoMerchantAPI.shared.createOrder(
                 orderParams: params, selectedMerchantIntegration: selectedMerchantIntegration
             )
             DispatchQueue.main.async {
@@ -63,7 +63,7 @@ class CardPaymentViewModel: ObservableObject {
                 self.state.capturedOrderResponse = .loading
             }
             let payPalClientMetadataID = payPalDataCollector?.collectDeviceData()
-            let order = try await DemoMerchantAPI.sharedService.captureOrder(
+            let order = try await DemoMerchantAPI.shared.captureOrder(
                 orderID: orderID,
                 selectedMerchantIntegration: selectedMerchantIntegration,
                 payPalClientMetadataID: payPalClientMetadataID
@@ -85,7 +85,7 @@ class CardPaymentViewModel: ObservableObject {
                 self.state.authorizedOrderResponse = .loading
             }
             let payPalClientMetadataID = payPalDataCollector?.collectDeviceData()
-            let order = try await DemoMerchantAPI.sharedService.authorizeOrder(
+            let order = try await DemoMerchantAPI.shared.authorizeOrder(
                 orderID: orderID,
                 selectedMerchantIntegration: selectedMerchantIntegration,
                 payPalClientMetadataID: payPalClientMetadataID

--- a/Demo/Demo/CardPayments/CardPaymentViewModel/CardPaymentViewModel.swift
+++ b/Demo/Demo/CardPayments/CardPaymentViewModel/CardPaymentViewModel.swift
@@ -101,36 +101,31 @@ class CardPaymentViewModel: ObservableObject {
         }
     }
 
-    func checkoutWith(card: Card, orderID: String, sca: SCA) async {
-        do {
-            DispatchQueue.main.async {
-                self.state.approveResultResponse = .loading
-            }
-            let config = try await configManager.getCoreConfig()
-            cardClient = CardClient(config: config)
-            payPalDataCollector = PayPalDataCollector(config: config)
-            let cardRequest = CardRequest(orderID: orderID, card: card, sca: sca)
-            cardClient?.approveOrder(request: cardRequest) { result in
-                switch result {
-                case .success(let cardResult):
-                    self.setApprovalSuccessResult(
-                        approveResult: CardPaymentState.CardResult(
-                            id: cardResult.orderID,
-                            status: cardResult.status,
-                            didAttemptThreeDSecureAuthentication: cardResult.didAttemptThreeDSecureAuthentication
-                        )
+    func checkoutWith(card: Card, orderID: String, sca: SCA) {
+        DispatchQueue.main.async {
+            self.state.approveResultResponse = .loading
+        }
+        let config = configManager.getCoreConfig()
+        cardClient = CardClient(config: config)
+        payPalDataCollector = PayPalDataCollector(config: config)
+        let cardRequest = CardRequest(orderID: orderID, card: card, sca: sca)
+        cardClient?.approveOrder(request: cardRequest) { result in
+            switch result {
+            case .success(let cardResult):
+                self.setApprovalSuccessResult(
+                    approveResult: CardPaymentState.CardResult(
+                        id: cardResult.orderID,
+                        status: cardResult.status,
+                        didAttemptThreeDSecureAuthentication: cardResult.didAttemptThreeDSecureAuthentication
                     )
-                case .failure(let error):
-                    if error == CardError.threeDSecureCanceledError {
-                        self.setApprovalCancelResult()
-                    } else {
-                        self.setApprovalFailureResult(error: error)
-                    }
+                )
+            case .failure(let error):
+                if error == CardError.threeDSecureCanceledError {
+                    self.setApprovalCancelResult()
+                } else {
+                    self.setApprovalFailureResult(error: error)
                 }
             }
-        } catch {
-            setApprovalFailureResult(error: error)
-            print("failed in checkout with card. \(error.localizedDescription)")
         }
     }
 

--- a/Demo/Demo/CardPayments/CardPaymentViewModel/CardPaymentViewModel.swift
+++ b/Demo/Demo/CardPayments/CardPaymentViewModel/CardPaymentViewModel.swift
@@ -43,7 +43,7 @@ class CardPaymentViewModel: ObservableObject {
         do {
             DispatchQueue.main.async { self.state.createdOrderResponse = .loading }
             let order = try await DemoMerchantAPI.shared.createOrder(
-                orderParams: params, selectedMerchantIntegration: selectedMerchantIntegration
+                orderParams: params, integration: selectedMerchantIntegration
             )
             DispatchQueue.main.async {
                 self.state.createdOrderResponse = .loaded(order)
@@ -65,8 +65,8 @@ class CardPaymentViewModel: ObservableObject {
             let payPalClientMetadataID = payPalDataCollector?.collectDeviceData()
             let order = try await DemoMerchantAPI.shared.captureOrder(
                 orderID: orderID,
-                selectedMerchantIntegration: selectedMerchantIntegration,
-                payPalClientMetadataID: payPalClientMetadataID
+                integration: selectedMerchantIntegration,
+                clientMetadataID: payPalClientMetadataID
             )
             DispatchQueue.main.async {
                 self.state.capturedOrderResponse = .loaded(order)
@@ -87,8 +87,8 @@ class CardPaymentViewModel: ObservableObject {
             let payPalClientMetadataID = payPalDataCollector?.collectDeviceData()
             let order = try await DemoMerchantAPI.shared.authorizeOrder(
                 orderID: orderID,
-                selectedMerchantIntegration: selectedMerchantIntegration,
-                payPalClientMetadataID: payPalClientMetadataID
+                integration: selectedMerchantIntegration,
+                clientMetadataID: payPalClientMetadataID
             )
             DispatchQueue.main.async {
                 self.state.authorizedOrderResponse = .loaded(order)

--- a/Demo/Demo/CardPayments/CardViewComponents/CardOrderApproveView.swift
+++ b/Demo/Demo/CardPayments/CardViewComponents/CardOrderApproveView.swift
@@ -52,15 +52,11 @@ struct CardOrderApproveView: View {
 
                         ZStack {
                             Button("Approve Order") {
-                                Task {
-                                    do {
-                                        await cardPaymentViewModel.checkoutWith(
-                                            card: card,
-                                            orderID: orderID,
-                                            sca: cardPaymentViewModel.state.scaSelection
-                                        )
-                                    }
-                                }
+                                cardPaymentViewModel.checkoutWith(
+                                    card: card,
+                                    orderID: orderID,
+                                    sca: cardPaymentViewModel.state.scaSelection
+                                )
                             }
                             .buttonStyle(RoundedBlueButtonStyle())
                             if case .loading = cardPaymentViewModel.state.approveResultResponse {

--- a/Demo/Demo/CardVault/CardVaultViewModel/CardVaultViewModel.swift
+++ b/Demo/Demo/CardVault/CardVaultViewModel/CardVaultViewModel.swift
@@ -7,25 +7,20 @@ class CardVaultViewModel: VaultViewModel {
 
     let configManager = CoreConfigManager(domain: "Card Vault")
 
-    func vault(card: Card, setupToken: String) async {
+    func vault(card: Card, setupToken: String) {
         DispatchQueue.main.async {
             self.state.updateSetupTokenResponse = .loading
         }
-        do {
-            let config = try await configManager.getCoreConfig()
-            let cardClient = CardClient(config: config)
-            let cardVaultRequest = CardVaultRequest(card: card, setupTokenID: setupToken)
-            cardClient.vault(cardVaultRequest) { result in
-                switch result {
-                case .success(let cardVaultResult):
-                    self.setUpdateSetupTokenResult(vaultResult: cardVaultResult, vaultError: nil)
-                case .failure(let error):
-                    self.setUpdateSetupTokenResult(vaultResult: nil, vaultError: error)
-                }
+        let config = configManager.getCoreConfig()
+        let cardClient = CardClient(config: config)
+        let cardVaultRequest = CardVaultRequest(card: card, setupTokenID: setupToken)
+        cardClient.vault(cardVaultRequest) { result in
+            switch result {
+            case .success(let cardVaultResult):
+                self.setUpdateSetupTokenResult(vaultResult: cardVaultResult, vaultError: nil)
+            case .failure(let error):
+                self.setUpdateSetupTokenResult(vaultResult: nil, vaultError: error)
             }
-        } catch {
-            self.setUpdateSetupTokenResult(vaultResult: nil, vaultError: error)
-            print("failed in updating setup token. \(error.localizedDescription)")
         }
     }
 

--- a/Demo/Demo/CardVault/CardVaultViews/UpdateSetupTokenView.swift
+++ b/Demo/Demo/CardVault/CardVaultViews/UpdateSetupTokenView.swift
@@ -50,9 +50,7 @@ struct UpdateSetupTokenView: View {
 
             ZStack {
                 Button("Vault Card") {
-                    Task {
-                        await cardVaultViewModel.vault(card: card, setupToken: setupToken)
-                    }
+                    cardVaultViewModel.vault(card: card, setupToken: setupToken)
                 }
                 .buttonStyle(RoundedBlueButtonStyle())
                 if case .loading = cardVaultViewModel.state.updateSetupTokenResponse {

--- a/Demo/Demo/Networking/DemoMerchantAPI.swift
+++ b/Demo/Demo/Networking/DemoMerchantAPI.swift
@@ -45,11 +45,13 @@ final class DemoMerchantAPI {
 
     func createSetupToken(
         customerID: String? = nil,
-        selectedMerchantIntegration: MerchantIntegration,
-        paymentSourceType: PaymentSourceType
+        integration: MerchantIntegration,
+        paymentSource: PaymentSourceType
     ) async throws -> CreateSetupTokenResponse {
         do {
-            let requestBody = CreateSetupTokenParam(customer: VaultCustomer(id: customerID), paymentSource: paymentSourceType)
+            let customer = VaultCustomer(id: customerID)
+            let requestBody =
+                CreateSetupTokenParam(customer: customer, paymentSource: paymentSource)
 
             guard let url = buildURL(for: .setupTokens) else {
                 throw URLResponseError.invalidURL
@@ -63,9 +65,13 @@ final class DemoMerchantAPI {
         }
     }
 
-    func createPaymentToken(setupToken: String, selectedMerchantIntegration: MerchantIntegration) async throws -> PaymentTokenResponse {
+    func createPaymentToken(
+        setupToken: String,
+        integration: MerchantIntegration
+    ) async throws -> PaymentTokenResponse {
         do {
-            let requestBody = PaymentTokenParam(paymentSource: PaymentTokenParam.PaymentSource(setupTokenID: setupToken))
+            let paymentSource = PaymentTokenParam.PaymentSource(setupTokenID: setupToken)
+            let requestBody = PaymentTokenParam(paymentSource: paymentSource)
             guard let url = buildURL(for: .paymentTokens) else {
                 throw URLResponseError.invalidURL
             }
@@ -80,7 +86,11 @@ final class DemoMerchantAPI {
         }
     }
 
-    func completeOrder(intent: Intent, orderID: String, payPalClientMetadataID: String? = nil) async throws -> Order {
+    func completeOrder(
+        intent: Intent,
+        orderID: String,
+        clientMetadataID: String? = nil
+    ) async throws -> Order {
         let endpoint: Endpoint = intent == .authorize
             ? .orderAuthorize(orderID: orderID)
             : .orderCapture(orderID: orderID)
@@ -89,8 +99,8 @@ final class DemoMerchantAPI {
         }
 
         var urlRequest = buildURLRequest(method: "POST", url: url, body: EmptyBodyParams())
-        if let payPalClientMetadataID {
-            urlRequest.addValue(payPalClientMetadataID, forHTTPHeaderField: "PayPal-Client-Metadata-Id")
+        if let clientMetadataID {
+            urlRequest.addValue(clientMetadataID, forHTTPHeaderField: "PayPal-Client-Metadata-Id")
         }
         let data = try await data(for: urlRequest)
         return try parse(from: data)
@@ -98,16 +108,16 @@ final class DemoMerchantAPI {
 
     func captureOrder(
         orderID: String,
-        selectedMerchantIntegration: MerchantIntegration,
-        payPalClientMetadataID: String? = nil
+        integration: MerchantIntegration,
+        clientMetadataID: String? = nil
     ) async throws -> Order {
         guard let url = buildURL(for: .orderCapture(orderID: orderID)) else {
             throw URLResponseError.invalidURL
         }
         
         var urlRequest = buildURLRequest(method: "POST", url: url, body: EmptyBodyParams())
-        if let payPalClientMetadataID {
-            urlRequest.addValue(payPalClientMetadataID, forHTTPHeaderField: "PayPal-Client-Metadata-Id")
+        if let clientMetadataID {
+            urlRequest.addValue(clientMetadataID, forHTTPHeaderField: "PayPal-Client-Metadata-Id")
         }
         let data = try await data(for: urlRequest)
         return try parse(from: data)
@@ -115,26 +125,31 @@ final class DemoMerchantAPI {
     
     func authorizeOrder(
         orderID: String,
-        selectedMerchantIntegration: MerchantIntegration,
-        payPalClientMetadataID: String? = nil
+        integration: MerchantIntegration,
+        clientMetadataID: String? = nil
     ) async throws -> Order {
         guard let url = buildURL(for: .orderAuthorize(orderID: orderID)) else {
             throw URLResponseError.invalidURL
         }
         
         var urlRequest = buildURLRequest(method: "POST", url: url, body: EmptyBodyParams())
-        if let payPalClientMetadataID {
-            urlRequest.addValue(payPalClientMetadataID, forHTTPHeaderField: "PayPal-Client-Metadata-Id")
+        if let clientMetadataID {
+            urlRequest.addValue(clientMetadataID, forHTTPHeaderField: "PayPal-Client-Metadata-Id")
         }
         let data = try await data(for: urlRequest)
         return try parse(from: data)
     }
     
-    /// This function replicates a way a merchant may go about creating an order on their server and is not part of the SDK flow.
+    /// This function replicates a way a merchant may go about creating an order on their server
+    /// and is not part of the SDK flow.
+    /// 
     /// - Parameter orderParams: the parameters to create the order with
     /// - Returns: an order
     /// - Throws: an error explaining why create order failed
-    func createOrder(orderParams: CreateOrderParams, selectedMerchantIntegration: MerchantIntegration) async throws -> Order {
+    func createOrder(
+        orderParams: CreateOrderParams,
+        integration: MerchantIntegration
+    ) async throws -> Order {
         guard let url = buildURL(for: .orders) else {
             throw URLResponseError.invalidURL
         }
@@ -163,7 +178,7 @@ final class DemoMerchantAPI {
 
     // MARK: Private methods
 
-    private func buildURLRequest<T>(method: String, url: URL, body: T) -> URLRequest where T: Encodable {
+    private func buildURLRequest<T: Encodable>(method: String, url: URL, body: T) -> URLRequest {
         let encoder = JSONEncoder()
         if DemoSettings.environment.usesPayPalRESTContract {
             encoder.keyEncodingStrategy = .convertToSnakeCase

--- a/Demo/Demo/Networking/DemoMerchantAPI.swift
+++ b/Demo/Demo/Networking/DemoMerchantAPI.swift
@@ -149,15 +149,16 @@ final class DemoMerchantAPI {
     ///   - environment: the current environment
     /// - Returns: a String representing an clientID
     /// - Throws: an error explaining why fetch clientID failed
-    public func getClientID(environment: DemoEnvironment, selectedMerchantIntegration: MerchantIntegration) async -> String? {
-
+    public func getClientID(environment: DemoEnvironment) -> String {
+        let defaultEnvironment = DemoSettings.merchantIntegration.clientID
+        
         #if DEBUG
         if environment == .custom {
-            return DemoSettings.customEnvironment?.clientID
+            return DemoSettings.customEnvironment?.clientID ?? defaultEnvironment
         }
         #endif
 
-        return selectedMerchantIntegration.clientID
+        return defaultEnvironment
     }
 
     // MARK: Private methods

--- a/Demo/Demo/Networking/DemoMerchantAPI.swift
+++ b/Demo/Demo/Networking/DemoMerchantAPI.swift
@@ -41,12 +41,6 @@ final class DemoMerchantAPI {
 
     static let sharedService = DemoMerchantAPI()
 
-    // To hardcode an order ID and client ID for this demo app, set the below values
-    enum InjectedValues {
-        static let orderID: String? = nil
-        static let clientID: String? = nil
-    }
-
     private init() {}
 
     func createSetupToken(
@@ -141,9 +135,6 @@ final class DemoMerchantAPI {
     /// - Returns: an order
     /// - Throws: an error explaining why create order failed
     func createOrder(orderParams: CreateOrderParams, selectedMerchantIntegration: MerchantIntegration) async throws -> Order {
-        if let injectedOrderID = InjectedValues.orderID {
-            return Order(id: injectedOrderID, status: "CREATED")
-        }
         guard let url = buildURL(for: .orders) else {
             throw URLResponseError.invalidURL
         }
@@ -159,9 +150,6 @@ final class DemoMerchantAPI {
     /// - Returns: a String representing an clientID
     /// - Throws: an error explaining why fetch clientID failed
     public func getClientID(environment: DemoEnvironment, selectedMerchantIntegration: MerchantIntegration) async -> String? {
-        if let injectedClientID = InjectedValues.clientID {
-            return injectedClientID
-        }
 
         #if DEBUG
         if environment == .custom {

--- a/Demo/Demo/Networking/DemoMerchantAPI.swift
+++ b/Demo/Demo/Networking/DemoMerchantAPI.swift
@@ -39,7 +39,7 @@ final class DemoMerchantAPI {
         }
     }
 
-    static let sharedService = DemoMerchantAPI()
+    static let shared = DemoMerchantAPI()
 
     private init() {}
 

--- a/Demo/Demo/Networking/DemoMerchantAPI.swift
+++ b/Demo/Demo/Networking/DemoMerchantAPI.swift
@@ -207,28 +207,6 @@ final class DemoMerchantAPI {
         URL(string: "https://api.sandbox.paypal.com" + endpoint)
     }
 
-    private func fetchClientID(environment: DemoEnvironment, selectedMerchantIntegration: MerchantIntegration) async -> String? {
-        do {
-            let clientIDRequest = ClientIDRequest()
-            let request = try createUrlRequest(
-                clientIDRequest: clientIDRequest, environment: environment, selectedMerchantIntegration: selectedMerchantIntegration
-            )
-            let (data, response) = try await URLSession.shared.performRequest(with: request)
-            guard let response = response as? HTTPURLResponse else {
-                throw URLResponseError.serverError
-            }
-            switch response.statusCode {
-            case 200..<300:
-                let clientIDResponse: ClientIDResponse = try parse(from: data)
-                return clientIDResponse.clientID
-            default: throw URLResponseError.dataParsingError
-            }
-        } catch {
-            print("Error in fetching clientID")
-            return nil
-        }
-    }
-    
     private func createUrlRequest(
         clientIDRequest: ClientIDRequest,
         environment: DemoEnvironment,

--- a/Demo/Demo/PayPalPayments/PayPalWebViewModel/PayPalWebViewModel.swift
+++ b/Demo/Demo/PayPalPayments/PayPalWebViewModel/PayPalWebViewModel.swift
@@ -109,7 +109,7 @@ class PayPalWebViewModel: ObservableObject {
             state.createdOrderResponse = .loading
             let order = try await DemoMerchantAPI.shared.createOrder(
                 orderParams: params,
-                selectedMerchantIntegration: DemoSettings.merchantIntegration
+                integration: DemoSettings.merchantIntegration
             )
             self.order = order
             state.createdOrderResponse = .loaded(order)
@@ -163,7 +163,7 @@ class PayPalWebViewModel: ObservableObject {
                 let order = try await DemoMerchantAPI.shared.completeOrder(
                     intent: intent,
                     orderID: orderID,
-                    payPalClientMetadataID: payPalClientMetadataID
+                    clientMetadataID: payPalClientMetadataID
                 )
                 setOrderCompletionLoadedState(order: order)
             }

--- a/Demo/Demo/PayPalPayments/PayPalWebViewModel/PayPalWebViewModel.swift
+++ b/Demo/Demo/PayPalPayments/PayPalWebViewModel/PayPalWebViewModel.swift
@@ -158,18 +158,11 @@ class PayPalWebViewModel: ObservableObject {
         }
     }
 
-    func getPayPalClient() async throws -> PayPalClient? {
-        do {
-            let config = try await configManager.getCoreConfig()
-            let payPalClient = PayPalClient(config: config)
-            payPalDataCollector = PayPalDataCollector(config: config)
-            return payPalClient
-        } catch {
-            DispatchQueue.main.async {
-                self.state.createdOrderResponse = .error(message: error.localizedDescription)
-            }
-            return nil
-        }
+    func getPayPalClient() -> PayPalClient? {
+        let config = configManager.getCoreConfig()
+        let payPalClient = PayPalClient(config: config)
+        payPalDataCollector = PayPalDataCollector(config: config)
+        return payPalClient
     }
 
     func completeTransaction() async throws {

--- a/Demo/Demo/PayPalPayments/PayPalWebViewModel/PayPalWebViewModel.swift
+++ b/Demo/Demo/PayPalPayments/PayPalWebViewModel/PayPalWebViewModel.swift
@@ -34,11 +34,7 @@ class PayPalWebViewModel: ObservableObject {
     ) async throws {
         state.createdOrderResponse = .loading
 
-        guard let client = try await getPayPalClient() else {
-            let message = "Error initializing PayPalClient"
-            state.createdOrderResponse = .error(message: message)
-            throw CheckoutError.clientInitializationFailed(message)
-        }
+        let client = makePayPalClient()
         payPalClient = client
 
         let urlConfig: PayPalURLConfig
@@ -125,40 +121,34 @@ class PayPalWebViewModel: ObservableObject {
     }
 
     func paymentButtonTapped(funding: PayPalCheckoutFundingSource) {
-        Task {
-            do {
-                state.approveResultResponse = .loading
+        state.approveResultResponse = .loading
 
-                if payPalClient == nil {
-                    payPalClient = try await getPayPalClient()
-                }
-                guard let payPalClient, let orderID = state.createOrder?.id else {
-                    state.approveResultResponse = .error(message: "Missing PayPal client or order ID")
-                    return
-                }
+        if payPalClient == nil {
+            payPalClient = makePayPalClient()
+        }
+        guard let payPalClient, let orderID = state.createOrder?.id else {
+            state.approveResultResponse = .error(message: "Missing PayPal client or order ID")
+            return
+        }
 
-                payPalClient.start(orderID: orderID) { result in
-                    switch result {
-                    case .success(let paypalResult):
-                        self.state.approveResultResponse = .loaded(
-                            PayPalPaymentState.ApprovalResult(id: paypalResult.orderID, status: "APPROVED")
-                        )
-                        self.checkoutResult = paypalResult
-                    case .failure(let error):
-                        if error == PayPalError.checkoutCanceledError {
-                            self.state.approveResultResponse = .error(message: "PayPal checkout was canceled.")
-                        } else {
-                            self.state.approveResultResponse = .error(message: error.localizedDescription)
-                        }
-                    }
+        payPalClient.start(orderID: orderID) { result in
+            switch result {
+            case .success(let paypalResult):
+                self.state.approveResultResponse = .loaded(
+                    PayPalPaymentState.ApprovalResult(id: paypalResult.orderID, status: "APPROVED")
+                )
+                self.checkoutResult = paypalResult
+            case .failure(let error):
+                if error == PayPalError.checkoutCanceledError {
+                    self.state.approveResultResponse = .error(message: "PayPal checkout was canceled.")
+                } else {
+                    self.state.approveResultResponse = .error(message: error.localizedDescription)
                 }
-            } catch {
-                state.createdOrderResponse = .error(message: error.localizedDescription)
             }
         }
     }
 
-    func getPayPalClient() -> PayPalClient? {
+    func makePayPalClient() -> PayPalClient {
         let config = configManager.getCoreConfig()
         let payPalClient = PayPalClient(config: config)
         payPalDataCollector = PayPalDataCollector(config: config)

--- a/Demo/Demo/PayPalPayments/PayPalWebViewModel/PayPalWebViewModel.swift
+++ b/Demo/Demo/PayPalPayments/PayPalWebViewModel/PayPalWebViewModel.swift
@@ -111,7 +111,7 @@ class PayPalWebViewModel: ObservableObject {
             )
 
             state.createdOrderResponse = .loading
-            let order = try await DemoMerchantAPI.sharedService.createOrder(
+            let order = try await DemoMerchantAPI.shared.createOrder(
                 orderParams: params,
                 selectedMerchantIntegration: DemoSettings.merchantIntegration
             )
@@ -177,7 +177,7 @@ class PayPalWebViewModel: ObservableObject {
             setLoadingState()
             if let orderID = state.createOrder?.id {
                 let payPalClientMetadataID = payPalDataCollector?.collectDeviceData()
-                let order = try await DemoMerchantAPI.sharedService.completeOrder(
+                let order = try await DemoMerchantAPI.shared.completeOrder(
                     intent: intent,
                     orderID: orderID,
                     payPalClientMetadataID: payPalClientMetadataID

--- a/Demo/Demo/PayPalVault/PayPalVaultViewModel/PayPalVaultViewModel.swift
+++ b/Demo/Demo/PayPalVault/PayPalVaultViewModel/PayPalVaultViewModel.swift
@@ -68,14 +68,9 @@ class PayPalVaultViewModel: VaultViewModel {
         }
     }
 
-    func getPayPalClient() async throws -> PayPalClient? {
-        do {
-            let config = try await configManager.getCoreConfig()
-            return PayPalClient(config: config)
-        } catch {
-            state.setupTokenResponse = .error(message: error.localizedDescription)
-            return nil
-        }
+    func getPayPalClient() -> PayPalClient? {
+        let config = configManager.getCoreConfig()
+        return PayPalClient(config: config)
     }
 
     func handleUniversalLinkReturn(_ url: URL) {

--- a/Demo/Demo/PayPalVault/PayPalVaultViewModel/PayPalVaultViewModel.swift
+++ b/Demo/Demo/PayPalVault/PayPalVaultViewModel/PayPalVaultViewModel.swift
@@ -6,17 +6,12 @@ import CorePayments
 class PayPalVaultViewModel: VaultViewModel {
 
     let configManager = CoreConfigManager(domain: "PayPal Vault")
-
     var paypalClient: PayPalClient?
 
     func vault() async throws {
         state.setupTokenResponse = .loading
 
-        guard let client = try await getPayPalClient() else {
-            let message = "Error initializing PayPalClient"
-            state.setupTokenResponse = .error(message: message)
-            throw VaultFlowError.clientInitializationFailed(message)
-        }
+        let client = makePayPalClient()
         paypalClient = client
         
         let resolvedUserIdentity = UserIdentityFactory.makeUserIdentity(
@@ -68,7 +63,7 @@ class PayPalVaultViewModel: VaultViewModel {
         }
     }
 
-    func getPayPalClient() -> PayPalClient? {
+    func makePayPalClient() -> PayPalClient {
         let config = configManager.getCoreConfig()
         return PayPalClient(config: config)
     }

--- a/Demo/Demo/SwiftUIComponents/CommonComponents/CoreConfigManager.swift
+++ b/Demo/Demo/SwiftUIComponents/CommonComponents/CoreConfigManager.swift
@@ -10,7 +10,7 @@ class CoreConfigManager {
     }
 
     func getClientID() async -> String? {
-        await DemoMerchantAPI.sharedService.getClientID(
+        await DemoMerchantAPI.shared.getClientID(
             environment: DemoSettings.environment,
             selectedMerchantIntegration: DemoSettings.merchantIntegration
         )

--- a/Demo/Demo/SwiftUIComponents/CommonComponents/CoreConfigManager.swift
+++ b/Demo/Demo/SwiftUIComponents/CommonComponents/CoreConfigManager.swift
@@ -9,18 +9,12 @@ class CoreConfigManager {
         self.domain = domain
     }
 
-    func getClientID() async -> String? {
-        await DemoMerchantAPI.shared.getClientID(
-            environment: DemoSettings.environment,
-            selectedMerchantIntegration: DemoSettings.merchantIntegration
-        )
+    func getClientID() -> String {
+        DemoMerchantAPI.shared.getClientID(environment: DemoSettings.environment)
     }
 
-    func getCoreConfig() async throws -> CoreConfig {
-        guard let clientID = await getClientID() else {
-            throw CoreSDKError(code: 0, domain: domain, errorDescription: "Error getting clientID")
-        }
-        
+    func getCoreConfig() -> CoreConfig {
+        let clientID = getClientID()
         return CoreConfig(
             clientID: clientID,
             environment: DemoSettings.environment.paypalSDKEnvironment,

--- a/Demo/Demo/Vault/VaultViewModel/VaultViewModel.swift
+++ b/Demo/Demo/Vault/VaultViewModel/VaultViewModel.swift
@@ -42,8 +42,8 @@ class VaultViewModel: ObservableObject {
 
             let setupTokenResult = try await DemoMerchantAPI.shared.createSetupToken(
                 customerID: customerID,
-                selectedMerchantIntegration: selectedMerchantIntegration,
-                paymentSourceType: paymentSourceType
+                integration: selectedMerchantIntegration,
+                paymentSource: paymentSourceType
             )
             state.setupTokenResponse = .loaded(setupTokenResult)
             return setupTokenResult
@@ -73,7 +73,7 @@ class VaultViewModel: ObservableObject {
             }
             let paymentTokenResult = try await DemoMerchantAPI.shared.createPaymentToken(
                 setupToken: setupToken,
-                selectedMerchantIntegration: selectedMerchantIntegration
+                integration: selectedMerchantIntegration
             )
             DispatchQueue.main.async {
                 self.state.paymentTokenResponse = .loaded(paymentTokenResult)

--- a/Demo/Demo/Vault/VaultViewModel/VaultViewModel.swift
+++ b/Demo/Demo/Vault/VaultViewModel/VaultViewModel.swift
@@ -40,7 +40,7 @@ class VaultViewModel: ObservableObject {
                 paymentSourceType = PaymentSourceType.paypal(usageType: "MERCHANT", experienceContext: experienceContext)
             }
 
-            let setupTokenResult = try await DemoMerchantAPI.sharedService.createSetupToken(
+            let setupTokenResult = try await DemoMerchantAPI.shared.createSetupToken(
                 customerID: customerID,
                 selectedMerchantIntegration: selectedMerchantIntegration,
                 paymentSourceType: paymentSourceType
@@ -71,7 +71,7 @@ class VaultViewModel: ObservableObject {
             DispatchQueue.main.async {
                 self.state.paymentTokenResponse = .loading
             }
-            let paymentTokenResult = try await DemoMerchantAPI.sharedService.createPaymentToken(
+            let paymentTokenResult = try await DemoMerchantAPI.shared.createPaymentToken(
                 setupToken: setupToken,
                 selectedMerchantIntegration: selectedMerchantIntegration
             )


### PR DESCRIPTION
### Reason for changes

`DemoMerchantAPI.getClientID()` is no longer `async` and it should never `throw`. Refactoring this interface will allow us to remove a lot of unnecessary error handling code.

### Summary of changes

- Refactor `DemoMerchantAPI.getClientID()` to be synchronous and non-throwing.
- Clean up `DemoMerchantAPI` code formatting to meet 120 column limit.
- Rename some `DemoMerchantAPI` methods to make them less semantically coupled to other parts of the demo application. 

### Checklist

- [ ] ~Added a changelog entry~

### Authors
> List GitHub usernames for everyone who contributed to this pull request.

- @sshropshire