### PR TITLE
Remove deprecated canOpenURL(:) method

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,7 @@
   * **Breaking:** `CoreConfig` requires a `merchantID` parameter; optional `bnCode` parameter added. See the [v3 Migration Guide](v3_MIGRATION_GUIDE.md) for details.
   * **Breaking:** Remove `PatchCCOWithAppSwitchEligibility` (and its `AppSwitchEligibility` response type) and the `ExternalTokenKind` constants — the legacy PatchCCO app-switch-eligibility path is no longer used
   * **Breaking:** Rename `Environment` to `CoreEnvironment`
+  * **Deprecated:** `UIApplication.isPayPalAppInstalled()` — no longer used to determine app switch eligibility; will be removed in the next major release
   * Improve error messages for non-JSON/unstructured error responses to include the HTTP status, request URL, and raw response body
 
 ## 2.0.1 (2025-11-03)

--- a/Sources/CorePayments/UIApplication+URLOpener.swift
+++ b/Sources/CorePayments/UIApplication+URLOpener.swift
@@ -7,7 +7,6 @@ public protocol URLOpener {
         universalLinksOnly: Bool,
         completionHandler completion: ((Bool) -> Void)?
     )
-    func isPayPalAppInstalled() -> Bool
 }
 
 public extension URLOpener {
@@ -18,13 +17,6 @@ public extension URLOpener {
 }
 
 extension UIApplication: URLOpener {
-
-    public func isPayPalAppInstalled() -> Bool {
-        guard let payPalURL = URL(string: "paypal://") else {
-            return false
-        }
-        return canOpenURL(payPalURL)
-    }
 
     public func open(
         _ url: URL,

--- a/Sources/CorePayments/UIApplication+URLOpener.swift
+++ b/Sources/CorePayments/UIApplication+URLOpener.swift
@@ -7,6 +7,7 @@ public protocol URLOpener {
         universalLinksOnly: Bool,
         completionHandler completion: ((Bool) -> Void)?
     )
+    func isPayPalAppInstalled() -> Bool
 }
 
 public extension URLOpener {
@@ -17,6 +18,14 @@ public extension URLOpener {
 }
 
 extension UIApplication: URLOpener {
+
+    @available(*, deprecated, message: "No longer used for app switch eligibility. Will be removed in the next major release.")
+    public func isPayPalAppInstalled() -> Bool {
+        guard let payPalURL = URL(string: "paypal://") else {
+            return false
+        }
+        return canOpenURL(payPalURL)
+    }
 
     public func open(
         _ url: URL,

--- a/Sources/PayPalPayments/APIRequests/CreateShopperSessionAPI.swift
+++ b/Sources/PayPalPayments/APIRequests/CreateShopperSessionAPI.swift
@@ -90,12 +90,14 @@ public class CreateShopperSessionAPI {
         
         let experimentationContext = ShopperSessionExperimentationContext(merchantAccountId: coreConfig.merchantID)
         
+        /// we can no longer determine if paypalNativeAppInstalled
+        /// sending true so flow attempts App Switch in the future
         let appSwitchEligibilityInput = AppSwitchEligibilityInput(
             contextId: contextId,
             tokenType: tokenType.rawValue,
             osType: PayPalCoreConstants.osType,
             merchantOptInForAppSwitch: true,
-            paypalNativeAppInstalled: urlOpener.isPayPalAppInstalled(),
+            paypalNativeAppInstalled: true,
             experimentationContext: experimentationContext,
             buyerEmailAddressMerchantPassed: userIdentity?.email,
             shoppersSessionId: userIdentity?.existingPayPalSessionID

--- a/Sources/PayPalPayments/APIRequests/CreateShopperSessionAPI.swift
+++ b/Sources/PayPalPayments/APIRequests/CreateShopperSessionAPI.swift
@@ -80,7 +80,6 @@ public class CreateShopperSessionAPI {
     /// - Throws: A `CoreSDKError` if the network call or response parsing fails.
     func createShopperSessionWithAppSwitchEligibility(
         tokenType: TokenType,
-        urlOpener: URLOpener,
         urlConfig: PayPalURLConfig,
         userIdentity: PayPalUserIdentity?,
         analyticsData: PayPalCheckoutAnalyticsData? = nil

--- a/Sources/PayPalPayments/Models/PayPalCheckoutAnalyticsData+Analytics.swift
+++ b/Sources/PayPalPayments/Models/PayPalCheckoutAnalyticsData+Analytics.swift
@@ -20,7 +20,7 @@ extension PayPalCheckoutAnalyticsData {
         cancelAppURL = urlConfig.cancelAppURL
         fallbackSchemeURL = urlConfig.fallbackSchemeURL
         
-        paypalNativeAppInstalled = UIApplication.shared.isPayPalAppInstalled()
+        paypalNativeAppInstalled = nil
         isVaultRequest = tokenType == .vaultID
     }
 

--- a/Sources/PayPalPayments/PayPalClient.swift
+++ b/Sources/PayPalPayments/PayPalClient.swift
@@ -454,8 +454,7 @@ public class PayPalClient: NSObject {
         makeURL: (_ base: String, _ sessionID: String) -> URL?,
         fallback: () -> Void
     ) async {
-        if urlOpener.isPayPalAppInstalled(),
-           session.appSwitchEligible,
+        if session.appSwitchEligible,
            let base = session.redirectURL,
            let sessionID = session.shopperSessionConfig?.id,
            let url = makeURL(base, sessionID) {

--- a/Sources/PayPalPayments/PayPalClient.swift
+++ b/Sources/PayPalPayments/PayPalClient.swift
@@ -141,7 +141,6 @@ public class PayPalClient: NSObject {
         sessionTask = Task {
             try await createShopperSessionAPI.createShopperSessionWithAppSwitchEligibility(
                 tokenType: tokenType,
-                urlOpener: urlOpener,
                 urlConfig: urlConfig,
                 userIdentity: userIdentity,
                 analyticsData: analyticsData

--- a/UnitTests/PayPalPaymentsTests/CreateShopperSessionAPI_Tests.swift
+++ b/UnitTests/PayPalPaymentsTests/CreateShopperSessionAPI_Tests.swift
@@ -47,7 +47,6 @@ class CreateShopperSessionAPI_Tests: XCTestCase {
     var mockNetworkingClient: MockNetworkingClient!
     var mockAuthAPI: MockAuthenticationSecureTokenServiceAPI!
     private var capturingTrackingEventsAPI: CapturingTrackingEventsAPI!
-    var mockURLOpener: MockURLOpener!
     var sut: CreateShopperSessionAPI!
 
     let fakeURLConfig = PayPalURLConfig(
@@ -64,7 +63,6 @@ class CreateShopperSessionAPI_Tests: XCTestCase {
         mockNetworkingClient = MockNetworkingClient(http: MockHTTP(coreConfig: config))
         mockAuthAPI = MockAuthenticationSecureTokenServiceAPI(coreConfig: config)
         capturingTrackingEventsAPI = CapturingTrackingEventsAPI()
-        mockURLOpener = MockURLOpener()
 
         let analyticsService = AnalyticsService(
             coreConfig: config,
@@ -101,7 +99,6 @@ class CreateShopperSessionAPI_Tests: XCTestCase {
 
         _ = try await sut.createShopperSessionWithAppSwitchEligibility(
             tokenType: .orderID,
-            urlOpener: mockURLOpener,
             urlConfig: fakeURLConfig,
             userIdentity: nil
         )

--- a/UnitTests/PayPalPaymentsTests/PayPalWebCheckoutClient_CreateSession_Tests.swift
+++ b/UnitTests/PayPalPaymentsTests/PayPalWebCheckoutClient_CreateSession_Tests.swift
@@ -196,8 +196,7 @@ class PayPalClient_CreateSession_Tests: XCTestCase {
             domain: PayPalError.domain,
             errorDescription: "Session fetch failed."
         )
-        mockURLOpener.mockIsPayPalAppInstalled = false
-
+        
         payPalClient.createPayPalSession(sessionType: .checkout, urlConfig: fakeURLConfig)
 
         let expectation = expectation(description: "start fails with sessionNotCreatedError")
@@ -228,7 +227,6 @@ class PayPalClient_CreateSession_Tests: XCTestCase {
             domain: PayPalError.domain,
             errorDescription: "Session fetch failed."
         )
-        mockURLOpener.mockIsPayPalAppInstalled = true
         mockURLOpener.mockOpenURLSuccess = true
 
         payPalClient.createPayPalSession(sessionType: .checkout, urlConfig: fakeURLConfig)
@@ -257,8 +255,7 @@ class PayPalClient_CreateSession_Tests: XCTestCase {
             domain: PayPalError.domain,
             errorDescription: "Session fetch failed."
         )
-        mockURLOpener.mockIsPayPalAppInstalled = false
-
+        
         payPalClient.createPayPalSession(sessionType: .vaultWithoutPurchase, urlConfig: fakeURLConfig)
 
         let expectation = expectation(description: "vault fails with sessionNotCreatedError")
@@ -286,7 +283,6 @@ class PayPalClient_CreateSession_Tests: XCTestCase {
             domain: PayPalError.domain,
             errorDescription: "Session fetch failed."
         )
-        mockURLOpener.mockIsPayPalAppInstalled = true
         mockURLOpener.mockOpenURLSuccess = true
 
         payPalClient.createPayPalSession(sessionType: .vaultWithoutPurchase, urlConfig: fakeURLConfig)

--- a/UnitTests/TestShared/MockCreateShopperSessionAPI.swift
+++ b/UnitTests/TestShared/MockCreateShopperSessionAPI.swift
@@ -14,7 +14,6 @@ class MockCreateShopperSessionAPI: CreateShopperSessionAPI {
 
     override func createShopperSessionWithAppSwitchEligibility(
         tokenType: TokenType,
-        urlOpener: URLOpener,
         urlConfig: PayPalURLConfig,
         userIdentity: PayPalUserIdentity?,
         analyticsData: PayPalCheckoutAnalyticsData? = nil

--- a/UnitTests/TestShared/MockURLOpener.swift
+++ b/UnitTests/TestShared/MockURLOpener.swift
@@ -3,12 +3,17 @@ import Foundation
 
 class MockURLOpener: URLOpener {
 
+    var mockIsPayPalAppInstalled = false
     var mockOpenURLSuccess = true
     var lastOpenedURL: URL?
     var lastUniversalLinksOnly: Bool?
 
     var didOpenURLHandler: (() -> Void)?
 
+    func isPayPalAppInstalled() -> Bool {
+        mockIsPayPalAppInstalled
+    }
+    
     func open(_ url: URL, universalLinksOnly: Bool, completionHandler completion: ((Bool) -> Void)?) {
         lastOpenedURL = url
         lastUniversalLinksOnly = universalLinksOnly

--- a/UnitTests/TestShared/MockURLOpener.swift
+++ b/UnitTests/TestShared/MockURLOpener.swift
@@ -3,17 +3,12 @@ import Foundation
 
 class MockURLOpener: URLOpener {
 
-    var mockIsPayPalAppInstalled = false
     var mockOpenURLSuccess = true
     var lastOpenedURL: URL?
     var lastUniversalLinksOnly: Bool?
 
     var didOpenURLHandler: (() -> Void)?
 
-    func isPayPalAppInstalled() -> Bool {
-        mockIsPayPalAppInstalled
-    }
-    
     func open(_ url: URL, universalLinksOnly: Bool, completionHandler completion: ((Bool) -> Void)?) {
         lastOpenedURL = url
         lastUniversalLinksOnly = universalLinksOnly


### PR DESCRIPTION
### Reason for changes

Apple deprecated `canOpenURL(:)` method so we need to stop relying on it 

### Summary of changes

- Remove `isPayPalAppInstalled()` method
- Pass `true` to `createShopperSession()` as well as `attemptSessionAppSwitchOrFallback()` so flow attempts app switch every time 
- Pass `paypal_installed = null` to Analytics 

### Checklist

- [ ] Added a changelog entry

### Authors
> List GitHub usernames for everyone who contributed to this pull request.

- NastassiaRodzik