### PR TITLE
Add custom amount field to PayPal Web Checkout demo screen

### DIFF
--- a/Demo/Demo/PayPalPayments/PayPalWebPaymentsView/PayPalWebCreateOrderView.swift
+++ b/Demo/Demo/PayPalPayments/PayPalWebPaymentsView/PayPalWebCreateOrderView.swift
@@ -16,6 +16,7 @@ struct PayPalWebCreateOrderView: View {
     @State private var email: String = ""
     @State private var phone: String = ""
     @State private var ssid: String = ""
+    @State private var amount: String = "10.00"
     @State var shouldVaultSelected = false
 
     var body: some View {
@@ -59,6 +60,7 @@ struct PayPalWebCreateOrderView: View {
                     phone: $phone,
                     ssid: $ssid
                 )
+                FloatingLabelTextField(placeholder: "Amount", text: $amount, keyboardType: .decimalPad)
                 HStack {
                     Toggle("Should Vault with Purchase", isOn: $shouldVaultSelected)
                     Spacer()
@@ -76,7 +78,8 @@ struct PayPalWebCreateOrderView: View {
                                         email: email,
                                         phone: phone,
                                         ssid: ssid
-                                    )
+                                    ),
+                                    amount: amount
                                 )
                             } catch {
                                 print("Error in checkout. \(error.localizedDescription)")

--- a/Demo/Demo/PayPalPayments/PayPalWebViewModel/PayPalWebViewModel.swift
+++ b/Demo/Demo/PayPalPayments/PayPalWebViewModel/PayPalWebViewModel.swift
@@ -7,7 +7,6 @@ import FraudProtection
 class PayPalWebViewModel: ObservableObject {
     
     private enum DemoFixtures {
-        static let defaultAmount = "10.00"
         static let vaultAttributes = Vault(storeInVault: "ON_SUCCESS", usageType: "MERCHANT", customerType: "CONSUMER")
     }
 
@@ -86,9 +85,10 @@ class PayPalWebViewModel: ObservableObject {
     /// S4: PayPal vault + app-switch     -> attributes.vault + experienceContext.appSwitchContext
     private func fetchOrder(shouldVault: Bool, amount: String) async throws -> Order {
         do {
+            let defaultAmount = "10.00"
             let amountRequest = Amount(
                 currencyCode: "USD",
-                value: amount.isEmpty ? DemoFixtures.defaultAmount : amount
+                value: amount.isEmpty ? defaultAmount : amount
             )
 
             var paymentSource: OrderPaymentSource?

--- a/Demo/Demo/PayPalPayments/PayPalWebViewModel/PayPalWebViewModel.swift
+++ b/Demo/Demo/PayPalPayments/PayPalWebViewModel/PayPalWebViewModel.swift
@@ -7,7 +7,7 @@ import FraudProtection
 class PayPalWebViewModel: ObservableObject {
     
     private enum DemoFixtures {
-        static let amount = Amount(currencyCode: "USD", value: "10.00")
+        static let defaultAmount = "10.00"
         static let vaultAttributes = Vault(storeInVault: "ON_SUCCESS", usageType: "MERCHANT", customerType: "CONSUMER")
     }
 
@@ -30,7 +30,8 @@ class PayPalWebViewModel: ObservableObject {
     func checkout(
         shouldVault: Bool,
         userAction: PayPalUserAction,
-        userIdentity: PayPalUserIdentity?
+        userIdentity: PayPalUserIdentity?,
+        amount: String
     ) async throws {
         state.createdOrderResponse = .loading
 
@@ -52,7 +53,7 @@ class PayPalWebViewModel: ObservableObject {
             userAction: userAction
         )
 
-        async let orderTask = fetchOrder(shouldVault: shouldVault)
+        async let orderTask = fetchOrder(shouldVault: shouldVault, amount: amount)
         let order = try await orderTask
 
         state.approveResultResponse = .loading
@@ -83,9 +84,12 @@ class PayPalWebViewModel: ObservableObject {
     /// S2: PayPal app-switch (no vault) -> experienceContext with appSwitchContext
     /// S3: PayPal vault (no app-switch)  -> attributes.vault + experienceContext
     /// S4: PayPal vault + app-switch     -> attributes.vault + experienceContext.appSwitchContext
-    private func fetchOrder(shouldVault: Bool) async throws -> Order {
+    private func fetchOrder(shouldVault: Bool, amount: String) async throws -> Order {
         do {
-            let amountRequest = DemoFixtures.amount
+            let amountRequest = Amount(
+                currencyCode: "USD",
+                value: amount.isEmpty ? DemoFixtures.defaultAmount : amount
+            )
 
             var paymentSource: OrderPaymentSource?
             


### PR DESCRIPTION
## Summary
- Adds an editable "Amount" field (`FloatingLabelTextField`, decimal keyboard) to the PayPal Web Checkout demo screen, defaulting to "10.00"
- `PayPalWebViewModel.checkout(...)` now accepts an `amount` parameter and builds the order's `Amount` from it instead of the hardcoded `DemoFixtures.amount` fixture
 
### Checklist

- [x] Added a changelog entry

### Authors
> List GitHub usernames for everyone who contributed to this pull request.

- @joaaraujo-paypal