### PR TITLE
[Patch] Pass proper user action to createShopperSession

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,11 @@
 
 # PayPal iOS SDK Release Notes
 
+## Unreleased
+
+* PayPalPayments
+  * Fix `createPayPalSession()` sending a hardcoded `PAY` payment type in the shopper session experimentation context regardless of the caller's `userAction` — now correctly passes `CONTINUE`, `PAY`, or `COMMIT` based on `userAction`
+
 ## 3.0.0 (2026-08-19)
 
 * PayPalPayments

--- a/Sources/PayPalPayments/APIRequests/CreateShopperSessionAPI.swift
+++ b/Sources/PayPalPayments/APIRequests/CreateShopperSessionAPI.swift
@@ -82,14 +82,17 @@ public class CreateShopperSessionAPI {
         tokenType: TokenType,
         urlOpener: URLOpener,
         urlConfig: PayPalURLConfig,
+        userAction: PayPalUserAction,
         userIdentity: PayPalUserIdentity?,
         analyticsData: PayPalCheckoutAnalyticsData? = nil
     ) async throws -> ShopperSessionResult {
 
         let contextId = UUID().uuidString
         
-        let experimentationContext = ShopperSessionExperimentationContext(merchantAccountId: coreConfig.merchantID)
-        
+        let experimentationContext = ShopperSessionExperimentationContext(
+            paymentType: userAction.externalPaymentType,
+            merchantAccountId: coreConfig.merchantID
+        )
         let appSwitchEligibilityInput = AppSwitchEligibilityInput(
             contextId: contextId,
             tokenType: tokenType.rawValue,

--- a/Sources/PayPalPayments/APIRequests/CreateShopperSessionVariables.swift
+++ b/Sources/PayPalPayments/APIRequests/CreateShopperSessionVariables.swift
@@ -41,7 +41,7 @@ struct ShopperSessionExperimentationContext: Encodable {
         integrationChannel: String = PayPalCoreConstants.integrationChannel,
         isWebLLSEligible: Bool = false,
         isWebView: Bool = false,
-        paymentType: String = "PAY",
+        paymentType: String,
         buyerGUID: String? = nil,
         merchantAccountId: String
     ) {

--- a/Sources/PayPalPayments/Models/PayPalUserAction.swift
+++ b/Sources/PayPalPayments/Models/PayPalUserAction.swift
@@ -20,3 +20,17 @@ public enum PayPalUserAction {
         }
     }
 }
+
+extension PayPalUserAction {
+    
+    var externalPaymentType: String {
+        switch self {
+        case .continue:
+            return "CONTINUE"
+        case .payNow:
+            return "PAY"
+        case .setupNow:
+            return "COMMIT"
+        }
+    }
+}

--- a/Sources/PayPalPayments/PayPalClient.swift
+++ b/Sources/PayPalPayments/PayPalClient.swift
@@ -143,6 +143,7 @@ public class PayPalClient: NSObject {
                 tokenType: tokenType,
                 urlOpener: urlOpener,
                 urlConfig: urlConfig,
+                userAction: userAction,
                 userIdentity: userIdentity,
                 analyticsData: analyticsData
             )

--- a/UnitTests/PayPalPaymentsTests/CreateShopperSessionAPI_Tests.swift
+++ b/UnitTests/PayPalPaymentsTests/CreateShopperSessionAPI_Tests.swift
@@ -103,6 +103,7 @@ class CreateShopperSessionAPI_Tests: XCTestCase {
             tokenType: .orderID,
             urlOpener: mockURLOpener,
             urlConfig: fakeURLConfig,
+            userAction: .continue,
             userIdentity: nil
         )
 

--- a/UnitTests/PayPalPaymentsTests/PayPalWebCheckoutClient_CreateSession_Tests.swift
+++ b/UnitTests/PayPalPaymentsTests/PayPalWebCheckoutClient_CreateSession_Tests.swift
@@ -393,6 +393,48 @@ class PayPalClient_CreateSession_Tests: XCTestCase {
 
         waitForExpectations(timeout: 2)
     }
+    
+    func testCreatePayPalSession_userActionPayNow() {
+        mockCreateShopperSessionAPI.stubResponse = makeIneligibleSession()
+
+        payPalClient.createPayPalSession(sessionType: .checkout, urlConfig: fakeURLConfig, userAction: .payNow)
+
+        let expectation = expectation(description: "session task runs")
+        DispatchQueue.main.asyncAfter(deadline: .now() + 0.5) {
+            XCTAssertEqual(self.mockCreateShopperSessionAPI.capturedUserAction, .payNow)
+            expectation.fulfill()
+        }
+
+        waitForExpectations(timeout: 2)
+    }
+    
+    func testCreatePayPalSession_userActionContinue() {
+        mockCreateShopperSessionAPI.stubResponse = makeIneligibleSession()
+
+        payPalClient.createPayPalSession(sessionType: .checkout, urlConfig: fakeURLConfig, userAction: .continue)
+
+        let expectation = expectation(description: "session task runs")
+        DispatchQueue.main.asyncAfter(deadline: .now() + 0.5) {
+            XCTAssertEqual(self.mockCreateShopperSessionAPI.capturedUserAction, .continue)
+            expectation.fulfill()
+        }
+
+        waitForExpectations(timeout: 2)
+    }
+    
+    func testCreatePayPalSession_userActionSetupNow() {
+        mockCreateShopperSessionAPI.stubResponse = makeIneligibleSession()
+
+        payPalClient.createPayPalSession(sessionType: .checkout, urlConfig: fakeURLConfig, userAction: .setupNow)
+
+        let expectation = expectation(description: "session task runs")
+        DispatchQueue.main.asyncAfter(deadline: .now() + 0.5) {
+            XCTAssertEqual(self.mockCreateShopperSessionAPI.capturedUserAction, .setupNow)
+            expectation.fulfill()
+        }
+
+        waitForExpectations(timeout: 2)
+    }
 
     // MARK: - sessionTask lifecycle
 

--- a/UnitTests/TestShared/MockCreateShopperSessionAPI.swift
+++ b/UnitTests/TestShared/MockCreateShopperSessionAPI.swift
@@ -9,6 +9,7 @@ class MockCreateShopperSessionAPI: CreateShopperSessionAPI {
 
     // Captured call arguments for assertion
     var capturedURLConfig: PayPalURLConfig?
+    var capturedUserAction: PayPalUserAction?
     var capturedUserIdentity: PayPalUserIdentity?
     var callCount = 0
 
@@ -16,13 +17,15 @@ class MockCreateShopperSessionAPI: CreateShopperSessionAPI {
         tokenType: TokenType,
         urlOpener: URLOpener,
         urlConfig: PayPalURLConfig,
+        userAction: PayPalUserAction,
         userIdentity: PayPalUserIdentity?,
         analyticsData: PayPalCheckoutAnalyticsData? = nil
     ) async throws -> ShopperSessionResult {
         callCount += 1
         capturedURLConfig = urlConfig
         capturedUserIdentity = userIdentity
-
+        capturedUserAction = userAction
+        
         if let stubError {
             throw stubError
         }


### PR DESCRIPTION
### Reason for changes

- We noticed userAction PayNow being applied to Continue sessions 

### Summary of changes

- Pass selected user action to `createShopperSession()`

### Checklist

- [x] Added a changelog entry

### Authors
> List GitHub usernames for everyone who contributed to this pull request.

- NastassiaRodzik